### PR TITLE
Fixes #98 - Alias iso8601 to iso8601_extended

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ Some common scenarios with examples.
 
 ```elixir
 # With timezone offset
-> date = "2015-06-24T04:50:34-0500"
+> date = "2015-06-24T04:50:34-05:00"
 > date |> DateFormat.parse("{ISO}")
 {:ok,
  %DateTime{calendar: :gregorian, day: 24, hour: 4, minute: 50, month: 6,
@@ -140,7 +140,7 @@ Some common scenarios with examples.
 
 ```elixir
 > Date.local |> DateFormat.format("{ISO}")
-{:ok, "2015-06-24T00:04:09.293-0500"}
+{:ok, "2015-06-24T00:04:09.293-05:00"}
 > Date.local |> DateFormat.format("{ISOz}")
 {:ok, "2015-06-24T05:04:13.910Z"}
 ```

--- a/bench/dateformat_bench.exs
+++ b/bench/dateformat_bench.exs
@@ -5,7 +5,7 @@ defmodule Timex.DateFormat.Bench do
     alias Timex.Parse.DateTime.Tokenizers.Default
 
     @datetime "2014-07-22T12:30:05Z"
-    @datetime_zoned "2014-07-22T12:30:05+0200"
+    @datetime_zoned "2014-07-22T12:30:05+02:00"
 
     bench "(default) parse ISO 8601 datetime" do
       datetime = DateFormat.parse(@datetime, "{ISOz}")

--- a/docs/Basic Usage.md
+++ b/docs/Basic Usage.md
@@ -80,7 +80,7 @@
 
 ```elixir
 # With timezone offset
-> date = "2015-06-24T04:50:34-0500"
+> date = "2015-06-24T04:50:34-05:00"
 > date |> DateFormat.parse("{ISO}")
 {:ok,
  %DateTime{calendar: :gregorian, day: 24, hour: 4, minute: 50, month: 6,
@@ -105,7 +105,7 @@
 
 ```elixir
 > Date.local |> DateFormat.format("{ISO}")
-{:ok, "2015-06-24T00:04:09.293-0500"}
+{:ok, "2015-06-24T00:04:09.293-05:00"}
 > Date.local |> DateFormat.format("{ISOz}")
 {:ok, "2015-06-24T05:04:13.910Z"}
 ```

--- a/lib/format/datetime/formatter.ex
+++ b/lib/format/datetime/formatter.ex
@@ -93,6 +93,7 @@ defmodule Timex.Format.DateTime.Formatter do
     ms     = format_token(:sec_fractional, date, modifiers, flags, width_spec(-1, nil))
     "#{hour}:#{minute}:#{sec}#{ms}"
   end
+  # NOTE: iso_8601 is deprecated in favor of iso_8601_extended
   def format_token(token, %DateTime{} = date, modifiers, _flags, _width)
     when token in [:iso_8601, :iso_8601z] do
     date  = case token do
@@ -113,6 +114,50 @@ defmodule Timex.Format.DateTime.Formatter do
         "#{year}-#{month}-#{day}T#{hour}:#{min}:#{sec}#{ms}#{tz}"
       :iso_8601z ->
         "#{year}-#{month}-#{day}T#{hour}:#{min}:#{sec}#{ms}Z"
+    end
+  end
+  def format_token(token, %DateTime{} = date, modifiers, _flags, _width)
+    when token in [:iso_8601_extended, :iso_8601_extended_z] do
+    date  = case token do
+      :iso_8601_extended  -> date
+      :iso_8601_extended_z -> Timezone.convert(date, "UTC")
+    end
+    flags = [padding: :zeroes]
+    year  = format_token(:year4, date, modifiers, flags, width_spec(4..4))
+    month = format_token(:month, date, modifiers, flags, width_spec(2..2))
+    day   = format_token(:day, date, modifiers, flags, width_spec(2..2))
+    hour  = format_token(:hour24, date, modifiers, flags, width_spec(2..2))
+    min   = format_token(:min, date, modifiers, flags, width_spec(2..2))
+    sec   = format_token(:sec, date, modifiers, flags, width_spec(2..2))
+    ms    = format_token(:sec_fractional, date, modifiers, flags, width_spec(-1, nil))
+    case token do
+      :iso_8601_extended ->
+        tz = format_token(:zoffs_colon, date, modifiers, flags, width_spec(-1, nil))
+        "#{year}-#{month}-#{day}T#{hour}:#{min}:#{sec}#{ms}#{tz}"
+      :iso_8601_extended_z ->
+        "#{year}-#{month}-#{day}T#{hour}:#{min}:#{sec}#{ms}Z"
+    end
+  end
+  def format_token(token, %DateTime{} = date, modifiers, _flags, _width)
+    when token in [:iso_8601_basic, :iso_8601_basic_z] do
+    date  = case token do
+      :iso_8601_basic  -> date
+      :iso_8601_basic_z -> Timezone.convert(date, "UTC")
+    end
+    flags = [padding: :zeroes]
+    year  = format_token(:year4, date, modifiers, flags, width_spec(4..4))
+    month = format_token(:month, date, modifiers, flags, width_spec(2..2))
+    day   = format_token(:day, date, modifiers, flags, width_spec(2..2))
+    hour  = format_token(:hour24, date, modifiers, flags, width_spec(2..2))
+    min   = format_token(:min, date, modifiers, flags, width_spec(2..2))
+    sec   = format_token(:sec, date, modifiers, flags, width_spec(2..2))
+    ms    = format_token(:sec_fractional, date, modifiers, flags, width_spec(-1, nil))
+    case token do
+      :iso_8601_basic ->
+        tz = format_token(:zoffs, date, modifiers, flags, width_spec(-1, nil))
+        "#{year}#{month}#{day}T#{hour}#{min}#{sec}#{ms}#{tz}"
+      :iso_8601_basic_z ->
+        "#{year}#{month}#{day}T#{hour}#{min}#{sec}#{ms}Z"
     end
   end
   def format_token(token, %DateTime{} = date, modifiers, _flags, _width)

--- a/lib/format/datetime/formatters/default.ex
+++ b/lib/format/datetime/formatters/default.ex
@@ -73,26 +73,34 @@ defmodule Timex.Format.DateTime.Formatters.Default do
   specification. The benefit of using these over manually constructed ISO
   formats is that these directives convert the date to UTC for you.
 
-  * `{ISO}`         - `<date>T<time><offset>`. Full date and time
-                      specification (e.g. `2007-08-13T16:48:01 +0300`)
+  * `{ISO:Basic}`      - `<date>T<time><offset>`. Full date and time
+                         specification without separators. This is equivalent
+                         to `{ISO}`. (e.g. `20070813T164801+0300`)
 
-  * `{ISOz}`        - `<date>T<time>Z`. Full date and time in UTC (e.g.
-                      `2007-08-13T13:48:01Z`)
+  * `{ISO:Basic:Z}`    - `<date>T<time>Z`. Full date and time in UTC without
+                         separators (e.g. `20070813T134801Z`)
 
-  * `{ISOdate}`     - `YYYY-MM-DD`. That is, 4-digit year number, followed by
-                      2-digit month and day numbers (e.g. `2007-08-13`)
+  * `{ISO:Extended}`   - `<date>T<time><offset>`. Full date and time
+                         specification with separators. This is equivalent
+                         to `{ISO}`. (e.g. `2007-08-13T16:48:01 +03:00`)
 
-  * `{ISOtime}`     - `hh:mm:ss`. That is, 2-digit hour, minute, and second,
-                      separated by colons (e.g. `13:04:05`). Midnight is 00 hours.
+  * `{ISO:Extended:Z}` - `<date>T<time>Z`. Full date and time in UTC. This is
+                         equivalent to `{ISOz}` (e.g. `2007-08-13T13:48:01Z`)
 
-  * `{ISOweek}`     - `YYYY-Www`. That is, ISO week-based year, followed by ISO
-                      week number (e.g. `2007-W09`)
+  * `{ISOdate}`        - `YYYY-MM-DD`. That is, 4-digit year number, followed by
+                         2-digit month and day numbers (e.g. `2007-08-13`)
 
-  * `{ISOweek-day}` - `YYYY-Www-D`. That is, an `{ISOweek}`, additionally
-                      followed by weekday (e.g. `2007-W09-1`)
+  * `{ISOtime}`        - `hh:mm:ss`. That is, 2-digit hour, minute, and second,
+                         separated by colons (e.g. `13:04:05`). Midnight is 00 hours.
 
-  * `{ISOord}`      - `YYYY-DDD`. That is, year number, followed by the ordinal
-                      day number (e.g. `2007-113`)
+  * `{ISOweek}`        - `YYYY-Www`. That is, ISO week-based year, followed by ISO
+                         week number (e.g. `2007-W09`)
+
+  * `{ISOweek-day}`    - `YYYY-Www-D`. That is, an `{ISOweek}`, additionally
+                         followed by weekday (e.g. `2007-W09-1`)
+
+  * `{ISOord}`         - `YYYY-DDD`. That is, year number, followed by the ordinal
+                         day number (e.g. `2007-113`)
 
   These directives provide support for miscellaneous common formats:
 

--- a/lib/parse/datetime/parser.ex
+++ b/lib/parse/datetime/parser.ex
@@ -21,7 +21,7 @@ defmodule Timex.Parse.DateTime.Parser do
   ## Examples
 
       iex> use Timex
-      ...> {:ok, dt} = #{__MODULE__}.parse("2014-07-29T00:20:41.196Z", "{ISOz}")
+      ...> {:ok, dt} = #{__MODULE__}.parse("2014-07-29T00:20:41.196Z", "{ISO:Extended:Z}")
       ...> dt.year
       2014
       iex> dt.month
@@ -44,7 +44,7 @@ defmodule Timex.Parse.DateTime.Parser do
   ## Examples
 
       iex> use Timex
-      ...> {:ok, dt} = #{__MODULE__}.parse("2014-07-29T00:30:41.196-0200", "{ISO}", Timex.Parse.DateTime.Tokenizers.Default)
+      ...> {:ok, dt} = #{__MODULE__}.parse("2014-07-29T00:30:41.196-02:00", "{ISO:Extended}", Timex.Parse.DateTime.Tokenizers.Default)
       ...> dt.year
       2014
       iex> dt.month

--- a/lib/parse/datetime/tokenizers/default.ex
+++ b/lib/parse/datetime/tokenizers/default.ex
@@ -50,8 +50,9 @@ defmodule Timex.Parse.DateTime.Tokenizers.Default do
         "Zname", "Z::", "Z:", "Z",
         # Compound
         "ISOord", "ISOweek-day", "ISOweek", "ISOdate", "ISOtime", "ISOz", "ISO",
-        "RFC822z", "RFC822", "RFC1123z", "RFC1123", "RFC3339z", "RFC3339",
-        "ANSIC", "UNIX", "kitchen"
+        "ISO:Extended", "ISO:Extended:Z", "ISO:Basic", "ISO:Basic:Z", "RFC822z",
+        "RFC822", "RFC1123z", "RFC1123", "RFC3339z", "RFC3339", "ANSIC", "UNIX",
+        "kitchen"
       ])],
       &coalesce_token/1
     )
@@ -119,22 +120,26 @@ defmodule Timex.Parse.DateTime.Tokenizers.Default do
       "Z:"    -> Directive.get(:zoffs_colon, directive, opts)
       "Z::"   -> Directive.get(:zoffs_sec, directive, opts)
       # Preformatted Directives
-      "ISO"         -> Directive.get(:iso_8601, directive, opts)
-      "ISOz"        -> Directive.get(:iso_8601z, directive, opts)
-      "ISOdate"     -> Directive.get(:iso_date, directive, opts)
-      "ISOtime"     -> Directive.get(:iso_time, directive, opts)
-      "ISOweek"     -> Directive.get(:iso_week, directive, opts)
-      "ISOweek-day" -> Directive.get(:iso_weekday, directive, opts)
-      "ISOord"      -> Directive.get(:iso_ordinal, directive, opts)
-      "RFC822"      -> Directive.get(:rfc_822, directive, opts)
-      "RFC822z"     -> Directive.get(:rfc_822z, directive, opts)
-      "RFC1123"     -> Directive.get(:rfc_1123, directive, opts)
-      "RFC1123z"    -> Directive.get(:rfc_1123z, directive, opts)
-      "RFC3339"     -> Directive.get(:rfc_3339, directive, opts)
-      "RFC3339z"    -> Directive.get(:rfc_3339z, directive, opts)
-      "ANSIC"       -> Directive.get(:ansic, directive, opts)
-      "UNIX"        -> Directive.get(:unix, directive, opts)
-      "kitchen"     -> Directive.get(:kitchen, directive, opts)
+      "ISO"            -> Directive.get(:iso_8601, directive, opts)
+      "ISOz"           -> Directive.get(:iso_8601z, directive, opts)
+      "ISO:Extended"   -> Directive.get(:iso_8601_extended, directive, opts)
+      "ISO:Extended:Z" -> Directive.get(:iso_8601_extended_z, directive, opts)
+      "ISO:Basic"      -> Directive.get(:iso_8601_basic, directive, opts)
+      "ISO:Basic:Z"    -> Directive.get(:iso_8601_basic_z, directive, opts)
+      "ISOdate"        -> Directive.get(:iso_date, directive, opts)
+      "ISOtime"        -> Directive.get(:iso_time, directive, opts)
+      "ISOweek"        -> Directive.get(:iso_week, directive, opts)
+      "ISOweek-day"    -> Directive.get(:iso_weekday, directive, opts)
+      "ISOord"         -> Directive.get(:iso_ordinal, directive, opts)
+      "RFC822"         -> Directive.get(:rfc_822, directive, opts)
+      "RFC822z"        -> Directive.get(:rfc_822z, directive, opts)
+      "RFC1123"        -> Directive.get(:rfc_1123, directive, opts)
+      "RFC1123z"       -> Directive.get(:rfc_1123z, directive, opts)
+      "RFC3339"        -> Directive.get(:rfc_3339, directive, opts)
+      "RFC3339z"       -> Directive.get(:rfc_3339z, directive, opts)
+      "ANSIC"          -> Directive.get(:ansic, directive, opts)
+      "UNIX"           -> Directive.get(:unix, directive, opts)
+      "kitchen"        -> Directive.get(:kitchen, directive, opts)
     end
   end
 

--- a/lib/parse/datetime/tokenizers/directive.ex
+++ b/lib/parse/datetime/tokenizers/directive.ex
@@ -102,6 +102,14 @@ defmodule Timex.Parse.DateTime.Tokenizers.Directive do
     do: %Directive{type: :iso_8601, value: directive, flags: flags, modifiers: mods, width: width, parser: Parsers.iso8601(flags)}
   def get(:iso_8601z, directive, flags, mods, width),
     do: %Directive{type: :iso_8601z, value: directive, flags: flags, modifiers: mods, width: width, parser: Parsers.iso8601([{:zulu, true}|flags])}
+  def get(:iso_8601_extended, directive, flags, mods, width),
+    do: %Directive{type: :iso_8601_extended, value: directive, flags: flags, modifiers: mods, width: width, parser: Parsers.iso8601_extended(flags)}
+  def get(:iso_8601_extended_z, directive, flags, mods, width),
+    do: %Directive{type: :iso_8601_extended_z, value: directive, flags: flags, modifiers: mods, width: width, parser: Parsers.iso8601_extended([{:zulu, true}|flags])}
+  def get(:iso_8601_basic, directive, flags, mods, width),
+    do: %Directive{type: :iso_8601_basic, value: directive, flags: flags, modifiers: mods, width: width, parser: Parsers.iso8601_basic(flags)}
+  def get(:iso_8601_basic_z, directive, flags, mods, width),
+    do: %Directive{type: :iso_8601_basic_z, value: directive, flags: flags, modifiers: mods, width: width, parser: Parsers.iso8601_basic([{:zulu, true}|flags])}
   def get(:iso_date, directive, flags, mods, width),
     do: %Directive{type: :iso_date, value: directive, flags: flags, modifiers: mods, width: width, parser: Parsers.iso_date(flags)}
   def get(:iso_time, directive, flags, mods, width),

--- a/test/format_default_test.exs
+++ b/test/format_default_test.exs
@@ -235,14 +235,26 @@ defmodule DateFormatTest.FormatDefault do
              "Invalid directive flag: Timezone offsets require 0-padding to remain unambiguous."}} = format(date, "{_Z::}")
   end
 
-  test "format ISO8601" do
+  test "format ISO8601 (Extended)" do
     date = Date.from({{2013,3,5},{23,25,19}}, "Europe/Athens")
     assert { :ok, "2013-03-05T23:25:19+02:00" } = format(date, "{ISO}")
-    assert { :ok, "2013-03-05T21:25:19Z" }     = format(date, "{ISOz}")
+    assert { :ok, "2013-03-05T23:25:19+02:00" } = format(date, "{ISO:Extended}")
+    assert { :ok, "2013-03-05T21:25:19Z" }      = format(date, "{ISOz}")
+    assert { :ok, "2013-03-05T21:25:19Z" }      = format(date, "{ISO:Extended:Z}")
 
     local = {{2013,3,5},{23,25,19}}
-    assert { :ok, "2013-03-05T23:25:19-08:00" } = format(Date.from(local, "America/Los_Angeles"), "{ISO}")
-    assert { :ok, "2013-03-05T23:25:19+00:00" } = format(Date.from(local, :utc), "{ISO}")
+    assert { :ok, "2013-03-05T23:25:19-08:00" } = format(Date.from(local, "America/Los_Angeles"), "{ISO:Extended}")
+    assert { :ok, "2013-03-05T23:25:19+00:00" } = format(Date.from(local, :utc), "{ISO:Extended}")
+  end
+
+  test "format ISO8601 (Basic)" do
+    date = Date.from({{2013,3,5},{23,25,19}}, "Europe/Athens")
+    assert { :ok, "20130305T232519+0200" } = format(date, "{ISO:Basic}")
+    assert { :ok, "20130305T212519Z" }      = format(date, "{ISO:Basic:Z}")
+
+    local = {{2013,3,5},{23,25,19}}
+    assert { :ok, "20130305T232519-0800" } = format(Date.from(local, "America/Los_Angeles"), "{ISO:Basic}")
+    assert { :ok, "20130305T232519+0000" } = format(Date.from(local, :utc), "{ISO:Basic}")
   end
 
   test "format ISO date" do

--- a/test/parse_default_test.exs
+++ b/test/parse_default_test.exs
@@ -244,6 +244,58 @@ defmodule DateFormatTest.ParseDefault do
     assert { :ok, ^date5} = parse("2007-04-05T14Z", "{ISO}")
   end
 
+  test "parse ISO8601 (Extended)" do
+    date1 = Date.from({{2014, 8, 14}, {12, 34, 33}})
+    date2 = %{date1 | :ms => 199}
+
+    assert { :ok, ^date1 } = parse("2014-08-14T12:34:33+00:00", "{ISO:Extended}")
+    assert { :ok, ^date1 } = parse("2014-08-14T12:34:33+0000", "{ISO:Extended}")
+    assert { :ok, ^date1 } = parse("2014-08-14T12:34:33+00", "{ISO:Extended}")
+    assert { :ok, ^date1 } = parse("2014-08-14T12:34:33Z", "{ISO:Extended}")
+    assert { :ok, ^date1 } = parse("2014-08-14T12:34:33Z", "{ISO:Extended:Z}")
+
+    assert { :ok, ^date2 } = parse("2014-08-14T12:34:33.199+00:00", "{ISO:Extended}")
+    assert { :ok, ^date2 } = parse("2014-08-14T12:34:33.199+0000", "{ISO:Extended}")
+    assert { :ok, ^date2 } = parse("2014-08-14T12:34:33.199+00", "{ISO:Extended}")
+    assert { :ok, ^date2 } = parse("2014-08-14T12:34:33.199Z", "{ISO:Extended}")
+    assert { :ok, ^date2 } = parse("2014-08-14T12:34:33.199Z", "{ISO:Extended:Z}")
+
+    date3 = Date.from({{2014, 8, 14}, {12, 34, 33}}, "Etc/GMT+5")
+    assert { :ok, ^date3 } = parse("2014-08-14T12:34:33-05:00", "{ISO:Extended}")
+    assert { :ok, ^date3 } = parse("2014-08-14T12:34:33-0500", "{ISO:Extended}")
+    assert { :ok, ^date3 } = parse("2014-08-14T12:34:33-05", "{ISO:Extended}")
+
+    date4 = Date.from({{2007, 4, 5}, {14, 30, 0}})
+    assert { :ok, ^date4} = parse("2007-04-05T14:30Z", "{ISO:Extended}")
+
+    date5 = Date.from({{2007, 4, 5}, {14, 0, 0}})
+    assert { :ok, ^date5} = parse("2007-04-05T14Z", "{ISO:Extended}")
+  end
+
+  test "parse ISO8601 (Basic)" do
+    date1 = Date.from({{2014, 8, 14}, {12, 34, 33}})
+    date2 = %{date1 | :ms => 199}
+
+    assert { :ok, ^date1 } = parse("20140814T123433+0000", "{ISO:Basic}")
+    assert { :ok, ^date1 } = parse("20140814T123433+00", "{ISO:Basic}")
+    assert { :ok, ^date1 } = parse("20140814T123433Z", "{ISO:Basic}")
+    assert { :ok, ^date1 } = parse("20140814T123433Z", "{ISO:Basic:Z}")
+
+    assert { :ok, ^date2 } = parse("20140814T123433.199+0000", "{ISO:Basic}")
+    assert { :ok, ^date2 } = parse("20140814T123433.199+00", "{ISO:Basic}")
+    assert { :ok, ^date2 } = parse("20140814T123433.199Z", "{ISO:Basic}")
+    assert { :ok, ^date2 } = parse("20140814T123433.199Z", "{ISO:Basic:Z}")
+
+    date3 = Date.from({{2014, 8, 14}, {12, 34, 33}}, "Etc/GMT+5")
+    assert { :ok, ^date3 } = parse("20140814T123433-0500", "{ISO:Basic}")
+    assert { :ok, ^date3 } = parse("20140814T123433-05", "{ISO:Basic}")
+
+    date4 = Date.from({{2007, 4, 5}, {14, 30, 0}})
+    assert { :ok, ^date4} = parse("20070405T1430Z", "{ISO:Basic}")
+
+    date5 = Date.from({{2007, 4, 5}, {14, 0, 0}})
+    assert { :ok, ^date5} = parse("20070405T14Z", "{ISO:Basic}")
+  end
 
   defp parse(date, fmt) do
     DateFormat.parse(date, fmt)


### PR DESCRIPTION
Fixes #98 - Replace ISO8601 `{ISO}` and `{ISOz}` w/ `{ISO:Extended}` and `{ISO:Extended:Z}`.

 - [x] Support `{ISO:Extended}` and `{ISO:Extended:Z}`, w/ backwards compatibility for `{ISO}` `{ISOz}`
 - [x] Add `{ISO:Basic}` and `{ISO:Basic:Z}` support

```elixir
iex(3)> Date.local |> DateFormat.format("{ISO}")
{:ok, "2015-11-09T20:10:43.088-08:00"}
iex(4)> Date.local |> DateFormat.format("{ISOz}")
{:ok, "2015-11-10T04:10:53.136Z"}

iex(5)> Date.local |> DateFormat.format("{ISO:Extended}")
{:ok, "2015-11-09T20:10:48.264-08:00"}
iex(6)> Date.local |> DateFormat.format("{ISO:Extended:Z}")
{:ok, "2015-11-10T04:10:57.136Z"}
iex(2)> Date.local |> DateFormat.format("{ISO:Basic}")
{:ok, "20151122T132003.872-0800"}
iex(3)> Date.local |> DateFormat.format("{ISO:Basic:Z}")
{:ok, "20151122T212006.640Z"}
```