### PR TITLE
add millisecond parsing to strftime parser using %L

### DIFF
--- a/lib/parse/datetime/parser.ex
+++ b/lib/parse/datetime/parser.ex
@@ -224,6 +224,7 @@ defmodule Timex.Parse.DateTime.Parser do
           n when is_number(n) -> %{date | :millisecond => n}
         end
       :us -> %{date | :millisecond => div(value, 1000)}
+      :ms -> %{date | :millisecond => value}
       :sec_epoch -> DateTime.from_seconds(value, :epoch)
       am_pm when am_pm in [:am, :AM] ->
         {converted, hemisphere} = Time.to_12hour_clock(hh)

--- a/lib/parse/datetime/parsers.ex
+++ b/lib/parse/datetime/parsers.ex
@@ -150,6 +150,9 @@ defmodule Timex.Parse.DateTime.Parsers do
   def microseconds(_) do
     label(map(integer, fn us -> [us: us] end), "microseconds")
   end
+  def milliseconds(_) do
+    label(map(integer, fn ms -> [ms: ms] end), "milliseconds")
+  end
 
   def zname(_) do
     word_of(~r/[\/\w_]/)

--- a/lib/parse/datetime/tokenizers/directive.ex
+++ b/lib/parse/datetime/tokenizers/directive.ex
@@ -45,7 +45,7 @@ defmodule Timex.Parse.DateTime.Tokenizers.Directive do
     iso_weeknum: :week_of_year, week_mon: :week_of_year, week_sun: :week_of_year,
     wday_mon: :weekday, wday_sun: :weekday, wdshort: :weekday_short, wdfull: :weekday_full,
     min: :minute, sec: :second, sec_fractional: :second_fractional, sec_epoch: :seconds_epoch,
-    us: :microseconds, am: :ampm, AM: :ampm, zabbr: :zname,
+    us: :microseconds, ms: :milliseconds, am: :ampm, AM: :ampm, zabbr: :zname,
     iso_8601: :iso8601, iso_8601_extended: :iso8601_extended, iso_8601_basic: :iso8601_basic,
     rfc_822: :rfc822, rfc_1123: :rfc1123, rfc_3339: :rfc3339,
     strftime_iso_date: :iso_date,

--- a/lib/parse/datetime/tokenizers/strftime.ex
+++ b/lib/parse/datetime/tokenizers/strftime.ex
@@ -45,7 +45,7 @@ defmodule Timex.Parse.DateTime.Tokenizers.Strftime do
         # Weeks
         "V", "W", "U",
         # Time
-        "H", "k", "I", "l", "M", "S", "s", "P", "p", "f",
+        "H", "k", "I", "l", "M", "S", "s", "P", "p", "f", "L",
         # Timezones
         "Z", "z",
         # Compound
@@ -107,6 +107,7 @@ defmodule Timex.Parse.DateTime.Tokenizers.Strftime do
       "P" -> Directive.get(:am, directive, opts)
       "p" -> Directive.get(:AM, directive, opts)
       "f" -> force_width(3, :us, directive, opts)
+      "L" -> force_width(3, :ms, directive, opts)
       # Timezones
       "Z"   -> Directive.get(:zname, directive, opts)
       "z"   -> Directive.get(:zoffs, directive, opts)

--- a/test/parse_strftime_test.exs
+++ b/test/parse_strftime_test.exs
@@ -20,6 +20,11 @@ defmodule DateFormatTest.ParseStrftime do
     assert {:ok, ^date} = parse("20150713 14:01:21.053021", "%Y%m%d %H:%M:%S.%f")
   end
 
+  test "parse format with milliseconds" do
+    date = Timex.datetime({{2015,7,13}, {14,1,21,38}})
+    assert {:ok, ^date} = parse("20150713 14:01:21.038", "%Y%m%d %H:%M:%S.%L")
+  end
+
   defp parse(date, fmt) do
     Timex.parse(date, fmt, :strftime)
   end


### PR DESCRIPTION
### Summary of changes

I added a new format specifier %L to the strftime parser, to parse milliseconds from a 3 digit number, for example "2015-05-02 15:11:02.023" with "%Y-%m-%d %H:%M:%S.%L".  I added a milliseconds function to lib/parse/datetime/parsers.ex, the other changes were adding additional cases in the existing functions.