### PR TITLE
Make sure that the diff is from previous time until now

### DIFF
--- a/lib/time/time.ex
+++ b/lib/time/time.ex
@@ -222,8 +222,7 @@ defmodule Timex.Time do
   end
 
   def elapsed(timestamp = {_,_,_}, reference_time = {_,_,_}, type) do
-    diff = diff(timestamp, reference_time)
-    convert(diff, type)
+    diff(reference_time, timestamp) |> convert(type)
   end
 
   @doc """

--- a/test/time_test.exs
+++ b/test/time_test.exs
@@ -53,15 +53,15 @@ defmodule TimeTests do
   end
 
   test :elapsed do
-    now = {1362,568902,363960}
-    time = {1362,568903,363960}
-    time_in_millis = Time.to_msecs(time)
+    previous_time = {1362,568902,363960}
+    now = {1362,568903,363960}
+    time_in_millis = Time.to_msecs(previous_time)
 
-    assert Time.elapsed(time, now, :usecs) == 1000000
-    assert Time.elapsed(time, now, :msecs) == 1000
-    assert Time.elapsed(time, now, :secs) == 1
-    assert Time.elapsed(time, now, :mins) == 0.016666666666666666
-    assert Time.elapsed(time, now, :hours) == 0.0002777777777777778
+    assert Time.elapsed(previous_time, now, :usecs) == 1000000
+    assert Time.elapsed(previous_time, now, :msecs) == 1000
+    assert Time.elapsed(previous_time, now, :secs) == 1
+    assert Time.elapsed(previous_time, now, :mins) == 0.016666666666666666
+    assert Time.elapsed(previous_time, now, :hours) == 0.0002777777777777778
     assert_raise FunctionClauseError, fn ->
       Time.elapsed(time_in_millis, :msecs)
     end


### PR DESCRIPTION
I realized that the previous version is actually backwards. This would love to negative times being elapsed. 

The reason the tests passed before was that `now` was actually before `time`. I have renamed `time` to be `previous_time` to make this very clear.
