### PR TITLE
Some small optimizations and removal of imperative if uses.

### DIFF
--- a/lib/date/date.ex
+++ b/lib/date/date.ex
@@ -1293,10 +1293,7 @@ defmodule Timex.Date do
   defp validate({year, month, day}) do
     # Check if we got past the last day of the month
     max_day = days_in_month(year, month)
-    if day > max_day do
-      day = max_day
-    end
-    {year, month, day}
+    {year, month, min(day, max_day)}
   end
 
   defp mod(a, b), do: rem(rem(a, b) + b, b)

--- a/lib/time/time.ex
+++ b/lib/time/time.ex
@@ -347,13 +347,9 @@ defmodule Timex.Time do
 
   defp normalize({mega, sec, micro}) do
     # TODO: check for negative values
-    if micro >= @million do
-      { sec, micro } = mdivmod(sec, micro)
-    end
+    { sec, micro } = mdivmod(sec, micro)
 
-    if sec >= @million do
-      { mega, sec } = mdivmod(mega, sec)
-    end
+    { mega, sec } = mdivmod(mega, sec)
 
     { mega, sec, micro }
   end

--- a/lib/timezone/timezone_local.ex
+++ b/lib/timezone/timezone_local.ex
@@ -45,17 +45,18 @@ defmodule Timex.Timezone.Local do
 
   def lookup(), do: Date.now |> lookup
   def lookup(%DateTime{} = date) do
-    tz = Application.get_env(:timex, :local_timezone)
-    if tz == nil do
-      tz = case :os.type() do
-        {:unix, :darwin} -> localtz(:osx, date)
-        {:unix, _}       -> localtz(:unix, date)
-        {:win32, :nt}    -> localtz(:win, date)
-        _                -> raise "Unsupported operating system!"
-      end
-      Application.put_env(:timex, :local_timezone, tz)
+    case Application.get_env(:timex, :local_timezone) do
+      nil ->
+        tz = case :os.type() do
+          {:unix, :darwin} -> localtz(:osx, date)
+          {:unix, _}       -> localtz(:unix, date)
+          {:win32, :nt}    -> localtz(:win, date)
+          _                -> raise "Unsupported operating system!"
+        end
+        Application.put_env(:timex, :local_timezone, tz)
+        tz
+      tz -> tz
     end
-    tz
   end
 
   # Get the locally configured timezone on OSX systems


### PR DESCRIPTION
In Elixir 1.3 imperative uses of if are going to emit warnings, so I took a look at this library and found some ways to remove them and optimize it. This PR changes 3 things.
- In Date.validate/1, instead of checking if day > max_day, just return min(day, max_day).
- Because of how div/2 and rem/2 behave, there is no need to check for >= @million in Time.normalize/1.
- In Timezone.Local.lookup/1, instead of checking if tz == nil, it's now one big case statement, removing the last imperative if.