### PR TITLE
BUGFIX: shifting months to the end of a year would have resulted in a…

### DIFF
--- a/lib/datetime/datetime.ex
+++ b/lib/datetime/datetime.ex
@@ -792,6 +792,12 @@ defmodule Timex.DateTime do
       m < 0  -> %{datetime | :year => year + div(m, 12), :month => 12 + rem(m, 12)}
       :else  -> %{datetime | :month => m}
     end
+
+    # setting months to remainders may result in month = 0
+    if shifted.month == 0 do
+      shifted = %{ shifted | :year => shifted.year - 1, :month => 12 }
+    end
+
     # If the shift fails, it's because it's a high day number, and the month
     # shifted to does not have that many days. This will be handled by always
     # shifting to the last day of the month shifted to.

--- a/lib/datetime/datetime.ex
+++ b/lib/datetime/datetime.ex
@@ -793,9 +793,10 @@ defmodule Timex.DateTime do
       :else  -> %{datetime | :month => m}
     end
 
-    # setting months to remainders may result in month = 0
-    if shifted.month == 0 do
-      shifted = %{ shifted | :year => shifted.year - 1, :month => 12 }
+    # setting months to remainders may result in invalid :month => 0
+    shifted = case shifted.month do
+      0 -> %{ shifted | :year => shifted.year - 1, :month => 12 }
+      _ -> shifted
     end
 
     # If the shift fails, it's because it's a high day number, and the month

--- a/test/datetime_test.exs
+++ b/test/datetime_test.exs
@@ -407,4 +407,10 @@ defmodule DateTimeTests do
     date |> Timex.datetime |> Timex.shift(spec)
   end
 
+  test "shifting to end of year" do
+    assert Timex.date({2016,4,25}) |> Timex.shift( months: 19 ) == Timex.date({2017, 11, 25})
+    assert Timex.date({2016,4,25}) |> Timex.shift( months: 20 ) == Timex.date({2017, 12, 25})
+    assert Timex.date({2016,4,25}) |> Timex.shift( months: 21 ) == Timex.date({2018,  1, 25})
+  end
+
 end


### PR DESCRIPTION
### Summary of changes

This PR addresses issue 158 submitted by @mindreframer 

## Issue description

- when shifting dates by months and months > 12; month was set to rem( months, 12) 
  - which could result in setting month to zero which leads to dates like {2018,0,25} 
  - that dates consequently fail when used in other functions

## Bugfix description
- added a simple check for this and setting month to 12 and decrement year by 1 in this case
- added small test that addresses the bug