### PR TITLE
Bring documentation for Date.compare() into agreement with the implementation

### DIFF
--- a/lib/date/date.ex
+++ b/lib/date/date.ex
@@ -853,9 +853,9 @@ defmodule Timex.Date do
   @doc """
   Compare two dates returning one of the following values:
 
-   * `-1` -- `this` comes after `other`
-   * `0`  -- Both arguments represent the same date when coalesced to the same timezone.
-   * `1`  -- `this` comes before `other`
+   * `-1` -- the first date comes before the second one
+   * `0`  -- both arguments represent the same date when coalesced to the same timezone.
+   * `1`  -- the first date comes after the second one
 
   """
   @spec compare(DateTime.t, DateTime.t | :epoch | :zero | :distant_past | :distant_future) :: -1 | 0 | 1


### PR DESCRIPTION
After fixing #11 in [this commit](https://github.com/bitwalker/timex/commit/a645179bb2c02e0d6afd2f654066d8fbbc537601), the docs got out of sync.