### PR TITLE
Fixes indentation of code examples in docs

### DIFF
--- a/lib/interval/interval.ex
+++ b/lib/interval/interval.ex
@@ -48,25 +48,25 @@ defmodule Timex.Interval do
 
   ## Examples
 
-    iex> use Timex
-    ...> Interval.new(from: ~D[2014-09-22], until: ~D[2014-09-29])
-    ...> |> Interval.format!("%Y-%m-%d", :strftime)
-    "[2014-09-22, 2014-09-29)"
+      iex> use Timex
+      ...> Interval.new(from: ~D[2014-09-22], until: ~D[2014-09-29])
+      ...> |> Interval.format!("%Y-%m-%d", :strftime)
+      "[2014-09-22, 2014-09-29)"
 
-    iex> use Timex
-    ...> Interval.new(from: ~D[2014-09-22], until: [days: 7])
-    ...> |> Interval.format!("%Y-%m-%d", :strftime)
-    "[2014-09-22, 2014-09-29)"
+      iex> use Timex
+      ...> Interval.new(from: ~D[2014-09-22], until: [days: 7])
+      ...> |> Interval.format!("%Y-%m-%d", :strftime)
+      "[2014-09-22, 2014-09-29)"
 
-    iex> use Timex
-    ...> Interval.new(from: ~D[2014-09-22], until: [days: 7], left_open: true, right_open: false)
-    ...> |> Interval.format!("%Y-%m-%d", :strftime)
-    "(2014-09-22, 2014-09-29]"
+      iex> use Timex
+      ...> Interval.new(from: ~D[2014-09-22], until: [days: 7], left_open: true, right_open: false)
+      ...> |> Interval.format!("%Y-%m-%d", :strftime)
+      "(2014-09-22, 2014-09-29]"
 
-    iex> use Timex
-    ...> Interval.new(from: ~N[2014-09-22T15:30:00], until: [minutes: 20], right_open: false)
-    ...> |> Interval.format!("%H:%M", :strftime)
-    "[15:30, 15:50]"
+      iex> use Timex
+      ...> Interval.new(from: ~N[2014-09-22T15:30:00], until: [minutes: 20], right_open: false)
+      ...> |> Interval.format!("%H:%M", :strftime)
+      "[15:30, 15:50]"
 
   """
   def new(options \\ []) do
@@ -104,15 +104,15 @@ defmodule Timex.Interval do
 
   ## Example
 
-    iex> use Timex
-    ...> Interval.new(from: ~D[2014-09-22], until: [months: 5])
-    ...> |> Interval.duration(:months)
-    5
+      iex> use Timex
+      ...> Interval.new(from: ~D[2014-09-22], until: [months: 5])
+      ...> |> Interval.duration(:months)
+      5
 
-    iex> use Timex
-    ...> Interval.new(from: ~N[2014-09-22T15:30:00], until: [minutes: 20])
-    ...> |> Interval.duration(:duration)
-    Duration.from_minutes(20)
+      iex> use Timex
+      ...> Interval.new(from: ~N[2014-09-22T15:30:00], until: [minutes: 20])
+      ...> |> Interval.duration(:duration)
+      Duration.from_minutes(20)
 
   """
   def duration(%__MODULE__{from: from, until: until}, :duration) do
@@ -129,20 +129,20 @@ defmodule Timex.Interval do
 
   ## Examples
 
-    iex> use Timex
-    ...> Interval.new(from: ~D[2014-09-22], until: [days: 3], right_open: false)
-    ...> |> Interval.with_step([days: 1]) |> Enum.map(&Timex.format!(&1, "%Y-%m-%d", :strftime))
-    ["2014-09-22", "2014-09-23", "2014-09-24", "2014-09-25"]
+      iex> use Timex
+      ...> Interval.new(from: ~D[2014-09-22], until: [days: 3], right_open: false)
+      ...> |> Interval.with_step([days: 1]) |> Enum.map(&Timex.format!(&1, "%Y-%m-%d", :strftime))
+      ["2014-09-22", "2014-09-23", "2014-09-24", "2014-09-25"]
 
-    iex> use Timex
-    ...> Interval.new(from: ~D[2014-09-22], until: [days: 3], right_open: false)
-    ...> |> Interval.with_step([days: 2]) |> Enum.map(&Timex.format!(&1, "%Y-%m-%d", :strftime))
-    ["2014-09-22", "2014-09-24"]
+      iex> use Timex
+      ...> Interval.new(from: ~D[2014-09-22], until: [days: 3], right_open: false)
+      ...> |> Interval.with_step([days: 2]) |> Enum.map(&Timex.format!(&1, "%Y-%m-%d", :strftime))
+      ["2014-09-22", "2014-09-24"]
 
-    iex> use Timex
-    ...> Interval.new(from: ~D[2014-09-22], until: [days: 3], right_open: false)
-    ...> |> Interval.with_step([days: 3]) |> Enum.map(&Timex.format!(&1, "%Y-%m-%d", :strftime))
-    ["2014-09-22", "2014-09-25"]
+      iex> use Timex
+      ...> Interval.new(from: ~D[2014-09-22], until: [days: 3], right_open: false)
+      ...> |> Interval.with_step([days: 3]) |> Enum.map(&Timex.format!(&1, "%Y-%m-%d", :strftime))
+      ["2014-09-22", "2014-09-25"]
 
   """
   def with_step(%__MODULE__{} = interval, step) do


### PR DESCRIPTION
### Summary of changes

Some parts of the documentation of the `Timex.Interval` module are not generated/formatted correctly, namely the code examples of the `new`, `duration` and `with_step` functions.
See https://hexdocs.pm/timex/Timex.Interval.html#duration/2

This commit fixes the formatting by indenting the example code 4 spaces, allowing markdown to recognize it as code.

Nothing else was changed, tests still run.

Thank you for your work on this lib!

Cheers,
Chris

### Checklist

- [X] New functions have typespecs, changed functions were updated
- [X] Same for documentation, including moduledocs
- [X] Tests were added or updated to cover changes
- [X] Commits were squashed into a single coherent commit