### PR TITLE
fix shifting bug

### DIFF
--- a/lib/datetime/datetime.ex
+++ b/lib/datetime/datetime.ex
@@ -789,7 +789,7 @@ defmodule Timex.DateTime do
       value == -12 -> %{datetime | :year => year - 1}
       m == 0 -> %{datetime | :year => year - 1, :month => 12}
       m > 12 -> %{datetime | :year => year + div(m, 12), :month => rem(m, 12)}
-      m < 0  -> %{datetime | :year => year + div(m, 12), :month => 12 + rem(m, 12)}
+      m < 0  -> %{datetime | :year => year + min(div(m, 12), -1), :month => 12 + rem(m, 12)}
       :else  -> %{datetime | :month => m}
     end
     # If the shift fails, it's because it's a high day number, and the month

--- a/test/date_test.exs
+++ b/test/date_test.exs
@@ -343,6 +343,7 @@ defmodule DateTests do
     assert %Date{year: 2014, month: 1, day: 5} = shift(datetime, months: 10)
     assert %Date{year: 2013, month: 1, day: 5} = shift(datetime, months: -2)
     assert %Date{year: 2012, month: 3, day: 5} = shift(datetime, months: -12)
+    assert %Date{year: 2012, month: 9, day: 5} = shift(datetime, months: -6)
 
     datetime = { {2013,3,31}, time }
     assert %Date{year: 2013, month: 4, day: 30} = shift(datetime, months: 1)


### PR DESCRIPTION
### Summary of changes

Fix for #174.  The test added should fail without this change.  The issue is `div(-3, 12)` (or any negative number greater than -12), will return 0 for the year shift, when it should go back a year.

### Checklist

- [x] New functions have typespecs, changed functions were updated
- [x] Same for documentation, including moduledocs
- [x] Tests were added or updated to cover changes
- [x] Commits were squashed into a single coherent commit
