### PR TITLE
use tzdata 0.5.2

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -23,7 +23,7 @@ defmodule Timex.Mixfile do
   end
 
   def deps do
-    [{:tzdata, "~> 0.5.1"},
+    [{:tzdata, "~> 0.5.2"},
      {:combine, "~> 0.5"},
      {:ex_doc, "~> 0.5", only: :dev},
      {:benchfella, "~> 0.2", only: :dev},


### PR DESCRIPTION
There was a bug in tzdata 0.5.1 which caused repeated errors and OTP app crash if the OTP release is not in the sam absolute path it was built in. See [here](https://github.com/lau/tzdata/pull/6) for more details.
