### PR TITLE
Remove unneeded earmark dependency

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -38,7 +38,6 @@ defmodule Timex.Mixfile do
      {:combine, "~> 0.7"},
      {:gettext, "~> 0.10"},
      {:ex_doc, "~> 0.13", only: :dev},
-     {:earmark, "~> 1.0", only: :dev},
      {:benchfella, "~> 0.3", only: :dev},
      {:dialyze, "~> 0.2", only: :dev},
      {:excoveralls, "~> 0.4", only: [:dev, :test]},


### PR DESCRIPTION
From ex_doc 0.12.0, earmark is no longer an optional dependency and doesn't have to be listed separately anymore. This can be proved by the fact that, while I removed earmark from the mix.exs, it's still present in the mix.lock.