### PR TITLE
Handle the :us token when using %f in strftime parsing

### DIFF
--- a/lib/parse/datetime/parser.ex
+++ b/lib/parse/datetime/parser.ex
@@ -218,6 +218,7 @@ defmodule Timex.Parse.DateTime.Parser do
           "" -> date
           n when is_number(n) -> %{date | :ms => n}
         end
+      :us -> %{date | :ms => div(value, 1000)}
       :sec_epoch -> Date.from(value, :secs, :epoch)
       am_pm when am_pm in [:am, :AM] ->
         {converted, hemisphere} = Time.to_12hour_clock(hh)

--- a/test/parse_strftime_test.exs
+++ b/test/parse_strftime_test.exs
@@ -15,6 +15,11 @@ defmodule DateFormatTest.ParseStrftime do
     assert {:ok, ^date2} = parse("Mon Jul 06 2015 00:00:00 GMT +0200 (CEST)", "%a %b %d %Y %H:%M:%S %Z %z (%Z)")
   end
 
+  test "parse format with microseconds" do
+    date = Date.from({{2015,7,13}, {14,1,21,53}})
+    assert {:ok, ^date} = parse("20150713 14:01:21.053021", "%Y%m%d %H:%M:%S.%f")
+  end
+
   defp parse(date, fmt) do
     DateFormat.parse(date, fmt, :strftime)
   end


### PR DESCRIPTION
Tried parsing a custom format with sub-second precision and got an error: `Unrecognized token: us`.  Added support to the `update_date` function along w/a test.