### PR TITLE
fix Timex.diff for equal datetimes and timestamp granularity

### DIFF
--- a/lib/comparable/datetime.ex
+++ b/lib/comparable/datetime.ex
@@ -80,7 +80,7 @@ defimpl Timex.Comparable, for: Timex.DateTime do
       {{:ok, this_secs}, {:ok, other_secs}} ->
         diff_secs = this_secs - other_secs
         cond do
-          diff_secs == 0 -> 0
+          diff_secs == 0 -> zero(type)
           diff_secs > 0  -> do_diff(this, this_secs, other, other_secs, type)
           diff_secs < 0  -> do_diff(other, other_secs, this, this_secs, type)
         end
@@ -97,7 +97,7 @@ defimpl Timex.Comparable, for: Timex.DateTime do
         {:error, {:ambiguous_comparison, ambiguous}}
     end
   end
-  defp do_diff(_, a, _, a, _), do: 0
+  defp do_diff(_, a, _, a, type), do: zero(type)
   defp do_diff(_adate, a, _bdate, b, :timestamp) do
     seconds = a - b
     case ok!(Time.from(seconds, :seconds)) do
@@ -160,5 +160,6 @@ defimpl Timex.Comparable, for: Timex.DateTime do
   end
   defp do_diff(_, _, _, _, unit) when not unit in @units,
     do: {:error, {:invalid_granularity, unit}}
-
+  defp zero(:timestamp), do: Time.zero
+  defp zero(_type), do: 0
 end

--- a/test/timex_test.exs
+++ b/test/timex_test.exs
@@ -241,6 +241,11 @@ defmodule TimexTests do
     assert Timex.diff(date2, date1, :months) === 25
   end
 
+  test "timestamp diff same datetime" do
+      dt = Timex.datetime({1984, 5, 10})
+      assert Timex.diff(dt, dt, :timestamp) === Time.zero
+  end
+
   test "beginning_of_year" do
     year_start = Timex.datetime({{2015, 1, 1},  {0, 0, 0}})
     assert Timex.beginning_of_year(2015) == Timex.to_date(year_start)


### PR DESCRIPTION
### Summary of changes

In my own app I was diff'ing 2 datetimes, asking for a timestamp back. In some cases I would diff 2 equal datetimes, and get a zero returned instead of `{0,0,0}` even though I requested a timestamp.

My PR fixes this, which I believe to be a bug.

### Checklist

- [x] New functions have typespecs, changed functions were updated
- [x] Same for documentation, including moduledocs
- [x] Tests were added or updated to cover changes
- [x] Commits were squashed into a single coherent commit

Prior to this fix, the :timestamp type was ignored and 0 integer was returned