### PR TITLE
Parser fixed to interpret 12am as midnight

### DIFF
--- a/lib/parse/datetime/parser.ex
+++ b/lib/parse/datetime/parser.ex
@@ -229,7 +229,10 @@ defmodule Timex.Parse.DateTime.Parser do
         {converted, hemisphere} = Time.to_12hour_clock(hh)
         case value do
           am when am in ["am", "AM"]->
-            %{date | :hour => converted}
+            cond do
+              converted == 12 -> %{date | :hour => 0}
+              :else -> %{date | :hour => converted}
+            end
           pm when pm in ["pm", "PM"] and hemisphere == :am ->
             cond do
               converted + 12 == 24 -> %{date | :hour => 0}

--- a/test/parse_default_test.exs
+++ b/test/parse_default_test.exs
@@ -129,7 +129,8 @@ defmodule DateFormatTest.ParseDefault do
     date_midnight = Timex.datetime({0,1,1})
     date_noon     = Timex.set(date_midnight, hour: 12)
 
-    assert { :ok, ^date_noon } = parse("am 12", "{am} {h12}")
+    assert { :ok, ^date_noon } = parse("pm 12", "{am} {h12}")
+    assert { :ok, ^date_midnight } = parse("12 am", "{h12} {am}")
     assert { :ok, ^date_midnight } = parse("PM 00", "{AM} {0h24}")
     date = Timex.datetime({{0,1,1}, {16,0,0}})
     assert { :ok, ^date } = parse("4 pm", "{h12} {am}")


### PR DESCRIPTION
This pull request fixes incorrect parsing of am time - 12:01 AM should parse as 00:01 (see http://www.timeanddate.com/time/am-and-pm.html )

Example (before fix): 
```
Timex.Parse.DateTime.Parser.parse!("Apr 6, 2016 12:17:35 am", "{Mshort} {D}, {YYYY} {h12}:{m}:{s} {AM}")
#<DateTime(2016-04-06T12:17:35Z)>
```
Example (after fix): 
```
Timex.Parse.DateTime.Parser.parse!("Apr 6, 2016 12:17:35 am", "{Mshort} {D}, {YYYY} {h12}:{m}:{s} {AM}")
#<DateTime(2016-04-06T00:17:35Z)>
```