### PR TITLE
Ensure that arguments to elapsed and diff are in timestamp form

### DIFF
--- a/lib/time/time.ex
+++ b/lib/time/time.ex
@@ -205,7 +205,8 @@ defmodule Timex.Time do
 
   @doc """
   Time interval between timestamp and now. If timestamp is after now in time, the
-  return value will be negative.
+  return value will be negative. Timestamp must be in format { megasecs, seconds,
+  microseconds }.
 
   The second argument is an atom indicating the type of time units to return:
   microseconds (:usec), milliseconds (:msec), seconds (:sec), minutes (:min),
@@ -216,13 +217,19 @@ defmodule Timex.Time do
   """
   def elapsed(timestamp, type \\ :timestamp)
 
-  def elapsed(timestamp, type) do
-    diff(now, timestamp, type)
+  def elapsed(timestamp = {_,_,_}, type) do
+    elapsed(timestamp, now, type)
+  end
+
+  def elapsed(timestamp = {_,_,_}, reference_time = {_,_,_}, type) do
+    diff = diff(timestamp, reference_time)
+    convert(diff, type)
   end
 
   @doc """
   Time interval between two timestamps. If the first timestamp comes before the
-  second one in time, the return value will be negative.
+  second one in time, the return value will be negative. Timestamp must be in format
+  { megasecs, seconds, microseconds }.
 
   The third argument is an atom indicating the type of time units to return:
   microseconds (:usec), milliseconds (:msec), seconds (:sec), minutes (:min),
@@ -238,7 +245,7 @@ defmodule Timex.Time do
     {mega1 - mega2, secs1 - secs2, micro1 - micro2}
   end
 
-  def diff(t1, t2, type) do
+  def diff(t1 = {_,_,_}, t2 = {_,_,_}, type) do
     convert(diff(t1, t2), type)
   end
 

--- a/test/time_test.exs
+++ b/test/time_test.exs
@@ -51,4 +51,19 @@ defmodule TimeTests do
     assert Time.to_secs(13, :hours) == 13 * 3600
     assert Time.to_secs({1,2,3}, :hms) == 3600 + 2 * 60 + 3
   end
+
+  test :elapsed do
+    now = {1362,568902,363960}
+    time = {1362,568903,363960}
+    time_in_millis = Time.to_msecs(time)
+
+    assert Time.elapsed(time, now, :usecs) == 1000000
+    assert Time.elapsed(time, now, :msecs) == 1000
+    assert Time.elapsed(time, now, :secs) == 1
+    assert Time.elapsed(time, now, :mins) == 0.016666666666666666
+    assert Time.elapsed(time, now, :hours) == 0.0002777777777777778
+    assert_raise FunctionClauseError, fn ->
+      Time.elapsed(time_in_millis, :msecs)
+    end
+  end
 end


### PR DESCRIPTION
Previously you could send floating point arguments. Because of how
the arguments were being matched on, diff was calling itself in an infinite
loop. This commit makes sure that the arguments are in the form that the docs
specify they should be. It also adds some tests to verify the functions are working
correctly.
