### PR TITLE
Add support for milliseconds in `Date.to_timestamp/2`

### DIFF
--- a/lib/date/date.ex
+++ b/lib/date/date.ex
@@ -377,13 +377,13 @@ defmodule Timex.Date do
   @spec to_timestamp(DateTime.t, :epoch | :zero) :: timestamp
   def to_timestamp(date, reference \\ :epoch)
 
-  def to_timestamp(date, :epoch) do
+  def to_timestamp(%DateTime{:ms => ms} = date, :epoch) do
     sec = to_secs(date)
-    { div(sec, @million), rem(sec, @million), 0 }
+    { div(sec, @million), rem(sec, @million), ms * 1000 }
   end
-  def to_timestamp(date, :zero) do
+  def to_timestamp(%DateTime{:ms => ms} = date, :zero) do
     sec = to_secs(date, :zero)
-    { div(sec, @million), rem(sec, @million), 0 }
+    { div(sec, @million), rem(sec, @million), ms * 1000 }
   end
 
   @doc """

--- a/test/date_test.exs
+++ b/test/date_test.exs
@@ -136,6 +136,14 @@ defmodule DateTests do
     assert {0,0,0} === Date.epoch |> Date.to_timestamp
     assert {62167,219200,0} === Date.epoch |> Date.to_timestamp(:zero)
     assert Date.epoch(:secs) == Date.epoch |> Date.to_timestamp(:zero) |> Time.to_secs
+
+    # Force some micro seconds to appear in case we are unlucky and hit when micro := 0
+    {mega, secs, _micro} = Time.now
+    now = {mega, secs, 864123}
+
+    # deliberately match against 864000 AND NOT 864123 since DateTime only
+    # takes milliseconds into account
+    assert {mega, secs, 864000} === Date.from(now, :timestamp, :epoch) |> Date.to_timestamp(:epoch)
   end
 
   test "to seconds" do


### PR DESCRIPTION
Converting from `DateTime` to erlang timestamp looses sub-second precision

```
> Timex.DateFormat.parse!("2015-10-03T00:47:37.861234Z", "{ISO}") |> Timex.Date.to_timestamp
#> actual:   {1443, 833257, 0}
#> expected: {1443, 833257, 861234}
#> patched:  {1443, 833257, 861000}
```

As shown above, the patch does not account for the microsecond part (since `Timex.DateTime` doesn't) and rounds it to the nearest millisecond. It could be an idea to add a `:us` parameter to `DateTime` but that would need some discussion on best implementation for backward compatibility.