### PR TITLE
collapse directives to 3 basic cases

### DIFF
--- a/lib/parse/datetime/tokenizers/directive.ex
+++ b/lib/parse/datetime/tokenizers/directive.ex
@@ -33,135 +33,41 @@ defmodule Timex.Parse.DateTime.Tokenizers.Directive do
     get(type, directive, flags, modifiers, width)
   end
 
-  # Years
-  def get(:year4, directive, flags, mods, width),
-    do: %Directive{type: :year4, value: directive, flags: flags, modifiers: mods, width: width, parser: Parsers.year4(flags)}
-  def get(:year2, directive, flags, mods, width),
-    do: %Directive{type: :year2, value: directive, flags: flags, modifiers: mods, width: width, parser: Parsers.year2(flags)}
-  def get(:century, directive, flags, mods, width),
-    do: %Directive{type: :century, value: directive, flags: flags, modifiers: mods, width: width, parser: Parsers.century(flags)}
-  def get(:iso_year4, directive, flags, mods, width),
-    do: %Directive{type: :iso_year4, value: directive, flags: flags, modifiers: mods, width: width, parser: Parsers.year4(flags)}
-  def get(:iso_year2, directive, flags, mods, width),
-    do: %Directive{type: :iso_year2, value: directive, flags: flags, modifiers: mods, width: width, parser: Parsers.year2(flags)}
-  # Months
-  def get(:month, directive, flags, mods, width),
-    do: %Directive{type: :month, value: directive, flags: flags, modifiers: mods, width: width, parser: Parsers.month2(flags)}
-  def get(:mshort, directive, flags, mods, width),
-    do: %Directive{type: :mshort, value: directive, flags: flags, modifiers: mods, width: width, parser: Parsers.month_short(flags)}
-  def get(:mfull, directive, flags, mods, width),
-    do: %Directive{type: :mfull, value: directive, flags: flags, modifiers: mods, width: width, parser: Parsers.month_full(flags)}
-  # Days
-  def get(:day, directive, flags, mods, width),
-    do: %Directive{type: :day, value: directive, flags: flags, modifiers: mods, width: width, parser: Parsers.day_of_month(flags)}
-  def get(:oday, directive, flags, mods, width),
-    do: %Directive{type: :oday, value: directive, flags: flags, modifiers: mods, width: width, parser: Parsers.day_of_year(flags)}
-  # Weeks
-  def get(:iso_weeknum, directive, flags, mods, width),
-    do: %Directive{type: :iso_weeknum, value: directive, flags: flags, modifiers: mods, width: width, parser: Parsers.week_of_year(flags)}
-  def get(:week_mon, directive, flags, mods, width),
-    do: %Directive{type: :week_mon, value: directive, flags: flags, modifiers: mods, width: width, parser: Parsers.week_of_year(flags)}
-  def get(:week_sun, directive, flags, mods, width),
-    do: %Directive{type: :week_sun, value: directive, flags: flags, modifiers: mods, width: width, parser: Parsers.week_of_year(flags)}
-  def get(:wday_mon, directive, flags, mods, width),
-    do: %Directive{type: :wday_mon, value: directive, flags: flags, modifiers: mods, width: width, parser: Parsers.weekday(flags)}
-  def get(:wday_sun, directive, flags, mods, width),
-    do: %Directive{type: :wday_sun, value: directive, flags: flags, modifiers: mods, width: width, parser: Parsers.weekday(flags)}
-  def get(:wdshort, directive, flags, mods, width),
-    do: %Directive{type: :wdshort, value: directive, flags: flags, modifiers: mods, width: width, parser: Parsers.weekday_short(flags)}
-  def get(:wdfull, directive, flags, mods, width),
-    do: %Directive{type: :wdfull, value: directive, flags: flags, modifiers: mods, width: width, parser: Parsers.weekday_full(flags)}
-  # Hours
-  def get(:hour24, directive, flags, mods, width),
-    do: %Directive{type: :hour24, value: directive, flags: flags, modifiers: mods, width: width, parser: Parsers.hour24(flags)}
-  def get(:hour12, directive, flags, mods, width),
-    do: %Directive{type: :hour12, value: directive, flags: flags, modifiers: mods, width: width, parser: Parsers.hour12(flags)}
-  def get(:min, directive, flags, mods, width),
-    do: %Directive{type: :min, value: directive, flags: flags, modifiers: mods, width: width, parser: Parsers.minute(flags)}
-  def get(:sec, directive, flags, mods, width),
-    do: %Directive{type: :sec, value: directive, flags: flags, modifiers: mods, width: width, parser: Parsers.second(flags)}
-  def get(:sec_fractional, directive, flags, mods, width),
-    do: %Directive{type: :sec_fractional, value: directive, flags: flags, modifiers: mods, width: width, parser: Parsers.second_fractional(flags)}
-  def get(:sec_epoch, directive, flags, mods, width),
-    do: %Directive{type: :sec_epoch, value: directive, flags: flags, modifiers: mods, width: width, parser: Parsers.seconds_epoch(flags)}
-  def get(:us, directive, flags, mods, width),
-    do: %Directive{type: :us, value: directive, flags: flags, modifiers: mods, width: width, parser: Parsers.microseconds(flags)}
-  def get(:am, directive, flags, mods, width),
-    do: %Directive{type: :am, value: directive, flags: flags, modifiers: mods, width: width, parser: Parsers.ampm(flags)}
-  def get(:AM, directive, flags, mods, width),
-    do: %Directive{type: :AM, value: directive, flags: flags, modifiers: mods, width: width, parser: Parsers.ampm(flags)}
-  # Timezones
-  def get(:zname, directive, flags, mods, width),
-    do: %Directive{type: :zname, value: directive, flags: flags, modifiers: mods, width: width, parser: Parsers.zname(flags)}
-  def get(:zabbr, directive, flags, mods, width),
-    do: %Directive{type: :zabbr, value: directive, flags: flags, modifiers: mods, width: width, parser: Parsers.zname(flags)}
-  def get(:zoffs, directive, flags, mods, width),
-    do: %Directive{type: :zoffs, value: directive, flags: flags, modifiers: mods, width: width, parser: Parsers.zoffs(flags)}
-  def get(:zoffs_colon, directive, flags, mods, width),
-    do: %Directive{type: :zoffs_colon, value: directive, flags: flags, modifiers: mods, width: width, parser: Parsers.zoffs_colon(flags)}
-  def get(:zoffs_sec, directive, flags, mods, width),
-    do: %Directive{type: :zoffs_sec, value: directive, flags: flags, modifiers: mods, width: width, parser: Parsers.zoffs_sec(flags)}
-  # Preformatted Directives
-  def get(:iso_8601, directive, flags, mods, width),
-    do: %Directive{type: :iso_8601, value: directive, flags: flags, modifiers: mods, width: width, parser: Parsers.iso8601(flags)}
-  def get(:iso_8601z, directive, flags, mods, width),
-    do: %Directive{type: :iso_8601z, value: directive, flags: flags, modifiers: mods, width: width, parser: Parsers.iso8601([{:zulu, true}|flags])}
-  def get(:iso_8601_extended, directive, flags, mods, width),
-    do: %Directive{type: :iso_8601_extended, value: directive, flags: flags, modifiers: mods, width: width, parser: Parsers.iso8601_extended(flags)}
-  def get(:iso_8601_extended_z, directive, flags, mods, width),
-    do: %Directive{type: :iso_8601_extended_z, value: directive, flags: flags, modifiers: mods, width: width, parser: Parsers.iso8601_extended([{:zulu, true}|flags])}
-  def get(:iso_8601_basic, directive, flags, mods, width),
-    do: %Directive{type: :iso_8601_basic, value: directive, flags: flags, modifiers: mods, width: width, parser: Parsers.iso8601_basic(flags)}
-  def get(:iso_8601_basic_z, directive, flags, mods, width),
-    do: %Directive{type: :iso_8601_basic_z, value: directive, flags: flags, modifiers: mods, width: width, parser: Parsers.iso8601_basic([{:zulu, true}|flags])}
-  def get(:iso_date, directive, flags, mods, width),
-    do: %Directive{type: :iso_date, value: directive, flags: flags, modifiers: mods, width: width, parser: Parsers.iso_date(flags)}
-  def get(:iso_time, directive, flags, mods, width),
-    do: %Directive{type: :iso_time, value: directive, flags: flags, modifiers: mods, width: width, parser: Parsers.iso_time(flags)}
-  def get(:iso_week, directive, flags, mods, width),
-    do: %Directive{type: :iso_week, value: directive, flags: flags, modifiers: mods, width: width, parser: Parsers.iso_week(flags)}
-  def get(:iso_weekday, directive, flags, mods, width),
-    do: %Directive{type: :iso_weekday, value: directive, flags: flags, modifiers: mods, width: width, parser: Parsers.iso_weekday(flags)}
-  def get(:iso_ordinal, directive, flags, mods, width),
-    do: %Directive{type: :iso_ordinal, value: directive, flags: flags, modifiers: mods, width: width, parser: Parsers.iso_ordinal(flags)}
-  def get(:rfc_822, directive, flags, mods, width),
-    do: %Directive{type: :rfc_822, value: directive, flags: flags, modifiers: mods, width: width, parser: Parsers.rfc822(flags)}
-  def get(:rfc_822z, directive, flags, mods, width),
-    do: %Directive{type: :rfc_822z, value: directive, flags: flags, modifiers: mods, width: width, parser: Parsers.rfc822([{:zulu, true}|flags])}
-  def get(:rfc_1123, directive, flags, mods, width),
-    do: %Directive{type: :rfc_1123, value: directive, flags: flags, modifiers: mods, width: width, parser: Parsers.rfc1123(flags)}
-  def get(:rfc_1123z, directive, flags, mods, width),
-    do: %Directive{type: :rfc_1123z, value: directive, flags: flags, modifiers: mods, width: width, parser: Parsers.rfc1123([{:zulu, true}|flags])}
-  def get(:rfc_3339, directive, flags, mods, width),
-    do: %Directive{type: :rfc_3339, value: directive, flags: flags, modifiers: mods, width: width, parser: Parsers.rfc3339(flags)}
-  def get(:rfc_3339z, directive, flags, mods, width),
-    do: %Directive{type: :rfc_3339z, value: directive, flags: flags, modifiers: mods, width: width, parser: Parsers.rfc3339([{:zulu, true}|flags])}
-  def get(:ansic, directive, flags, mods, width),
-    do: %Directive{type: :ansic, value: directive, flags: flags, modifiers: mods, width: width, parser: Parsers.ansic(flags)}
-  def get(:unix, directive, flags, mods, width),
-    do: %Directive{type: :unix, value: directive, flags: flags, modifiers: mods, width: width, parser: Parsers.unix(flags)}
-  def get(:kitchen, directive, flags, mods, width),
-    do: %Directive{type: :kitchen, value: directive, flags: flags, modifiers: mods, width: width, parser: Parsers.kitchen(flags)}
-  def get(:asn1_utc_time, directive, flags, mods, width),
-    do: %Directive{type: :asn1_utc_time, value: directive, flags: flags, modifiers: mods, width: width, parser: Parsers.asn1_utc_time(flags)}
-  def get(:asn1_generalized_time, directive, flags, mods, width),
-    do: %Directive{type: :asn1_generalized_time, value: directive, flags: flags, modifiers: mods, width: width, parser: Parsers.asn1_generalized_time(flags)}
-  def get(:asn1_generalized_time_z, directive, flags, mods, width),
-    do: %Directive{type: :asn1_generalized_time_z, value: directive, flags: flags, modifiers: mods, width: width, parser: Parsers.asn1_generalized_time([{:zulu, true}|flags])}
+  @simple_types [:year4, :year2, :century, :hour24, :hour12,
+    :zname, :zoffs, :zoffs_colon, :zoffs_sec,
+    :iso_date, :iso_time, :iso_week, :iso_weekday, :iso_ordinal,
+    :ansic, :unix, :kitchen, :slashed, :asn1_utc_time, :asn1_generalized_time,
+    :strftime_iso_clock, :strftime_iso_clock_full, :strftime_kitchen, :strftime_iso_shortdate,
+  ]
+  @mapped_types [iso_year4: :year4, iso_year2: :year2,
+    month: :month2, mshort: :month_short, mfull: :month_full,
+    day: :day_of_month, oday: :day_of_year,
+    iso_weeknum: :week_of_year, week_mon: :week_of_year, week_sun: :week_of_year,
+    wday_mon: :weekday, wday_sun: :weekday, wdshort: :weekday_short, wdfull: :weekday_full,
+    min: :minute, sec: :second, sec_fractional: :second_fractional, sec_epoch: :seconds_epoch,
+    us: :microseconds, am: :ampm, AM: :ampm, zabbr: :zname,
+    iso_8601: :iso8601, iso_8601_extended: :iso8601_extended, iso_8601_basic: :iso8601_basic,
+    rfc_822: :rfc822, rfc_1123: :rfc1123, rfc_3339: :rfc3339,
+    strftime_iso_date: :iso_date,
+  ]
+  @mapped_zulu_types [
+    iso_8601z: :iso8601, iso_8601_extended_z: :iso8601_extended, iso_8601_basic_z: :iso8601_basic,
+    rfc_822z: :rfc822, rfc_1123z: :rfc1123, rfc_3339z: :rfc3339, asn1_generalized_time_z: :asn1_generalized_time
+  ]
+  for type <- @simple_types do
+    def get(unquote(type), directive, flags, mods, width),
+      do: %Directive{type: unquote(type), value: directive, flags: flags, modifiers: mods, width: width, parser: apply(Parsers, unquote(type), [flags])}
+  end
+  for {type, parser_fun} <- @mapped_types do
+    def get(unquote(type), directive, flags, mods, width),
+      do: %Directive{type: unquote(type), value: directive, flags: flags, modifiers: mods, width: width, parser: apply(Parsers, unquote(parser_fun), [flags])}
+  end
+  for {type, parser_fun} <- @mapped_zulu_types do
+    def get(unquote(type), directive, flags, mods, width),
+      do: %Directive{type: unquote(type), value: directive, flags: flags, modifiers: mods, width: width, parser: apply(Parsers, unquote(parser_fun), [[{:zulu, true}|flags]])}
+  end
   def get(:asn1_generalized_time_tz, directive, flags, mods, width),
     do: %Directive{type: :asn1_generalized_time_tz, value: directive, flags: flags, modifiers: mods, width: width, parser: Parsers.asn1_generalized_time([{:zoffs, true}|flags])}
-  def get(:slashed, directive, flags, mods, width),
-    do: %Directive{type: :slashed, value: directive, flags: flags, modifiers: mods, width: width, parser: Parsers.slashed(flags)}
-  def get(:strftime_iso_date, directive, flags, mods, width),
-    do: %Directive{type: :strftime_iso_date, value: directive, flags: flags, modifiers: mods, width: width, parser: Parsers.iso_date(flags)}
-  def get(:strftime_iso_clock, directive, flags, mods, width),
-    do: %Directive{type: :strftime_iso_clock, value: directive, flags: flags, modifiers: mods, width: width, parser: Parsers.strftime_iso_clock(flags)}
-  def get(:strftime_iso_clock_full, directive, flags, mods, width),
-    do: %Directive{type: :strftime_iso_clock_full, value: directive, flags: flags, modifiers: mods, width: width, parser: Parsers.strftime_iso_clock_full(flags)}
-  def get(:strftime_kitchen, directive, flags, mods, width),
-    do: %Directive{type: :strftime_kitchen, value: directive, flags: flags, modifiers: mods, width: width, parser: Parsers.strftime_kitchen(flags)}
-  def get(:strftime_iso_shortdate, directive, flags, mods, width),
-    do: %Directive{type: :strftime_iso_shortdate, value: directive, flags: flags, modifiers: mods, width: width, parser: Parsers.strftime_iso_shortdate(flags)}
   # Catch-all
   def get(type, _directive, _flags, _mods, _width), do: {:error, "Unrecognized directive type: #{type}."}
 end


### PR DESCRIPTION
### Summary of changes

I'll review the commits, so I mostly want to understand the "why" rather than the "what"

### Checklist

- [x] New functions have typespecs, changed functions were updated
- [x] Same for documentation, including moduledocs
- [x] Tests were added or updated to cover changes
- [x] Commits were squashed into a single coherent commit

Prior to this commit the directive were extremely repetitive without a
great deal of value and, in some cases, hiding the relationship between
the Directive type and the related Parser function. This commit distills
the directives into 3 basic cases:
* Directive type == Parser function
* Directive type != Parser function
* Directive type != Parser function, add zulu flag

Although none currently exist, if we encounter a case that does not fit
any of these 3 scenarios, then we can add it as a special case.

@bitwalker, if you feel like this doesn't make it easier to read or maintain, feel free to close/wont-merge. This made it easier for _me_ to reason about it, but I'm not sure it's a universal improvement.