### PR TITLE
Fix return type of from_seconds/2

### DIFF
--- a/lib/datetime/datetime.ex
+++ b/lib/datetime/datetime.ex
@@ -399,8 +399,8 @@ defmodule Timex.DateTime do
   Converts an integer value representing seconds since the reference date (:epoch or :zero)
   to a DateTime struct representing that moment in time
   """
-  @spec from_seconds(non_neg_integer) :: DateTime.t :: {:error, atom}
-  @spec from_seconds(non_neg_integer, :epoch | :zero) :: DateTime.t :: {:error, atom}
+  @spec from_seconds(non_neg_integer) :: DateTime.t | {:error, atom}
+  @spec from_seconds(non_neg_integer, :epoch | :zero) :: DateTime.t | {:error, atom}
   def from_seconds(s, ref \\ :epoch)
   def from_seconds(s, :epoch) when is_positive_number(s) do
     construct(:calendar.gregorian_seconds_to_datetime(trunc(s) + epoch(:seconds)), %TimezoneInfo{})


### PR DESCRIPTION
### Summary of changes

Fixed type specifications for `Timex.DateTime.from_seconds/2` so that Dialyzer can run properly. Return type mistakenly used `::` instead of an or expression (`|`).

### Checklist

- [x] New functions have typespecs, changed functions were updated