### PR TITLE
Fix error when adding microseconds to DateTime

### DIFF
--- a/lib/datetime/datetime.ex
+++ b/lib/datetime/datetime.ex
@@ -335,7 +335,7 @@ defimpl Timex.Protocol, for: DateTime do
     rem_microseconds = rem(usecs_from_zero, 1_000*1_000)
 
     {{_y,_m,_d}=date,{h,mm,s}} = :calendar.gregorian_seconds_to_datetime(secs_from_zero)
-    Timezone.resolve(datetime.timezone.full_name, {date, {h,mm,s}})
+    Timezone.resolve(datetime.time_zone, {date, {h,mm,s}})
     |> Map.merge(%{microsecond: Helpers.construct_microseconds(rem_microseconds)})
   end
   defp shift_by(%DateTime{microsecond: {current_usecs, _}} = datetime, value, :milliseconds) do

--- a/test/timex_test.exs
+++ b/test/timex_test.exs
@@ -18,6 +18,13 @@ defmodule TimexTests do
     assert expected === result
   end
 
+  test "add microseconds" do
+    time = Timex.to_datetime({{2015, 6, 24}, {14, 27, 52}})
+    time = %{time | microsecond: {900_000, 6}}
+    added = Timex.add(time, Duration.from_microseconds(42))
+    assert added.microsecond === {900_042, 6}
+  end
+
   test "subtract" do
     date     = Timex.to_datetime({{2015, 6, 24}, {14, 27, 52}})
     expected = Timex.to_datetime({{2015, 6, 16}, {14, 27, 52}})


### PR DESCRIPTION
I've got an error when trying to do the following:

```elixir
Timex.now
|>  Timex.add(Duration.from_microseconds(160_000_001))

** (KeyError) key :timezone not found in: #<DateTime(2016-07-19T00:26:57.303708Z Etc/UTC)>
     stacktrace:
       (timex) lib/datetime/datetime.ex:338: Timex.Protocol.DateTime.shift_by/3
       (timex) lib/datetime/datetime.ex:248: Timex.Protocol.DateTime.apply_shifts/2
```