### PR TITLE
Bugfix in Date.diff/3 with :timestamp

### DIFF
--- a/lib/date/date.ex
+++ b/lib/date/date.ex
@@ -18,6 +18,7 @@ defmodule Timex.Date do
   """
   require Record
   alias Timex.DateTime,     as: DateTime
+  alias Timex.Time,         as: Time
   alias Timex.Timezone,     as: Timezone
   alias Timex.TimezoneInfo, as: TimezoneInfo
 
@@ -887,7 +888,7 @@ defmodule Timex.Date do
   @spec diff(DateTime.t, DateTime.t, :secs | :days | :weeks | :months | :years) :: integer
 
   def diff(this, other, :timestamp) do
-    diff(this, other, :secs) |> Time.from_sec
+    diff(this, other, :secs) |> Time.from(:secs)
   end
   def diff(this, other, :secs) do
     to_secs(other, :zero) - to_secs(this, :zero)

--- a/test/date_test.exs
+++ b/test/date_test.exs
@@ -295,6 +295,8 @@ defmodule DateTests do
     assert D.diff(date1, date2, :months) === -D.diff(date2, date1, :months)
     assert D.diff(date1, date2, :years)  === -D.diff(date2, date1, :years)
 
+    assert D.diff(date1, date2, :timestamp) === {0, 63, 158400}
+
     assert D.diff(epoch, date1, :days) === 365
     assert D.diff(epoch, date1, :secs) === 365 * 24 * 3600
     assert D.diff(epoch, date1, :years) === 1


### PR DESCRIPTION
`Date.diff/3` with `:timestamp` tried to call a function that does not exist, from a module that was not imported.

I added a test to avoid future regressions.
