### PR TITLE
fix time diff

### DIFF
--- a/lib/time/time.ex
+++ b/lib/time/time.ex
@@ -284,7 +284,7 @@ defmodule Timex.Time do
   def diff({_,_,_} = t1, {_,_,_} = t2, :timestamp) do
     microsecs = :timer.now_diff(t1, t2)
     mega  = div(microsecs, 1_000_000_000_000)
-    secs  = div(microsecs, 1_000_000 - mega*1_000_000)
+    secs  = div(microsecs - mega*1_000_000_000_000, 1_000_000)
     micro = rem(microsecs, 1_000_000)
     {mega, secs, micro}
   end

--- a/test/time_test.exs
+++ b/test/time_test.exs
@@ -30,6 +30,17 @@ defmodule TimeTests do
     assert Time.diff(timestamp2, timestamp1, :hours) == 55.587139 / 3600
   end
 
+  test "diff fix" do 
+    timestamp1 = {1450,746582,000000}
+    timestamp2 = {1451,981376,368306}
+    assert Time.diff(timestamp2, timestamp1) == {1, 234794, 368306}
+    assert Time.diff(timestamp2, timestamp1, :usecs) == 1234794368306
+    assert Time.diff(timestamp2, timestamp1, :msecs) == 1234794368.306
+    assert Time.diff(timestamp2, timestamp1, :secs)  == 1234794.368306
+    assert Time.diff(timestamp2, timestamp1, :mins)  == 1234794.368306 / 60
+    assert Time.diff(timestamp2, timestamp1, :hours) == 1234794.368306 / 3600
+  end
+
   test "measure/2" do
     {{_, _, _}, result} = Time.measure(fn x -> x end, [:nothing])
     assert result == :nothing


### PR DESCRIPTION
current implementation of diff(t1, t2, :timestamp) has an error, it will raise arithmetic exception when mega == 1, then secs = div(microsecs, 0)