### PR TITLE
Fix grammar in docs: “it's” → “its”

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -104,7 +104,7 @@ in making it happen.
 
 Timex is composed of the following general components:
 
-- The tzdata Parser Expression Grammar (PEG), it's associated mix task, and the
+- The tzdata Parser Expression Grammar (PEG), its associated mix task, and the
   current tzdata Erlang module produced by the PEG. This is used for parsing the
   raw Olson Timezone Database. (not yet on master)
 - The `Timex.Date` namespace, containing the `DateTime` struct, `DateTime` conversions,

--- a/docs/Formatting.md
+++ b/docs/Formatting.md
@@ -19,7 +19,7 @@ Formatting DateTimes in Timex is done via the `Timex.DateFormat` module. There a
 > Date.from({2013, 8, 18}) |> DateFormat.format(format_str, MyApp.MyDateFormatter)
 
 # If formatting fails for some reason you will get an `{:error, reason}` tuple, so it's
-# recommended to use `format/1` or `format/2`, however you can use the "bang"
+# recommended to use `format/1` or `format/2`; however you can use the "bang"
 # versions of these two, `format!/1` or `format!/2` which will return the result directly,
 # or raise on failure
 > Date.from({2013, 8, 18}) |> DateFormat.format!("%Y-%m-%d", :strftime)

--- a/docs/Working with DateTime.md
+++ b/docs/Working with DateTime.md
@@ -321,7 +321,7 @@ false
 {2015, 26}
 ```
 
-### Get the name of the month corresponding to it's ordinal number
+### Get the name of the month corresponding to its ordinal number
 
 ```elixir
 > Date.month_name(3)
@@ -330,7 +330,7 @@ false
 "Mar"
 ```
 
-### Convert a month name to it's ordinal number
+### Convert a month name to its ordinal number
 
 ```elixir
 > Date.month_to_num("March")

--- a/lib/date/date.ex
+++ b/lib/date/date.ex
@@ -499,7 +499,7 @@ defmodule Timex.Date do
   Convert an iso ordinal day number to the day it represents in the
   current year. If no date is provided, a new one will be created, with
   the time will be set to 0:00:00, in UTC. Otherwise, the date provided will
-  have it's month and day reset to the date represented by the ordinal day.
+  have its month and day reset to the date represented by the ordinal day.
 
   ## Examples
 

--- a/lib/date/interval.ex
+++ b/lib/date/interval.ex
@@ -46,7 +46,7 @@ defmodule Timex.Interval do
       while the set of non-negative reals, for example, is a right-open but not left-open interval.
       The open intervals coincide with the open sets of the real line in its standard topology."
 
-  Note: `until` shifts delegate to `Date.shift`, so the options provided should match it's valid options.
+  Note: `until` shifts delegate to `Date.shift`, so the options provided should match its valid options.
 
   ## Examples
 

--- a/lib/parse/datetime/parser.ex
+++ b/lib/parse/datetime/parser.ex
@@ -98,7 +98,7 @@ defmodule Timex.Parse.DateTime.Parser do
             {{{:force_utc, true}, _}, _} -> 9999
             # Timezones must always be applied after other date/time tokens ->
             {{{tz, _}, _}, _} when tz in [:zname, :zoffs, :zoffs_colon, :zoffs_sec] -> 9998
-            # If no weight is set, use the index as it's weight
+            # If no weight is set, use the index as its weight
             {{{_token, _value}, 0}, i} -> i
             # Use the directive weight
             {{{_token, _value}, weight}, _} -> weight

--- a/lib/time/time.ex
+++ b/lib/time/time.ex
@@ -19,37 +19,37 @@ defmodule Timex.Time do
   @million       1_000_000
 
   @doc """
-  Converts a timestamp to it's value in microseconds
+  Converts a timestamp to its value in microseconds
   """
   @spec to_usecs(Date.timestamp) :: quantity
   def to_usecs({mega, sec, micro}), do: (mega * @million + sec) * @million + micro
   @doc """
-  Converts a timestamp to it's value in milliseconds
+  Converts a timestamp to its value in milliseconds
   """
   @spec to_msecs(Date.timestamp) :: quantity
   def to_msecs({_, _, _} = ts), do: to_usecs(ts) / @usecs_in_msec
   @doc """
-  Converts a timestamp to it's value in seconds
+  Converts a timestamp to its value in seconds
   """
   @spec to_secs(Date.timestamp) :: quantity
   def to_secs({_, _, _} = ts), do: to_usecs(ts) / @usecs_in_sec
   @doc """
-  Converts a timestamp to it's value in minutes
+  Converts a timestamp to its value in minutes
   """
   @spec to_mins(Date.timestamp) :: quantity
   def to_mins(timestamp), do: to_secs(timestamp) / @secs_in_min
   @doc """
-  Converts a timestamp to it's value in hours
+  Converts a timestamp to its value in hours
   """
   @spec to_hours(Date.timestamp) :: quantity
   def to_hours(timestamp), do: to_secs(timestamp) / @secs_in_hour
   @doc """
-  Converts a timestamp to it's value in days
+  Converts a timestamp to its value in days
   """
   @spec to_days(Date.timestamp) :: quantity
   def to_days(timestamp), do: to_secs(timestamp) / @secs_in_day
   @doc """
-  Converts a timestamp to it's value in weeks
+  Converts a timestamp to its value in weeks
   """
   @spec to_weeks(Date.timestamp) :: quantity
   def to_weeks(timestamp), do: to_secs(timestamp) / @secs_in_week

--- a/lib/timezone/database.ex
+++ b/lib/timezone/database.ex
@@ -10,7 +10,7 @@ defmodule Timex.Timezone.Database do
 
 
   @doc """
-  Lookup the Olson time zone given it's standard name
+  Lookup the Olson time zone given its standard name
 
   ## Example
 

--- a/lib/timezone/timezone_local.ex
+++ b/lib/timezone/timezone_local.ex
@@ -113,7 +113,7 @@ defmodule Timex.Timezone.Local do
   # We ignore the reference date here, since there is no way to lookup
   # transition times for historical/future dates
   defp localtz(:win, _date) do
-    # Windows has many of it's own unique time zone names, which can
+    # Windows has many of its own unique time zone names, which can
     # also be translated to the OS's language.
     {:ok, handle} = :win32reg.open([:read])
     :ok           = :win32reg.change_key(handle, '\\local_machine\\#{@local_tz_key}')


### PR DESCRIPTION
“It’s” is short for “it is”. “Its” is the possessive. I searched for all usages of each version and replaced the incorrect usages.

Also, in one place, I changed a comma to a semicolon.