### PR TITLE
add support for partial-hour offset timezones

### DIFF
--- a/lib/format/datetime/formatter.ex
+++ b/lib/format/datetime/formatter.ex
@@ -551,11 +551,11 @@ defmodule Timex.Format.DateTime.Formatter do
         {:error, {:formatter, "Invalid directive flag: Timezone offsets require 0-padding to remain unambiguous."}}
       _ ->
         offset_hours = div(Timezone.total_offset(tz), 60)
-        offset_mins  = rem(Timezone.total_offset(tz), 60)
+        offset_mins  = abs(rem(Timezone.total_offset(tz), 60))
         hour  = "#{pad_numeric(offset_hours, [padding: :zeroes], width_spec(2..2))}"
         min   = "#{pad_numeric(offset_mins, [padding: :zeroes], width_spec(2..2))}"
         cond do
-          (offset_hours + offset_mins) >= 0 -> "+#{hour}#{min}"
+          offset_hours >= 0 -> "+#{hour}#{min}"
           true -> "#{hour}#{min}"
         end
     end

--- a/lib/parse/datetime/parser.ex
+++ b/lib/parse/datetime/parser.ex
@@ -247,12 +247,12 @@ defmodule Timex.Parse.DateTime.Parser do
         %{date | :timezone => Timezone.get(value, zone_date)}
       tz when tz in [:zoffs_colon, :zoffs_sec] ->
         case value do
-          <<?-, h1::utf8, h2::utf8, _::binary>> ->
+          <<?-, h1::utf8, h2::utf8, m1::utf8, m2::utf8, _::binary>> ->
             zone_date = Timex.to_erlang_datetime(date)
-            %{date | :timezone => Timezone.get(<<?-, h1::utf8, h2::utf8>>, zone_date)}
-          <<?+, h1::utf8, h2::utf8, _::binary>> ->
+            %{date | :timezone => Timezone.get(<<?-, h1::utf8, h2::utf8, m1::utf8, m2::utf8>>, zone_date)}
+          <<?+, h1::utf8, h2::utf8, m1::utf8, m2::utf8, _::binary>> ->
             zone_date = Timex.to_erlang_datetime(date)
-            %{date | :timezone => Timezone.get(<<?+, h1::utf8, h2::utf8>>, zone_date)}
+            %{date | :timezone => Timezone.get(<<?+, h1::utf8, h2::utf8, m1::utf8, m2::utf8>>, zone_date)}
           _ ->
             {:error, "#{token} not implemented"}
         end

--- a/lib/timezone/timezone.ex
+++ b/lib/timezone/timezone.ex
@@ -77,6 +77,19 @@ defmodule Timex.Timezone do
   def name_of("Y"),    do: name_of(-12)
   def name_of("Z"),    do: "UTC"
   def name_of("UT"),   do: "UTC"
+  def name_of("+0330"), do: "Asia/Tehran"
+  def name_of("+0430"), do: "Asia/Kabul"
+  def name_of("+0530"), do: "Asia/Colombo"
+  def name_of("+0545"), do: "Asia/Kathmandu"
+  def name_of("+0630"), do: "Asia/Rangoon"
+  def name_of("+0830"), do: "Asia/Pyongyang"
+  def name_of("+0845"), do: "Australia/Eucla"
+  def name_of("+0930"), do: "Australia/Darwin"
+  def name_of("+1245"), do: "Pacific/Chatham"
+  def name_of("+1345"), do: "Pacific/Chatham"
+  def name_of("-0430"), do: "America/Caracas"
+  def name_of("-0330"), do: "America/St_Johns"
+  def name_of("-0230"), do: "America/St_Johns"
   def name_of(offset) when is_integer(offset) do
     if offset > 0 do
       "Etc/GMT-#{offset}"

--- a/test/timezone_test.exs
+++ b/test/timezone_test.exs
@@ -127,4 +127,25 @@ defmodule TimezoneTests do
 
     assert 63645015540 = DateTime.to_seconds(Timex.datetime(datetime, "Europe/Vienna"), :zero, [utc: true])
   end
+
+  test "name_of" do
+    assert {:error, {:invalid_timezone, :wat}} = Timezone.name_of(:wat)
+    assert {:error, {:invalid_timezone, "America/Not_A_Real_Timezone"}} = Timezone.name_of("America/Not_A_Real_Timezone")
+    assert "America/Los_Angeles" = Timezone.name_of("America/Los_Angeles")
+    assert "Etc/GMT+0500" = Timezone.name_of("GMT+0500")
+    assert "Etc/GMT-0500" = Timezone.name_of("GMT-0500")
+  end
+
+  test "partial-hour offset timezones" do
+    zones = [
+      "Asia/Kathmandu", "Asia/Colombo", "Asia/Kabul", "Asia/Rangoon", "Asia/Pyongyang",
+      "Australia/Eucla", "Australia/Darwin",
+      "Pacific/Chatham",
+      "America/Caracas", "America/St_Johns",
+    ]
+    for tz <- zones do
+      date = Timex.DateTime.now(tz)
+      assert(date == date |> Timex.format!("{RFC3339}") |> Timex.parse!("{RFC3339}"), tz)
+    end
+  end
 end


### PR DESCRIPTION
### Summary of changes

I'll review the commits, so I mostly want to understand the "why" rather than the "what"

### Checklist

- [x] New functions have typespecs, changed functions were updated
- [x] Same for documentation, including moduledocs
- [x] Tests were added or updated to cover changes
- [x] Commits were squashed into a single coherent commit

Prior to this commit Timex would produce a blantantly incorrect value
for parsing a timestamp with a partial-hour offset timezone, such as
that of Nepal (+05:45). The resulting timestamp would have the correct
wall time, but a truncated timezone (+05:00), which would result in
incorrect timestamps in UTC. This commit adds support for partial-hour
offset timezones by calling them out as special cases when attempting to
execute `Timex.Timezone.name_of`, which eventually gets invoked by
`Timex.parse`.