### PR TITLE
Add Date.from ability to handle Phoenix datetime_select changeset

### DIFF
--- a/lib/date/date.ex
+++ b/lib/date/date.ex
@@ -284,6 +284,7 @@ defmodule Timex.Date do
   ## Examples
 
       > Date.from(:erlang.universaltime)             #=> %DateTime{...}
+      > Date.from(datetime_select params)            #=> %DateTime{...}
       > Date.from(:erlang.localtime)                 #=> %Datetime{...}
       > Date.from(:erlang.localtime, :local)         #=> %DateTime{...}
       > Date.from({2014,3,16}, "America/Chicago")    #=> %DateTime{...}
@@ -297,6 +298,9 @@ defmodule Timex.Date do
 
   def from({y,m,d} = date, :utc) when is_integer(y) and is_integer(m) and is_integer(d),
     do: construct({date, {0,0,0}}, %TimezoneInfo{})
+  def from(%{"day" => _, "hour" => _, "min" => _, "month" => _, "year" => _} = dtm, :utc) do
+    construct({{String.to_integer(dtm["year"]),String.to_integer(dtm["month"]),String.to_integer(dtm["day"])},{String.to_integer(dtm["hour"]),String.to_integer(dtm["min"]),00}}, %TimezoneInfo{})
+  end
   def from({{_,_,_},{_,_,_}} = datetime, :utc),
     do: construct(datetime, %TimezoneInfo{})
   def from({{_,_,_},{_,_,_,_}} = datetime, :utc),

--- a/test/date_test.exs
+++ b/test/date_test.exs
@@ -138,6 +138,11 @@ defmodule DateTests do
     assert %DateTime{year: 1970, month: 2, day: 1, hour: 0, minute: 0, second: 0} = Date.from(31, :days)
   end
 
+  test "from datetime_select" do
+    date = %{"day" => "05", "hour" => "12", "min" => "35", "month" => "2", "year" => "2016"}
+    assert %DateTime{year: 2016, month: 2, day: 05, hour: 12, minute: 35, second: 0} = date |> Date.from
+  end
+
   test "to timestamp" do
     assert {0,0,0} === Date.epoch |> Date.to_timestamp
     assert {62167,219200,0} === Date.epoch |> Date.to_timestamp(:zero)


### PR DESCRIPTION
I had added a Date.from version that takes the params from a Phoenix Edit View's datetime_select control and returns a Timex.Datetime struct to allow the creation of a changeset.
Example Usage:

```elixir
def update(conn, %{"id" => id, "cold_lead" => cold_lead_params}) do
  if(cold_lead_params||0 != 0) do
    if(Map.has_key?(cold_lead_params,"discovered")) do
      unless(Map.has_key?(cold_lead_params["discovered"],:calendar)) do
        cold_lead_params = update_in(cold_lead_params["discovered"], &(Timex.Date.from &1))
      end
    end
  end
  cold_lead = Repo.get!(ColdLead, id)
  changeset = ColdLead.changeset(cold_lead, cold_lead_params)
```

