### PR TITLE
Fixes shifting by milliseconds

### DIFF
--- a/lib/datetime/datetime.ex
+++ b/lib/datetime/datetime.ex
@@ -809,6 +809,19 @@ defmodule Timex.DateTime do
         resolve_timezone_info(shifted)
     end
   end
+  defp shift_by(%DateTime{} = datetime, value, :milliseconds) do
+    millisecs_from_zero = :calendar.datetime_to_gregorian_seconds({
+      {datetime.year,datetime.month,datetime.day},
+      {datetime.hour,datetime.minute,datetime.second}
+    }) * 1_000 + value
+
+    secs_from_zero = div(millisecs_from_zero, 1_000)
+    ms = rem(millisecs_from_zero, 1_000)
+
+    {{y,m,d}=date,{h,mm,s}} = :calendar.gregorian_seconds_to_datetime(secs_from_zero)
+    Timezone.resolve(datetime.timezone.full_name, {date, {h,mm,s,ms}})
+    |> Map.merge(%{millisecond: ms})
+  end
   defp shift_by(%DateTime{millisecond: ms} = datetime, value, units) do
     secs_from_zero = :calendar.datetime_to_gregorian_seconds({
       {datetime.year,datetime.month,datetime.day},

--- a/test/datetime_test.exs
+++ b/test/datetime_test.exs
@@ -195,6 +195,30 @@ defmodule DateTimeTests do
     assert DateTime.to_days(DateTime.epoch(), :zero) === 719528
   end
 
+  test "shift by milliseconds" do
+    date = {2013,3,5}
+    time = {23,23,23}
+    datetime = {date,time}
+
+    unchanged = datetime |> Timex.datetime
+    assert unchanged === shift(datetime, milliseconds: 0)
+
+    assert %DateTime{minute: 23, second: 23, millisecond: 1} = shift(datetime, milliseconds: 1)
+    assert %DateTime{minute: 23, second: 23, millisecond: 36} = shift(datetime, milliseconds: 36)
+    assert %DateTime{minute: 23, second: 24, millisecond: 0} = shift(datetime, milliseconds: 1000)
+    assert %DateTime{minute: 24, second: 24, millisecond: 38} = shift(datetime, milliseconds: 61038)
+    assert %DateTime{minute: 25, second: 1, millisecond: 45} = shift(datetime, milliseconds: (38+60)*1000+45)
+    assert %DateTime{minute: 59, second: 1, millisecond: 58} = shift(datetime, milliseconds: (38+60*35)*1000+58)
+    assert %DateTime{month: 3, day: 6, hour: 23, minute: 23, second: 23, millisecond: 20} = shift(datetime, milliseconds: 24*3600000 + 20)
+    assert %DateTime{month: 3, day: 5, hour: 23, minute: 23, second: 23, millisecond: 34} = shift(datetime, milliseconds: 24*3600000*365 + 34)
+
+    assert %DateTime{minute: 23, second: 22, millisecond: 999} = shift(datetime, milliseconds: -1)
+    assert %DateTime{minute: 23, second: 22, millisecond: 977} = shift(datetime, milliseconds: -23)
+    assert %DateTime{minute: 22, second: 58, millisecond: 0} = shift(datetime, seconds: -24, milliseconds: -1000)
+    assert %DateTime{minute: 23, second: 00, millisecond: 0} = shift(datetime, seconds: -24, milliseconds: 1000)
+    assert %DateTime{year: 2011, month: 3, day: 5, hour: 23, minute: 23, second: 23, millisecond: 0} = shift(datetime, milliseconds: -24*3600*(365*2+1)*1000)   # +1 day for leap year 2012
+  end
+
   test "shift by seconds" do
     date = {2013,3,5}
     time = {23,23,23}


### PR DESCRIPTION
### Summary of changes

Shifting date time by more than 1000 milliseconds is wrong - milliseconds are not incremented at all:

``` Elixir
%Timex.DateTime{calendar: :gregorian, day: 16, hour: 18, millisecond: 95,
 minute: 29, month: 4, second: 55,
 timezone: %Timex.TimezoneInfo{abbreviation: "UTC", from: :min,
  full_name: "UTC", offset_std: 0, offset_utc: 0, until: :max}, year: 2016}
|> Timex.shift(milliseconds: 1900) = %Timex.DateTime{calendar: :gregorian, day: 16, hour: 18, millisecond: 95,
 minute: 29, month: 4, second: 56,
 timezone: %Timex.TimezoneInfo{abbreviation: "UTC", from: :min,
  full_name: "UTC", offset_std: 0, offset_utc: 0, until: :max}, year: 2016}
```

This commit fixes this.

### Checklist

- [x] New functions have typespecs, changed functions were updated
- [x] Same for documentation, including moduledocs
- [x] Tests were added or updated to cover changes
- [x] Commits were squashed into a single coherent commit