### PR TITLE
diff of 7 days should == diff of 1 week

### DIFF
--- a/lib/comparable/datetime.ex
+++ b/lib/comparable/datetime.ex
@@ -122,7 +122,7 @@ defimpl Timex.Comparable, for: Timex.DateTime do
     extra_days = rem(days, 7)
     actual_weeks = (if extra_days == 0, do: weeks, else: weeks + 1)
     cond do
-      actual_weeks == 1 && extra_days < 7 -> 0
+      actual_weeks == 1 && days < 7 -> 0
       :else -> actual_weeks
     end
   end

--- a/test/timex_test.exs
+++ b/test/timex_test.exs
@@ -239,6 +239,13 @@ defmodule TimexTests do
     date2 = Timex.datetime({1969,2,11})
     assert Timex.diff(date1, date2, :months) === 25
     assert Timex.diff(date2, date1, :months) === 25
+
+    date7 = Timex.date({2016, 3, 27})
+    date8 = Timex.date({2016, 4, 3})
+    assert Timex.diff(date7, date8, :days) == 7
+    assert Timex.diff(date8, date7, :days) == 7
+    assert Timex.diff(date7, date8, :weeks) == 1
+    assert Timex.diff(date8, date7, :weeks) == 1
   end
 
   test "timestamp diff same datetime" do


### PR DESCRIPTION
### Summary of changes

I think when Timex.diff(a, b, :days) == 7
Timex.diff(a, b, :weeks) should == 1
currently Timex.diff(a, b, :weeks) == 0 when Timex(a, b, :days) == 7

### Checklist

- [ ] New functions have typespecs, changed functions were updated
- [ ] Same for documentation, including moduledocs
- [x] Tests were added or updated to cover changes
- [ ] Commits were squashed into a single coherent commit

d1 = Timex.date {2016, 3,28}; d2 = Timex.date {2016, 4,4}
Timex.diff d1, d2, :days # => 7
Timex.diff d1, d2, :weeks # => 1