### PR TITLE
Add how to use 'after?' to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,9 @@ true
 
 > Timex.before?(Date.today, Timex.shift(Date.today, days: 1))
 true
+
+> Timex.after?(Date.today, Timex.shift(Date.today, days: -1))
+true
 ```
 
 There are a ton of other functions for Dates, Times, and DateTimes, way more than can be covered here. Hopefully the above


### PR DESCRIPTION
The README does not contain what I was looking for; how to use Timex.after?/2

I think it should be included as well because many people(including me) want to use it when they implement 'New Product!' things for their applications.
