### PR TITLE
add ASN.1 GeneralizedTime format capability

### DIFF
--- a/lib/format/datetime/formatter.ex
+++ b/lib/format/datetime/formatter.ex
@@ -358,6 +358,29 @@ defmodule Timex.Format.DateTime.Formatter do
     sec   = format_token(locale, :sec, date, modifiers, flags, width_spec(2..2))
     "#{year}#{month}#{day}#{hour}#{min}#{sec}Z"
   end
+  def format_token(locale, :asn1_generalized_time, %DateTime{} = date, modifiers, _flags, _width) do
+    # `130305232519`
+    flags = [padding: :zeroes]
+    year  = format_token(locale, :year4, date, modifiers, flags, width_spec(4..4))
+    month = format_token(locale, :month, date, modifiers, flags, width_spec(2..2))
+    day   = format_token(locale, :day, date, modifiers, flags, width_spec(2..2))
+    hour  = format_token(locale, :hour24, date, modifiers, flags, width_spec(2..2))
+    min   = format_token(locale, :min, date, modifiers, flags, width_spec(2..2))
+    sec   = format_token(locale, :sec, date, modifiers, flags, width_spec(2..2))
+    "#{year}#{month}#{day}#{hour}#{min}#{sec}"
+  end
+  def format_token(locale, :asn1_generalized_time_z, %DateTime{} = date, modifiers, flags, width) do
+    # `130305232519Z`
+    date = Timezone.convert(date, "UTC")
+    base = format_token(locale, :asn1_generalized_time, date, modifiers, flags, width)
+    base <> "Z"
+  end
+  def format_token(locale, :asn1_generalized_time_tz, %DateTime{} = date, modifiers, flags, width) do
+    # `130305232519-0500`
+    offset = format_token(locale, :zoffs, date, modifiers, flags, width)
+    base = format_token(locale, :asn1_generalized_time, date, modifiers, flags, width)
+    base <> offset
+  end
   def format_token(locale, :kitchen, %DateTime{} = date, modifiers, _flags, _width) do
     # `3:25PM`
     hour  = format_token(locale, :hour12, date, modifiers, [], width_spec(2..2))

--- a/lib/format/datetime/formatters/default.ex
+++ b/lib/format/datetime/formatters/default.ex
@@ -104,18 +104,28 @@ defmodule Timex.Format.DateTime.Formatters.Default do
   * `{ASN1:UTCtime}`    - `YYMMDD<time>Z`. Full 2-digit year date and time in UTC without
                         separators (e.g. `070813134801Z`)
 
+  * `{ASN1:GeneralizedTime}` - `YYYYMMDD<time>`. Full 4-digit year date and time in local timezon without
+                        separators and with optional fractional seconds (e.g. `20070813134801.032`)
+  * `{ASN1:GeneralizedTime:Z}` - `YYYYMMDD<time>Z`. Full 4-digit year date and time in UTC without
+                        separators and with optional fractional seconds (e.g. `20070813134801.032Z`)
+  * `{ASN1:GeneralizedTime:TZ}` - `YYYYMMDD<time><offset>`. Full 4-digit year date and time in UTC without
+                        separators and with optional fractional seconds (e.g. `20070813134801.032-0500`)
+
   These directives provide support for miscellaneous common formats:
 
-  * `{RFC822}`           - e.g. `Mon, 05 Jun 14 23:20:59 UT`
-  * `{RFC822z}`          - e.g. `Mon, 05 Jun 14 23:20:59 Z`
-  * `{RFC1123}`          - e.g. `Tue, 05 Mar 2013 23:25:19 GMT`
-  * `{RFC1123z}`         - e.g. `Tue, 05 Mar 2013 23:25:19 +0200`
-  * `{RFC3339}`          - e.g. `2013-03-05T23:25:19+02:00`
-  * `{RFC3339z}`         - e.g. `2013-03-05T23:25:19Z`
-  * `{ANSIC}`            - e.g. `Tue Mar  5 23:25:19 2013`
-  * `{UNIX}`             - e.g. `Tue Mar  5 23:25:19 PST 2013`
-  * `{ASN1:UTCtime}`    - e.g. `130305232519Z`
-  * `{kitchen}`          - e.g. `3:25PM`
+  * `{RFC822}`                  - e.g. `Mon, 05 Jun 14 23:20:59 UT`
+  * `{RFC822z}`                 - e.g. `Mon, 05 Jun 14 23:20:59 Z`
+  * `{RFC1123}`                 - e.g. `Tue, 05 Mar 2013 23:25:19 GMT`
+  * `{RFC1123z}`                - e.g. `Tue, 05 Mar 2013 23:25:19 +0200`
+  * `{RFC3339}`                 - e.g. `2013-03-05T23:25:19+02:00`
+  * `{RFC3339z}`                - e.g. `2013-03-05T23:25:19Z`
+  * `{ANSIC}`                   - e.g. `Tue Mar  5 23:25:19 2013`
+  * `{UNIX}`                    - e.g. `Tue Mar  5 23:25:19 PST 2013`
+  * `{ASN1:UTCtime}`            - e.g. `130305232519Z`
+  * `{ASN1:GeneralizedTime}`    - e.g. `20130305232519.928`
+  * `{ASN1:GeneralizedTime:Z}`  - e.g. `20130305232519.928Z`
+  * `{ASN1:GeneralizedTime:TZ}` - e.g. `20130305232519.928-0500`
+  * `{kitchen}`                 - e.g. `3:25PM`
 
   """
   use Timex.Format.DateTime.Formatter

--- a/lib/parse/datetime/parsers.ex
+++ b/lib/parse/datetime/parsers.ex
@@ -508,6 +508,49 @@ defmodule Timex.Parse.DateTime.Parsers do
     sequence(parts ++ [literal(char("Z"))])
   end
   @doc """
+  ASN.1 GeneralizedTime standard date/time format.
+  Example: `20130305232519`
+  asn1_generalized_time(zulu: true)
+  Example: `20130305232519Z`
+  asn1_generalized_time(zoffs: true)
+  Example: `20130305232519-0700`
+  """
+  def asn1_generalized_time(opts \\ []) do
+    is_zulu?  = get_in(opts, [:zulu])
+    is_zoffs? = get_in(opts, [:zoffs])
+    parts = [
+      sequence([
+        year4([padding: :zeroes, min: 4, max: 4]),
+        month2([padding: :zeroes, min: 2, max: 2]),
+        day_of_month([padding: :zeroes, min: 2, max: 2])
+      ]),
+      choice([
+        sequence([
+          hour24([padding: :zeroes, min: 2, max: 2]),
+          minute([padding: :zeroes, min: 2, max: 2]),
+          second_fractional([padding: :zeroes]),
+        ]),
+        sequence([
+          hour24([padding: :zeroes, min: 2, max: 2]),
+          minute([padding: :zeroes, min: 2, max: 2]),
+          second([padding: :zeroes, min: 2, max: 2]),
+        ]),
+        sequence([
+          hour24([padding: :zeroes, min: 2, max: 2]),
+          minute([padding: :zeroes, min: 2, max: 2]),
+        ]),
+        sequence([
+          hour24([padding: :zeroes, min: 2, max: 2]),
+        ])
+      ])
+    ]
+    cond do
+      is_zulu?  == true -> sequence(parts ++ [literal(char("Z"))])
+      is_zoffs? == true -> sequence(parts ++ [zoffs(opts)])
+      true              -> sequence(parts)
+    end
+  end
+  @doc """
   Kitchen clock time format.
   Example: `3:25PM`
   """

--- a/lib/parse/datetime/tokenizers/default.ex
+++ b/lib/parse/datetime/tokenizers/default.ex
@@ -52,7 +52,8 @@ defmodule Timex.Parse.DateTime.Tokenizers.Default do
         "ISOord", "ISOweek-day", "ISOweek", "ISOdate", "ISOtime", "ISOz", "ISO",
         "ISO:Extended", "ISO:Extended:Z", "ISO:Basic", "ISO:Basic:Z", "RFC822z",
         "RFC822", "RFC1123z", "RFC1123", "RFC3339z", "RFC3339", "ANSIC", "UNIX",
-        "ASN1:UTCtime", "kitchen"
+        "ASN1:UTCtime", "ASN1:GeneralizedTime", "ASN1:GeneralizedTime:Z",
+        "ASN1:GeneralizedTime:TZ", "kitchen"
       ])],
       &coalesce_token/1
     )
@@ -141,6 +142,9 @@ defmodule Timex.Parse.DateTime.Tokenizers.Default do
       "ANSIC"          -> Directive.get(:ansic, directive, opts)
       "UNIX"           -> Directive.get(:unix, directive, opts)
       "ASN1:UTCtime"   -> Directive.get(:asn1_utc_time, directive, opts)
+      "ASN1:GeneralizedTime" -> Directive.get(:asn1_generalized_time, directive, opts)
+      "ASN1:GeneralizedTime:Z" -> Directive.get(:asn1_generalized_time_z, directive, opts)
+      "ASN1:GeneralizedTime:TZ" -> Directive.get(:asn1_generalized_time_tz, directive, opts)
       "kitchen"        -> Directive.get(:kitchen, directive, opts)
     end
   end

--- a/lib/parse/datetime/tokenizers/directive.ex
+++ b/lib/parse/datetime/tokenizers/directive.ex
@@ -144,6 +144,12 @@ defmodule Timex.Parse.DateTime.Tokenizers.Directive do
     do: %Directive{type: :kitchen, value: directive, flags: flags, modifiers: mods, width: width, parser: Parsers.kitchen(flags)}
   def get(:asn1_utc_time, directive, flags, mods, width),
     do: %Directive{type: :asn1_utc_time, value: directive, flags: flags, modifiers: mods, width: width, parser: Parsers.asn1_utc_time(flags)}
+  def get(:asn1_generalized_time, directive, flags, mods, width),
+    do: %Directive{type: :asn1_generalized_time, value: directive, flags: flags, modifiers: mods, width: width, parser: Parsers.asn1_generalized_time(flags)}
+  def get(:asn1_generalized_time_z, directive, flags, mods, width),
+    do: %Directive{type: :asn1_generalized_time_z, value: directive, flags: flags, modifiers: mods, width: width, parser: Parsers.asn1_generalized_time([{:zulu, true}|flags])}
+  def get(:asn1_generalized_time_tz, directive, flags, mods, width),
+    do: %Directive{type: :asn1_generalized_time_tz, value: directive, flags: flags, modifiers: mods, width: width, parser: Parsers.asn1_generalized_time([{:zoffs, true}|flags])}
   def get(:slashed, directive, flags, mods, width),
     do: %Directive{type: :slashed, value: directive, flags: flags, modifiers: mods, width: width, parser: Parsers.slashed(flags)}
   def get(:strftime_iso_date, directive, flags, mods, width),

--- a/test/format_default_test.exs
+++ b/test/format_default_test.exs
@@ -345,6 +345,35 @@ defmodule DateFormatTest.FormatDefault do
     assert { :ok, "130305232519Z" } = format(date, "{ASN1:UTCtime}")
   end
 
+  test "format ASN1 Generalized Time" do
+    local = {{2013,3,5},{23,25,19}}
+    date = Timex.datetime(local, :local)
+
+    assert { :ok, "20130305232519" } = format(date, "{ASN1:GeneralizedTime}")
+
+    date = Timex.datetime(local)
+
+    assert { :ok, "20130305232519" } = format(date, "{ASN1:GeneralizedTime}")
+  end
+
+  test "format ASN1 Generalized Time Z" do
+    local = {{2013,3,5},{23,25,19}}
+    date = Timex.datetime(local, :utc)
+
+    assert { :ok, "20130305232519Z" } = format(date, "{ASN1:GeneralizedTime:Z}")
+
+    date = Timex.datetime(local)
+
+    assert { :ok, "20130305232519Z" } = format(date, "{ASN1:GeneralizedTime:Z}")
+  end
+
+  test "format ASN1 Generalized Time TZ" do
+    local = {{2013,3,5},{23,25,19}}
+    date = Timex.datetime(local, "-0500")
+
+    assert { :ok, "20130305232519-0500" } = format(date, "{ASN1:GeneralizedTime:TZ}")
+  end
+
   test "format UNIX" do
     local = {{2013,3,5},{23,25,19}}
     date = Timex.datetime(local, :utc)

--- a/test/parse_default_test.exs
+++ b/test/parse_default_test.exs
@@ -234,6 +234,66 @@ defmodule DateFormatTest.ParseDefault do
     assert { :ok, ^date } = parse("1511162223Z", "{ASN1:UTCtime}")
   end
 
+  test "parse ASN1:GeneralizedTime" do
+    # YYYYMMDDHH[MM[SS[.fff]]]
+    # * `{ASN1:GeneralizedTime}`       - e.g. `Tue Mar  5 23:25:19 2013`
+    timestamp = {1236, 295519, 456000}
+    {:ok, result} = parse("20090305232519.456", "{ASN1:GeneralizedTime}")
+    assert ^timestamp = Timex.to_timestamp(result)
+
+    date = Timex.datetime({{2009, 3, 5}, {23, 25, 19}})
+    assert { :ok, ^date } = parse("20090305232519.000", "{ASN1:GeneralizedTime}")
+
+    date = Timex.datetime({{2009, 3, 5}, {23, 25, 19}})
+    assert { :ok, ^date } = parse("20090305232519", "{ASN1:GeneralizedTime}")
+
+    date = Timex.datetime({{2015, 11, 16}, {22, 23, 00}})
+    assert { :ok, ^date } = parse("201511162223", "{ASN1:GeneralizedTime}")
+
+    date = Timex.datetime({{2015, 11, 16}, {22, 00, 00}})
+    assert { :ok, ^date } = parse("2015111622", "{ASN1:GeneralizedTime}")
+  end
+
+  test "parse ASN1:GeneralizedTime:Z" do
+    # YYYYMMDDHH[MM[SS[.fff]]]Z
+    # * `{ASN1:GeneralizedTime:Z}`       - e.g. `Tue Mar  5 23:25:19 2013`
+    timestamp = {1236, 295519, 456000}
+    {:ok, result} = parse("20090305232519.456Z", "{ASN1:GeneralizedTime:Z}")
+    assert ^timestamp = Timex.to_timestamp(result)
+
+    date = Timex.datetime({{2009, 3, 5}, {23, 25, 19}})
+    assert { :ok, ^date } = parse("20090305232519.000Z", "{ASN1:GeneralizedTime:Z}")
+
+    date = Timex.datetime({{2009, 3, 5}, {23, 25, 19}})
+    assert { :ok, ^date } = parse("20090305232519Z", "{ASN1:GeneralizedTime:Z}")
+
+    date = Timex.datetime({{2015, 11, 16}, {22, 23, 00}}, "UTC")
+    assert { :ok, ^date } = parse("201511162223Z", "{ASN1:GeneralizedTime:Z}")
+
+    date = Timex.datetime({{2015, 11, 16}, {22, 00, 00}}, "UTC")
+    assert { :ok, ^date } = parse("2015111622Z", "{ASN1:GeneralizedTime:Z}")
+  end
+
+  test "parse ASN1:GeneralizedTime:TZ" do
+    # YYYYMMDDHH[MM[SS[.fff]]]Z
+    # * `{ASN1:GeneralizedTime:TZ}`       - e.g. `Tue Mar  5 23:25:19 2013`
+    timestamp = {1236, 320719, 456000}
+    {:ok, result} = parse("20090305232519.456-0700", "{ASN1:GeneralizedTime:TZ}")
+    assert ^timestamp = Timex.to_timestamp(result)
+
+    date = Timex.datetime({{2009, 3, 5}, {23, 25, 19}}, "Etc/GMT+7")
+    assert { :ok, ^date } = parse("20090305232519.000-0700", "{ASN1:GeneralizedTime:TZ}")
+
+    date = Timex.datetime({{2009, 3, 5}, {23, 25, 19}}, "Etc/GMT+7")
+    assert { :ok, ^date } = parse("20090305232519-0700", "{ASN1:GeneralizedTime:TZ}")
+
+    date = Timex.datetime({{2015, 11, 16}, {22, 23, 00}}, "Etc/GMT+7")
+    assert { :ok, ^date } = parse("201511162223-0700", "{ASN1:GeneralizedTime:TZ}")
+
+    date = Timex.datetime({{2015, 11, 16}, {22, 00, 00}}, "Etc/GMT+7")
+    assert { :ok, ^date } = parse("2015111622-0700", "{ASN1:GeneralizedTime:TZ}")
+  end
+
   test "parse kitchen" do
     # * `{kitchen}`     - e.g. `3:25PM`
     date = DateTime.now |> Timex.set(hour: 15, minute: 25, second: 0, millisecond: 0)


### PR DESCRIPTION
### Summary of changes

Prior to this commit Timex would, unstandably, barf if one attempted to
parse an ASN.1 GeneralizedTime format, which is the underlying format
for things like LDAP. This commit adds the ability to parse ASN.1
GeneralizedTime (UTC only).

- [x] New functions have typespecs, changed functions were updated
- [x] Same for documentation, including moduledocs
- [x] Tests were added or updated to cover changes
- [x] Commits were squashed into a single coherent commit

