### PR TITLE
fix ampm parsing (12am and 13am)

### DIFF
--- a/lib/parse/datetime/parser.ex
+++ b/lib/parse/datetime/parser.ex
@@ -226,17 +226,15 @@ defmodule Timex.Parse.DateTime.Parser do
       :us -> %{date | :millisecond => div(value, 1000)}
       :sec_epoch -> DateTime.from_seconds(value, :epoch)
       am_pm when am_pm in [:am, :AM] ->
-        {converted, hemisphere} = Time.to_12hour_clock(hh)
-        case value do
-          am when am in ["am", "AM"]->
-            %{date | :hour => converted}
-          pm when pm in ["pm", "PM"] and hemisphere == :am ->
-            cond do
-              converted + 12 == 24 -> %{date | :hour => 0}
-              :else -> %{date | :hour => converted + 12}
-            end
-          _ ->
-            %{date | :hour => converted}
+        cond do
+          hh == 24 ->
+            %{date | :hour => 0}
+          hh == 12 and (String.downcase(value) == "am") ->
+            %{date | :hour => 0}
+          hh in (1..11) and String.downcase(value) == "pm" ->
+            %{date | :hour => hh + 12} 
+          true ->
+            date
         end
       # Timezones
       :zoffs ->

--- a/test/parse_default_test.exs
+++ b/test/parse_default_test.exs
@@ -145,6 +145,7 @@ defmodule DateFormatTest.ParseDefault do
     assert { :ok, ^date_13 }       = parse("13 am", "{h24} {am}")
     assert { :ok, ^date_13 }       = parse("13 pm", "{h24} {am}")
     assert { :ok, ^date_midnight } = parse("PM 00", "{AM} {0h24}")
+    assert { :ok, ^date_midnight } = parse("24 pm", "{0h24} {am}")
   end
 
   test "parse simple time formats" do

--- a/test/parse_default_test.exs
+++ b/test/parse_default_test.exs
@@ -128,13 +128,23 @@ defmodule DateFormatTest.ParseDefault do
   test "parse hour12 and am/AM" do
     date_midnight = Timex.datetime({0,1,1})
     date_noon     = Timex.set(date_midnight, hour: 12)
+    date_5a       = Timex.set(date_midnight, hour: 5)
+    date_4p       = Timex.set(date_midnight, hour: 16)
 
-    assert { :ok, ^date_noon } = parse("am 12", "{am} {h12}")
+    assert { :ok, ^date_midnight } = parse("12 am", "{h12} {am}")
+    assert { :ok, ^date_noon }     = parse("12 pm", "{h12} {am}")
+    assert { :ok, ^date_5a }       = parse("5 am",  "{h12} {am}")
+    assert { :ok, ^date_4p }       = parse("4 pm",  "{h12} {am}")
+    assert { :ok, ^date_4p }       = parse("04 PM", "{0h12} {AM}")
+    assert { :ok, ^date_4p }       = parse(" 4 pm", "{_h12} {am}")
+  end
+
+  test "parse hour24 and am/AM" do
+    date_midnight = Timex.datetime({0,1,1})
+    date_13 = Timex.datetime({{0,1,1}, {13,0,0}})
+    assert { :ok, ^date_13 }       = parse("13 am", "{h24} {am}")
+    assert { :ok, ^date_13 }       = parse("13 pm", "{h24} {am}")
     assert { :ok, ^date_midnight } = parse("PM 00", "{AM} {0h24}")
-    date = Timex.datetime({{0,1,1}, {16,0,0}})
-    assert { :ok, ^date } = parse("4 pm", "{h12} {am}")
-    assert { :ok, ^date } = parse("04 PM", "{0h12} {AM}")
-    assert { :ok, ^date } = parse(" 4 pm", "{_h12} {am}")
   end
 
   test "parse simple time formats" do


### PR DESCRIPTION
### Summary of changes

`Timex.parse("12 am", "{h12} {am}")`  now returns T00:00 instead of noon.

`Timex.parse("17 am", "{h24} {am}")` now returns T17:00 instead of T05:00.


### Checklist

- [X ] New functions have typespecs, changed functions were updated
- [X ] Same for documentation, including moduledocs
- [X ] Tests were added or updated to cover changes
- [X ] Commits were squashed into a single coherent commit

