### PR TITLE
add docs and more explicit tests for fractional seconds

### DIFF
--- a/lib/format/datetime/formatters/default.ex
+++ b/lib/format/datetime/formatters/default.ex
@@ -56,6 +56,7 @@ defmodule Timex.Format.DateTime.Formatters.Default do
   * `{h12}`     - hour of the day (1..12)
   * `{m}`       - minutes of the hour (00..59)
   * `{s}`       - seconds of the minute (00..60)
+  * `{ss}`      - seconds of the minute, fractional (00.xxx..60.xxx) (xxx is milliseconds)
   * `{s-epoch}` - number of seconds since UNIX epoch
   * `{am}`      - lowercase am or pm (no padding)
   * `{AM}`      - uppercase AM or PM (no padding)

--- a/test/format_default_test.exs
+++ b/test/format_default_test.exs
@@ -440,6 +440,11 @@ defmodule DateFormatTest.FormatDefault do
     assert unexpected_end_err == format(date, "abc } def")
   end
 
+  test "milliseconds as fractional seconds via {ss}" do
+    date = Timex.datetime({{2015,11,9}, {8,37,48,655}})
+    assert { :ok, "2015-11-09T08:37:48.655" } = format(date, "{YYYY}-{0M}-{0D}T{h24}:{m}:{s}{ss}")
+  end
+
   test "issue #79 - invalid ISO 8601 string with fractional ms" do
     date = %DateTime{day: 14, hour: 12, month: 1, millisecond: 0.0, year: 2015, timezone: %TimezoneInfo{}}
     formatted = format(date, "{ISO}")

--- a/test/parse_default_test.exs
+++ b/test/parse_default_test.exs
@@ -148,6 +148,8 @@ defmodule DateFormatTest.ParseDefault do
   test "parse fractional seconds" do
     str = "2015-11-07T13:45:02.060Z"
     assert {:ok, %DateTime{second: 2, millisecond: 60}} = parse(str, "{ISOz}")
+    str = "2015-11-07T13:45:02.687"
+    assert {:ok, %DateTime{second: 2, millisecond: 687}} = parse(str, "{YYYY}-{M}-{0D}T{h24}:{m}:{ss}")
   end
 
   test "parse s-epoch" do


### PR DESCRIPTION
### Summary of changes

So I needed to parse a date like this:
"2016-04-01T10:43:47.687"

the {ss} fractional seconds seemed to be missing from the docs, so I added that, then a couple test cases to show examples explicitly in format strings.

I tried to parse also via the strftime formats, but I just couldn't get it.
The only way I could get it to work is to extend out the factional to explicit microseconds in the date string:
"2016-04-01T10:43:47.687000"
And then parse with this format:
%Y-%m-%dT%H:%M:%S.%f"

Should "2016-04-01T10:43:47.687" be directly parseable via sttftime format?

Thanks for this great library!

### Checklist

- [n/a] New functions have typespecs, changed functions were updated
- [x ] Same for documentation, including moduledocs
- [x] Tests were added or updated to cover changes
- [x] Commits were squashed into a single coherent commit

