### PR TITLE
Date to secs bug 24

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
-docs/
+doc/
+doc
 deps/
 ebin/
 _build/
 .exenv-version
+mix.lock

--- a/lib/date/date.ex
+++ b/lib/date/date.ex
@@ -881,15 +881,9 @@ defmodule Timex.Date do
   def compare(_, :distant_future), do: -1
   def compare(date, date),         do: 0
   def compare(a, b),               do: compare(a, b, :secs)
-  def compare(%DateTime{:timezone => thistz} = this, %DateTime{:timezone => othertz} = other, granularity)
+  def compare( this, other, granularity)
     when granularity in [:years, :months, :weeks, :days, :hours, :mins, :secs, :timestamp] do
-    localized = if thistz !== othertz do
-      # Convert `other` to `this`'s timezone
-      Timezone.convert(other, thistz)
-    else
-      other
-    end
-    difference = diff(this, localized, granularity)
+    difference = diff(this, other, granularity)
     cond do
       difference < 0  -> +1
       difference == 0 -> 0

--- a/lib/date/date.ex
+++ b/lib/date/date.ex
@@ -392,7 +392,7 @@ defmodule Timex.Date do
     offset = Timex.Timezone.diff(date,timezone(:utc))
     case offset do
       0 -> utc_to_secs(date)
-      _ -> utc_to_secs(date) - ( 60 * offset )
+      _ -> utc_to_secs(date) + ( 60 * offset )
     end
   end
 

--- a/lib/date/date.ex
+++ b/lib/date/date.ex
@@ -387,9 +387,23 @@ defmodule Timex.Date do
   def to_secs(date, reference \\ :epoch)
 
   def to_secs(date, :epoch), do: to_secs(date, :zero) - epoch(:secs)
-  def to_secs(%DateTime{:year => y, :month => m, :day => d, :hour => h, :minute => min, :second => s}, :zero) do
+
+  def to_secs(date, :zero) do
+    offset = Timex.Timezone.diff(date,timezone(:utc))
+    case offset do
+      0 -> utc_to_secs(date)
+      _ -> utc_to_secs(date) - ( 60 * offset )
+    end
+  end
+
+  # def to_secs(%DateTime{:year => y, :month => m, :day => d, :hour => h, :minute => min, :second => s}, :zero) do
+  #   :calendar.datetime_to_gregorian_seconds({{y, m, d}, {h, min, s}})
+  # end
+
+  defp utc_to_secs(%DateTime{:year => y, :month => m, :day => d, :hour => h, :minute => min, :second => s}) do
     :calendar.datetime_to_gregorian_seconds({{y, m, d}, {h, min, s}})
   end
+
 
   @doc """
   Convert the date to an integer number of days since Epoch or year 0.

--- a/lib/date/date.ex
+++ b/lib/date/date.ex
@@ -871,6 +871,17 @@ defmodule Timex.Date do
    * `0`  -- both arguments represent the same date when coalesced to the same timezone.
    * `1`  -- the first date comes after the second one
 
+  You can optionality specify a granularity of any of
+
+  :years :months :weeks :days :hours :mins :secs :timestamp 
+
+  and the dates will be compared with the cooresponding accuracy. 
+  The default granularity is :secs.
+
+  ## Examples
+
+    Date.compare(date1,date2,:years)
+
   """
   @spec compare(DateTime.t, DateTime.t | :epoch | :zero | :distant_past | :distant_future) :: -1 | 0 | 1
   @spec compare(DateTime.t, DateTime.t, :years | :months | :weeks | :days | :hours | :mins | :secs | :timestamp) :: -1 | 0 | 1
@@ -901,6 +912,11 @@ defmodule Timex.Date do
   @doc """
   Calculate time interval between two dates. If the second date comes after the
   first one in time, return value will be positive; and negative otherwise.
+  You must specify a granularity of any of
+
+  :years :months :weeks :days :hours :mins :secs :timestamp 
+
+  and the result will be an integer value of those units or a timestamp. 
   """
   @spec diff(DateTime.t, DateTime.t, :timestamp) :: timestamp
   @spec diff(DateTime.t, DateTime.t, :secs | :days | :weeks | :months | :years) :: integer

--- a/lib/date/date.ex
+++ b/lib/date/date.ex
@@ -1022,7 +1022,8 @@ defmodule Timex.Date do
       :hours  -> value * 3600
     end
     shifted = from(secs, :secs)
-    %{shifted | :timezone => tz}
+    # convert back to original tz 
+    Timezone.convert(shifted,tz)
   end
   def shift(%DateTime{:hour => h, :minute => m, :second => s, :timezone => tz} = date, [days: value]) do
     days = to_days(date)

--- a/mix.exs
+++ b/mix.exs
@@ -7,7 +7,7 @@ defmodule Timex.Mixfile do
       elixir: "~> 1.0.0",
       description: "A date/time library for Elixir",
       package: package,
-      deps: [] ]
+      deps: deps ]
 
   end
   def application, do: []
@@ -18,4 +18,10 @@ defmodule Timex.Mixfile do
       licenses: ["MIT"],
       links: %{ "GitHub": "https://github.com/bitwalker/timex" } ]
   end
+
+  def deps do 
+  [{:earmark, "~> 0.1", only: :dev},
+     {:ex_doc, "~> 0.5", only: :dev}]
+  end 
+
 end

--- a/test/date_test.exs
+++ b/test/date_test.exs
@@ -374,6 +374,17 @@ defmodule DateTests do
     assert %DateTime{year: 2011, month: 3, day: 5, hour: 23, minute: 23, second: 23} = shift(datetime, secs: -24*3600*(365*2+1))   # +1 day for leap year 2012
   end
 
+  test :shift_seconds_with_timezone do
+    utc = Timezone.get(:utc)
+    cst = Timezone.get("America/Chicago")
+
+    date1 = %DateTime{year: 2013, month: 3, day: 18, hour: 1, minute: 44, timezone: utc }
+    date2 = %DateTime{year: 2013, month: 3, day: 18, hour: 8, minute: 44, timezone: cst }
+    assert %DateTime{minute: 49 , second: 0} = shift(date1, secs: 5*60 )
+    assert %DateTime{minute: 49 , second: 0} = shift(date2, secs: 5*60 )
+
+  end 
+
   test :shift_minutes do
     date = {2013,3,5}
     time = {23,23,23}

--- a/test/date_test.exs
+++ b/test/date_test.exs
@@ -380,8 +380,9 @@ defmodule DateTests do
 
     date1 = %DateTime{year: 2013, month: 3, day: 18, hour: 1, minute: 44, timezone: utc }
     date2 = %DateTime{year: 2013, month: 3, day: 18, hour: 8, minute: 44, timezone: cst }
-    assert %DateTime{minute: 49 , second: 0} = shift(date1, secs: 5*60 )
-    assert %DateTime{minute: 49 , second: 0} = shift(date2, secs: 5*60 )
+    assert %DateTime{minute: 49 , second: 0} = D.shift(date1, secs: 5*60 )
+    assert %DateTime{minute: 49 , second: 0} = D.shift(date2, secs: 5*60 )
+
 
   end 
 
@@ -405,6 +406,17 @@ defmodule DateTests do
     assert %DateTime{month: 3, day: 4, hour: 23, minute: 59, second: 23} = shift(datetime, mins: -23*60-24)
     assert %DateTime{year: 2011, month: 3, day: 5, hour: 23, minute: 23, second: 23} = shift(datetime, mins: -60*24*(365*2 + 1))
   end
+
+  test :shift_minutes_with_timezone do
+    utc = Timezone.get(:utc)
+    cst = Timezone.get("America/Chicago")
+    
+    chicago_noon = %Timex.DateTime{calendar: :gregorian, day: 24, hour: 12, minute: 0, month: 2, ms: 0, second: 0,timezone: cst , year: 2014}
+    utc_dinner = %Timex.DateTime{calendar: :gregorian, day: 24, hour: 18, minute: 0, month: 2, ms: 0, second: 0,timezone: utc , year: 2014}
+    
+    assert %DateTime{ hour: 18, minute: 0 } = D.shift(chicago_noon, mins: 360 )
+    assert %DateTime{ hour: 12, minute: 0} = D.shift(utc_dinner, mins: -360 )
+  end 
 
   test :shift_hours do
     date = {2013,3,5}

--- a/test/date_test.exs
+++ b/test/date_test.exs
@@ -148,9 +148,12 @@ defmodule DateTests do
     assert D.to_secs(D.epoch()) === 0
     assert D.to_secs(D.epoch(), :zero) === 62167219200
 
-    date = D.from({2014,11,17}, "CST")
+    date = D.from({{2014,11,17},{0,0,0}}, "PST")
+    assert D.to_secs(date) == 1416211200
+
     ndate = D.from({2014,11,17})
-    refute D.to_secs(date) === D.to_secs(ndate)
+    assert D.to_secs(ndate) == 1416182400
+
   end
 
   test :to_days do

--- a/test/date_test.exs
+++ b/test/date_test.exs
@@ -147,6 +147,10 @@ defmodule DateTests do
 
     assert D.to_secs(D.epoch()) === 0
     assert D.to_secs(D.epoch(), :zero) === 62167219200
+
+    date = D.from({2014,11,17}, "CST")
+    ndate = D.from({2014,11,17})
+    refute D.to_secs(date) === D.to_secs(ndate)
   end
 
   test :to_days do

--- a/test/timezone_test.exs
+++ b/test/timezone_test.exs
@@ -54,8 +54,10 @@ defmodule TimezoneTests do
     gmt_plus_two    = Timezone.get(2)
     gmt_minus_three = Timezone.get(-3)
 
+    chicago_noon = %Timex.DateTime{calendar: :gregorian, day: 24, hour: 12, minute: 0, month: 2, ms: 0, second: 0,timezone: cst , year: 2014}
    
-    dinnertime = %DateTime{year: 2014, month: 2, day: 24, hour: 12, timezone: cst} |> Timezone.convert(utc) 
+    dinnertime = Timezone.convert(chicago_noon,utc) 
+
     assert %DateTime{hour: 18, timezone: utc} = dinnertime
     # If it's noon in CST, then it's 6'oclock in the evening in UTC
     assert %DateTime{hour: 18} = %DateTime{year: 2014, month: 2, day: 24, hour: 12, timezone: cst} |> Timezone.convert(utc)

--- a/test/timezone_test.exs
+++ b/test/timezone_test.exs
@@ -54,8 +54,9 @@ defmodule TimezoneTests do
     gmt_plus_two    = Timezone.get(2)
     gmt_minus_three = Timezone.get(-3)
 
-    assert %DateTime{hour: 18, timezone: utc} = %DateTime{year: 2014, month: 2, day: 24, hour: 12, timezone: cst} |> Timezone.convert(utc) 
-
+   
+    dinnertime = %DateTime{year: 2014, month: 2, day: 24, hour: 12, timezone: cst} |> Timezone.convert(utc) 
+    assert %DateTime{hour: 18, timezone: utc} = dinnertime
     # If it's noon in CST, then it's 6'oclock in the evening in UTC
     assert %DateTime{hour: 18} = %DateTime{year: 2014, month: 2, day: 24, hour: 12, timezone: cst} |> Timezone.convert(utc)
     # If it's noon in UTC, then it's 6'oclock in the morning in CST


### PR DESCRIPTION
This patch fixes the Date.to_secs bug and also adds some additional tests that came up during fixing the problem. There were several places in date.ex that had code that broke when this bug was fixed. This current code passes all the existing tests. 

I also added some documentation and the deps needed for mix docs to produce documentation. 