### PR TITLE
Fix incorrect unit names in the docs for Timex.Time functions

### DIFF
--- a/lib/time/time.ex
+++ b/lib/time/time.ex
@@ -147,7 +147,7 @@ defmodule Timex.Time do
   @doc """
   Return a timestamp representing a time lapse of length 0.
 
-    Time.convert(Time.zero, :sec)
+    Time.convert(Time.zero, :secs)
     #=> 0
 
   Can be useful for operations on collections of timestamps. For instance,
@@ -161,8 +161,8 @@ defmodule Timex.Time do
   Convert timestamp in the form { megasecs, seconds, microsecs } to the
   specified time units.
 
-  Supported units: microseconds (:usec), milliseconds (:msec), seconds (:sec),
-  minutes (:min), hours (:hour), days (:day), or weeks (:week).
+  Supported units: microseconds (:usecs), milliseconds (:msecs), seconds (:secs),
+  minutes (:mins), hours (:hours), days (:days), or weeks (:weeks).
   """
   def convert(timestamp, type \\ :timestamp)
   def convert(timestamp, :timestamp), do: timestamp
@@ -213,8 +213,8 @@ defmodule Timex.Time do
   microseconds }.
 
   The second argument is an atom indicating the type of time units to return:
-  microseconds (:usec), milliseconds (:msec), seconds (:sec), minutes (:min),
-  or hours (:hour).
+  microseconds (:usecs), milliseconds (:msecs), seconds (:secs), minutes (:mins),
+  or hours (:hours).
 
   When the second argument is omitted, the return value's format is { megasecs,
   seconds, microsecs }.
@@ -235,8 +235,8 @@ defmodule Timex.Time do
   { megasecs, seconds, microseconds }.
 
   The third argument is an atom indicating the type of time units to return:
-  microseconds (:usec), milliseconds (:msec), seconds (:sec), minutes (:min),
-  or hours (:hour).
+  microseconds (:usecs), milliseconds (:msecs), seconds (:secs), minutes (:mins),
+  or hours (:hours).
 
   When the third argument is omitted, the return value's format is { megasecs,
   seconds, microsecs }.
@@ -265,7 +265,7 @@ defmodule Timex.Time do
   end
 
   defp measure_result({micro, ret}) do
-    { to_timestamp(micro, :usec), ret }
+    { to_timestamp(micro, :usecs), ret }
   end
 
   defp normalize({mega, sec, micro}) do

--- a/test/time_test.exs
+++ b/test/time_test.exs
@@ -81,4 +81,11 @@ defmodule TimeTests do
       Time.elapsed(time_in_millis, :msecs)
     end
   end
+
+  # Just make sure that Timex.Time.measure is called at least once in the tests
+  test :measure do
+    reversed_list = Enum.to_list(100..1)
+    assert { {mega, secs, micro}, ^reversed_list } = Time.measure(fn -> Enum.reverse(1..100) end)
+    assert mega + secs + micro > 0
+  end
 end


### PR DESCRIPTION
This patch fixes outdated docs.

Nowadays, I would actually use full names for the units. Those would be simpler and more intuitive for the users: `:secs` -> `:seconds`, `:mins` -> `:minutes`, `:usecs` -> `:microseconds`, etc. Users are likely to utilize just one or two units, so they can wrap those long names in a function for convenience, like so:

```elixir
defmodule MyApp.Utils do
  @doc "Returns the difference between two timestamps in microseconds"
  @spec time_diff(Timex.Date.timestamp, Timex.Date.timestamp) :: Timex.Date.microseconds
  def time_diff(timestamp1, timestamp2) do
    Timex.Time.diff(timestamp1, timestamp2, :microseconds)
  end
end
```