### PR TITLE
Move :combine to applications

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -15,8 +15,7 @@ defmodule Timex.Mixfile do
   end
 
   def application do
-    [applications: [:logger, :tzdata, :gettext],
-     included_applications: [:combine],
+    [applications: [:logger, :tzdata, :gettext, :combine],
      env: [local_timezone: nil, default_locale: "en"]]
   end
 


### PR DESCRIPTION
Included application means that an application is started as part of
the supervision tree of the application including it, and can't be
used as dependency of any other application in the system.

The use of included application for :combine was obviously wrong,
because :timex is a library application and has no supervision tree.
Similarly :combine is a library application as well, and can't be
included in any supervision tree.

Instead it should be added to the :applications to express the
runtime dependency, which was probably the intention of adding it
to the :included_applications in the first place.