### PR TITLE
Fix/simplify from/to_timestamp/convert/to_x conversions and codify conversion values

### DIFF
--- a/lib/time/time.ex
+++ b/lib/time/time.ex
@@ -1,31 +1,41 @@
 defmodule Timex.Time do
 
+  @usecs_in_sec 1_000_000
+  @usecs_in_msec 1_000
+
+  @msecs_in_sec 1_000
+
+  @secs_in_min 60
+  @secs_in_hour @secs_in_min * 60
+  @secs_in_day @secs_in_hour * 24
+  @secs_in_week @secs_in_day * 7
+
   @million 1_000_000
 
-  Enum.each [usecs: @million, msecs: 1_000], fn {type, coef} ->
-    def to_usecs(value, unquote(type)), do: value * @million / unquote(coef)
-    def to_msecs(value, unquote(type)), do: value * 1000 / unquote(coef)
+  Enum.each [usecs: @usecs_in_sec, msecs: @msecs_in_sec], fn {type, coef} ->
+    def to_usecs(value, unquote(type)), do: value * @usecs_in_sec / unquote(coef)
+    def to_msecs(value, unquote(type)), do: value * @msecs_in_sec / unquote(coef)
     def to_secs(value, unquote(type)),  do: value / unquote(coef)
-    def to_mins(value, unquote(type)),  do: value / unquote(coef) / 60
-    def to_hours(value, unquote(type)), do: value / unquote(coef) / 3600
-    def to_days(value, unquote(type)),  do: value / unquote(coef) / (3600 * 24)
-    def to_weeks(value, unquote(type)), do: value / unquote(coef) / (3600 * 24 * 7)
+    def to_mins(value, unquote(type)),  do: value / unquote(coef) / @secs_in_min
+    def to_hours(value, unquote(type)), do: value / unquote(coef) / @secs_in_hour
+    def to_days(value, unquote(type)),  do: value / unquote(coef) / @secs_in_day
+    def to_weeks(value, unquote(type)), do: value / unquote(coef) / @secs_in_week
   end
 
-  Enum.each [secs: 1, mins: 60, hours: 3600, days: 3600 * 24, weeks: 3600 * 24 * 7], fn {type, coef} ->
+  Enum.each [secs: 1, mins: @secs_in_min, hours: @secs_in_hour, days: @secs_in_day, weeks: @secs_in_week], fn {type, coef} ->
     def unquote(type)(value), do: value * unquote(coef)
-    def to_usecs(value, unquote(type)), do: value * unquote(coef) * @million
-    def to_msecs(value, unquote(type)), do: value * unquote(coef) * 1000
+    def to_usecs(value, unquote(type)), do: value * unquote(coef) * @usecs_in_sec
+    def to_msecs(value, unquote(type)), do: value * unquote(coef) * @msecs_in_sec
     def to_secs(value, unquote(type)),  do: value * unquote(coef)
-    def to_mins(value, unquote(type)),  do: value * unquote(coef) / 60
-    def to_hours(value, unquote(type)), do: value * unquote(coef) / 3600
-    def to_days(value, unquote(type)),  do: value * unquote(coef) / (3600 * 24)
-    def to_weeks(value, unquote(type)), do: value * unquote(coef) / (3600 * 24 * 7)
+    def to_mins(value, unquote(type)),  do: value * unquote(coef) / @secs_in_min
+    def to_hours(value, unquote(type)), do: value * unquote(coef) / @secs_in_hour
+    def to_days(value, unquote(type)),  do: value * unquote(coef) / @secs_in_day
+    def to_weeks(value, unquote(type)), do: value * unquote(coef) / @secs_in_week
   end
 
 
   Enum.each [:to_usecs, :to_msecs, :to_secs, :to_mins, :to_hours, :to_days, :to_weeks], fn name ->
-    def unquote(name)({hours, minutes, seconds}, :hms), do: unquote(name)(hours * 3600 + minutes * 60 + seconds, :secs)
+    def unquote(name)({hours, minutes, seconds}, :hms), do: unquote(name)(hours * @secs_in_hour + minutes * @secs_in_min + seconds, :secs)
   end
 
   @doc """
@@ -65,54 +75,31 @@ defmodule Timex.Time do
   end
 
   def from(value, :usecs) do
+    value = round(value)
     { sec, micro } = mdivmod(value)
     { mega, sec }  = mdivmod(sec)
     { mega, sec, micro }
   end
 
-  def from(value, :msecs) do
-    #micro = value * 1000
-    { sec, micro } = divmod(value, 1000)
-    { mega, sec }  = mdivmod(sec)
-    { mega, sec, micro }
-  end
-
-  def from(value, :secs) do
-    # trunc ...
-    { sec, micro } = mdivmod(value)
-    { mega, sec }  = mdivmod(sec)
-    { mega, sec, micro }
-  end
+  def from(value, :msecs), do: from(value * @usecs_in_msec, :usecs)
+  def from(value, :secs),  do: from(value * @usecs_in_sec, :usecs)
+  def from(value, :mins),  do: from(value * @secs_in_min, :secs)
+  def from(value, :hours), do: from(value * @secs_in_hour, :secs)
+  def from(value, :days),  do: from(value * @secs_in_day, :secs)
+  def from(value, :weeks), do: from(value * @secs_in_week, :secs)
+  def from(value, :hms),   do: from(to_secs(value, :hms), :secs)
 
   def to_usecs({mega, sec, micro}), do: (mega * @million + sec) * @million + micro
-  def to_msecs({mega, sec, micro}), do: (mega * @million + sec) * 1000 + micro / 1000
-  def to_secs({mega, sec, micro}),  do: mega * @million + sec + micro / @million
-  def to_mins(timestamp),           do: to_secs(timestamp) / 60
-  def to_hours(timestamp),          do: to_secs(timestamp) / 3600
-  def to_days(timestamp),           do: to_secs(timestamp) / (3600 * 24)
-  def to_weeks(timestamp),          do: to_secs(timestamp) / (3600 * 24 * 7)
+  def to_msecs({_, _, _} = ts),     do: to_usecs(ts) / @usecs_in_msec
+  def to_secs({_, _, _} = ts),      do: to_usecs(ts) / @usecs_in_sec
+  def to_mins(timestamp),           do: to_secs(timestamp) / @secs_in_min
+  def to_hours(timestamp),          do: to_secs(timestamp) / @secs_in_hour
+  def to_days(timestamp),           do: to_secs(timestamp) / @secs_in_day
+  def to_weeks(timestamp),          do: to_secs(timestamp) / @secs_in_week
 
-  def to_timestamp(value, :usecs) do
-    { secs, microsecs } = mdivmod(value)
-    { megasecs, secs }  = mdivmod(secs)
-    {megasecs, secs, microsecs}
+  Enum.each [:usecs, :msecs, :secs, :mins, :hours, :days, :weeks, :hms], fn type ->
+    def to_timestamp(value, unquote(type)), do: from(value, unquote(type))
   end
-  def to_timestamp(value, :msecs) do
-    { secs, microsecs } = divmod(value, 1000)
-    { megasecs, secs }  = mdivmod(secs)
-    {megasecs, secs, microsecs}
-  end
-  def to_timestamp(value, :secs) do
-    secs      = trunc(value)
-    microsecs = trunc((value - secs) * @million)
-    { megasecs, secs } = mdivmod(secs)
-    {megasecs, secs, microsecs}
-  end
-  def to_timestamp(value, :mins),  do: to_timestamp(value * 60, :secs)
-  def to_timestamp(value, :hours), do: to_timestamp(value * 3600, :secs)
-  def to_timestamp(value, :days),  do: to_timestamp(value * 3600 * 24, :secs)
-  def to_timestamp(value, :weeks), do: to_timestamp(value * 3600 * 24 * 7, :secs)
-  def to_timestamp(value, :hms),   do: to_timestamp(to_secs(value, :hms), :secs)
 
   def add({mega1,sec1,micro1}, {mega2,sec2,micro2}) do
     normalize { mega1+mega2, sec1+sec2, micro1+micro2 }
@@ -166,13 +153,13 @@ defmodule Timex.Time do
   """
   def convert(timestamp, type \\ :timestamp)
   def convert(timestamp, :timestamp), do: timestamp
-  def convert(timestamp, :usecs), do: to_secs(timestamp) * 1000000
-  def convert(timestamp, :msecs), do: to_secs(timestamp) * 1000
+  def convert(timestamp, :usecs), do: to_usecs(timestamp)
+  def convert(timestamp, :msecs), do: to_msecs(timestamp)
   def convert(timestamp, :secs),  do: to_secs(timestamp)
-  def convert(timestamp, :mins),  do: to_secs(timestamp) / 60
-  def convert(timestamp, :hours), do: to_secs(timestamp) / 3600
-  def convert(timestamp, :days),  do: to_secs(timestamp) / (3600 * 24)
-  def convert(timestamp, :weeks), do: to_secs(timestamp) / (3600 * 24 * 7)
+  def convert(timestamp, :mins),  do: to_mins(timestamp)
+  def convert(timestamp, :hours), do: to_hours(timestamp)
+  def convert(timestamp, :days),  do: to_days(timestamp)
+  def convert(timestamp, :weeks), do: to_weeks(timestamp)
 
   @doc """
   Return time interval since the first day of year 0 to Epoch.

--- a/test/date_test.exs
+++ b/test/date_test.exs
@@ -322,7 +322,7 @@ defmodule DateTests do
     assert D.diff(date1, date2, :months) === -D.diff(date2, date1, :months)
     assert D.diff(date1, date2, :years)  === -D.diff(date2, date1, :years)
 
-    assert D.diff(date1, date2, :timestamp) === {0, 63, 158400}
+    assert D.diff(date1, date2, :timestamp) === {63, 158400, 0}
 
     assert D.diff(epoch, date1, :days) === 365
     assert D.diff(epoch, date1, :secs) === 365 * 24 * 3600

--- a/test/time_test.exs
+++ b/test/time_test.exs
@@ -67,6 +67,17 @@ defmodule TimeTests do
     assert Time.to_secs({1,2,3}, :hms) == 3600 + 2 * 60 + 3
   end
 
+  test :to_timestamp_from do
+    assert Time.to_timestamp(1, :usecs) == {0, 0, 1}
+    assert Time.to_timestamp(1, :msecs) == {0, 0, 1000}
+    assert Time.to_timestamp(1, :secs) == {0, 1, 0}
+    assert Time.to_timestamp(1, :mins) == {0, 60, 0}
+    assert Time.to_timestamp(1, :hours) == {0, 3600, 0}
+    assert Time.to_timestamp(1, :days) == {0, 86400, 0}
+    assert Time.to_timestamp(1, :weeks) == {0, 604800, 0}
+    assert Time.to_timestamp({1, 1, 1}, :hms) == {0, 3661, 0}
+  end
+
   test :elapsed do
     previous_time = {1362,568902,363960}
     now = {1362,568903,363960}


### PR DESCRIPTION
I apologize if I combined a couple of pull requests here......

Three things in this request, 

First - modify the Time.from and Time.to_timestamp functions to work properly. The msec variants did not properly multiple the msecs by 1000 so the values were not correct. The secs variants also did not work. The date_test modification clearly is an example of the problem - there are more then 63 seconds between Jan 1st 1971 and Jan 1st 1973.

Second - modified the functions so they, where possible, call down to a single version which does the work (either usecs or secs variant) and then convert the value back to the required type. I think the less places we're actually doing work the better.

Lastly - I also switched out the multiple locations that multiplied by an amount with an set of substitutions that declare what the value is.

Tests added and passed. If more tests desired/required please let me know...