### PR TITLE
Fix documentation mismatch regarding `{ISO}`, `{ISO:Basic}` and `{ISO:Extended}`

### DIFF
--- a/lib/format/datetime/formatters/default.ex
+++ b/lib/format/datetime/formatters/default.ex
@@ -74,8 +74,7 @@ defmodule Timex.Format.DateTime.Formatters.Default do
   formats is that these directives convert the date to UTC for you.
 
   * `{ISO:Basic}`      - `<date>T<time><offset>`. Full date and time
-                         specification without separators. This is equivalent
-                         to `{ISO}`. (e.g. `20070813T164801+0300`)
+                         specification without separators.
 
   * `{ISO:Basic:Z}`    - `<date>T<time>Z`. Full date and time in UTC without
                          separators (e.g. `20070813T134801Z`)


### PR DESCRIPTION
The documentation states for formatting a date time:

>  `{ISO:Basic}` [...] is equivalent to `{ISO}` 
> [..]
> `{ISO:Extended}` [..] is equivalent to `{ISO}` 
> (https://github.com/bitwalker/timex/blob/master/lib/format/datetime/formatters/default.ex#L76)

Both statements cannot be true and isn't reflecting the actual implementation:

```elixir
iex(1)> now = Timex.Date.now
%Timex.DateTime{calendar: :gregorian, day: 6, hour: 13, minute: 28, month: 1,
 ms: 532, second: 8,
 timezone: %Timex.TimezoneInfo{abbreviation: "UTC", from: :min,
  full_name: "UTC", offset_std: 0, offset_utc: 0, until: :max}, year: 2016}
iex(2)> Timex.DateFormat.format!(now, "{ISO:Basic}")
"20160106T132808.532+0000"
iex(3)> Timex.DateFormat.format!(now, "{ISO}")
"2016-01-06T13:28:08.532+00:00"
iex(4)> Timex.DateFormat.format!(now, "{ISO:Extended}")
"2016-01-06T13:28:08.532+00:00"
```

So from my observation `{ISO:Extended}` is equivalent to `{ISO}`.

(This might be related the changed of #98)