### PR TITLE
Spanish translations

### DIFF
--- a/priv/translations/es/LC_MESSAGES/day_periods.po
+++ b/priv/translations/es/LC_MESSAGES/day_periods.po
@@ -1,0 +1,28 @@
+## This file is a PO Template file.
+##
+## `msgid`s here are often extracted from source code.
+## Add new translations manually only if they're dynamic
+## translations that can't be statically extracted.
+##
+## Run `mix gettext.extract` to bring this file up to
+## date. Leave `msgstr`s empty as changing them here as no
+## effect: edit them in PO (`.po`) files instead.
+msgid ""
+msgstr ""
+"Language: es\n"
+
+#: lib/l10n/translator.ex:183
+msgid "AM"
+msgstr "AM"
+
+#: lib/l10n/translator.ex:185
+msgid "PM"
+msgstr "PM"
+
+#: lib/l10n/translator.ex:184
+msgid "am"
+msgstr "am"
+
+#: lib/l10n/translator.ex:186
+msgid "pm"
+msgstr "pm"

--- a/priv/translations/es/LC_MESSAGES/months.po
+++ b/priv/translations/es/LC_MESSAGES/months.po
@@ -1,0 +1,60 @@
+## This file is a PO Template file.
+##
+## `msgid`s here are often extracted from source code.
+## Add new translations manually only if they're dynamic
+## translations that can't be statically extracted.
+##
+## Run `mix gettext.extract` to bring this file up to
+## date. Leave `msgstr`s empty as changing them here as no
+## effect: edit them in PO (`.po`) files instead.
+msgid ""
+msgstr ""
+"Language: es\n"
+
+#: lib/l10n/translator.ex:220
+msgid "April"
+msgstr "Abril"
+
+#: lib/l10n/translator.ex:224
+msgid "August"
+msgstr "Agosto"
+
+#: lib/l10n/translator.ex:228
+msgid "December"
+msgstr "Diciembre"
+
+#: lib/l10n/translator.ex:218
+msgid "February"
+msgstr "Febrero"
+
+#: lib/l10n/translator.ex:217
+msgid "January"
+msgstr "Enero"
+
+#: lib/l10n/translator.ex:223
+msgid "July"
+msgstr "Julio"
+
+#: lib/l10n/translator.ex:222
+msgid "June"
+msgstr "Junio"
+
+#: lib/l10n/translator.ex:219
+msgid "March"
+msgstr "Marzo"
+
+#: lib/l10n/translator.ex:221
+msgid "May"
+msgstr "Mayo"
+
+#: lib/l10n/translator.ex:227
+msgid "November"
+msgstr "Noviembre"
+
+#: lib/l10n/translator.ex:226
+msgid "October"
+msgstr "Octubre"
+
+#: lib/l10n/translator.ex:225
+msgid "September"
+msgstr "Septiembre"

--- a/priv/translations/es/LC_MESSAGES/months_abbr.po
+++ b/priv/translations/es/LC_MESSAGES/months_abbr.po
@@ -1,0 +1,60 @@
+## This file is a PO Template file.
+##
+## `msgid`s here are often extracted from source code.
+## Add new translations manually only if they're dynamic
+## translations that can't be statically extracted.
+##
+## Run `mix gettext.extract` to bring this file up to
+## date. Leave `msgstr`s empty as changing them here as no
+## effect: edit them in PO (`.po`) files instead.
+msgid ""
+msgstr ""
+"Language: es\n"
+
+#: lib/l10n/translator.ex:207
+msgid "Apr"
+msgstr "Abr"
+
+#: lib/l10n/translator.ex:211
+msgid "Aug"
+msgstr "Ago"
+
+#: lib/l10n/translator.ex:215
+msgid "Dec"
+msgstr "Dic"
+
+#: lib/l10n/translator.ex:205
+msgid "Feb"
+msgstr "Feb"
+
+#: lib/l10n/translator.ex:204
+msgid "Jan"
+msgstr "Ene"
+
+#: lib/l10n/translator.ex:210
+msgid "Jul"
+msgstr "Jul"
+
+#: lib/l10n/translator.ex:209
+msgid "Jun"
+msgstr "Jun"
+
+#: lib/l10n/translator.ex:206
+msgid "Mar"
+msgstr "Mar"
+
+#: lib/l10n/translator.ex:208
+msgid "May"
+msgstr "May"
+
+#: lib/l10n/translator.ex:214
+msgid "Nov"
+msgstr "Nov"
+
+#: lib/l10n/translator.ex:213
+msgid "Oct"
+msgstr "Oct"
+
+#: lib/l10n/translator.ex:212
+msgid "Sep"
+msgstr "Sep"

--- a/priv/translations/es/LC_MESSAGES/numbers.po
+++ b/priv/translations/es/LC_MESSAGES/numbers.po
@@ -1,0 +1,16 @@
+## This file is a PO Template file.
+##
+## `msgid`s here are often extracted from source code.
+## Add new translations manually only if they're dynamic
+## translations that can't be statically extracted.
+##
+## Run `mix gettext.extract` to bring this file up to
+## date. Leave `msgstr`s empty as changing them here as no
+## effect: edit them in PO (`.po`) files instead.
+msgid ""
+msgstr ""
+"Language: es\n"
+
+#: lib/l10n/translator.ex:298
+msgid "#,##0.###"
+msgstr "#.##0,###"

--- a/priv/translations/es/LC_MESSAGES/relative_time.po
+++ b/priv/translations/es/LC_MESSAGES/relative_time.po
@@ -1,0 +1,232 @@
+## This file is a PO Template file.
+##
+## `msgid`s here are often extracted from source code.
+## Add new translations manually only if they're dynamic
+## translations that can't be statically extracted.
+##
+## Run `mix gettext.extract` to bring this file up to
+## date. Leave `msgstr`s empty as changing them here as no
+## effect: edit them in PO (`.po`) files instead.
+msgid ""
+msgstr ""
+"Language: es\n"
+
+#: lib/l10n/translator.ex:237
+msgid "last month"
+msgstr "el mes pasado"
+
+#: lib/l10n/translator.ex:243
+msgid "last week"
+msgstr "la semana pasada"
+
+#: lib/l10n/translator.ex:231
+msgid "last year"
+msgstr "el año pasado"
+
+#: lib/l10n/translator.ex:239
+msgid "next month"
+msgstr "el mes que viene"
+
+#: lib/l10n/translator.ex:245
+msgid "next week"
+msgstr "la semana que viene"
+
+#: lib/l10n/translator.ex:233
+msgid "next year"
+msgstr "el año que viene"
+
+#: lib/l10n/translator.ex:238
+msgid "this month"
+msgstr "este mes"
+
+#: lib/l10n/translator.ex:244
+msgid "this week"
+msgstr "esta semana"
+
+#: lib/l10n/translator.ex:232
+msgid "this year"
+msgstr "este año"
+
+#: lib/l10n/translator.ex:250
+msgid "today"
+msgstr "hoy"
+
+#: lib/l10n/translator.ex:251
+msgid "tomorrow"
+msgstr "mañana"
+
+#: lib/l10n/translator.ex:249
+msgid "yesterday"
+msgstr "ayer"
+
+#: lib/l10n/translator.ex:253
+msgid "%{count} day ago"
+msgid_plural "%{count} days ago"
+msgstr[0] "hace %{count} día"
+msgstr[1] "hace %{count} días"
+
+#: lib/l10n/translator.ex:278
+msgid "%{count} hour ago"
+msgid_plural "%{count} hours ago"
+msgstr[0] "hace %{count} hora"
+msgstr[1] "hace %{count} horas"
+
+#: lib/l10n/translator.ex:281
+msgid "%{count} minute ago"
+msgid_plural "%{count} minutes ago"
+msgstr[0] "hace %{count} minuto"
+msgstr[1] "hace %{count} minutos"
+
+#: lib/l10n/translator.ex:241
+msgid "%{count} month ago"
+msgid_plural "%{count} months ago"
+msgstr[0] "hace %{count} mes"
+msgstr[1] "hace %{count} meses"
+
+#: lib/l10n/translator.ex:284
+msgid "%{count} second ago"
+msgid_plural "%{count} seconds ago"
+msgstr[0] "hace %{count} segundo"
+msgstr[1] "hace %{count} segundos"
+
+#: lib/l10n/translator.ex:247
+msgid "%{count} week ago"
+msgid_plural "%{count} weeks ago"
+msgstr[0] "hace %{count} semana"
+msgstr[1] "hace %{count} semanas"
+
+#: lib/l10n/translator.ex:235
+msgid "%{count} year ago"
+msgid_plural "%{count} years ago"
+msgstr[0] "hace %{count} año"
+msgstr[1] "hace %{count} años"
+
+#: lib/l10n/translator.ex:252
+msgid "in %{count} day"
+msgid_plural "in %{count} days"
+msgstr[0] "en %{count} día"
+msgstr[1] "en %{count} días"
+
+#: lib/l10n/translator.ex:277
+msgid "in %{count} hour"
+msgid_plural "in %{count} hours"
+msgstr[0] "en %{count} hora"
+msgstr[1] "en %{count} horas"
+
+#: lib/l10n/translator.ex:280
+msgid "in %{count} minute"
+msgid_plural "in %{count} minutes"
+msgstr[0] "en %{count} minuto"
+msgstr[1] "en %{count} minutos"
+
+#: lib/l10n/translator.ex:240
+msgid "in %{count} month"
+msgid_plural "in %{count} months"
+msgstr[0] "en %{count} mes"
+msgstr[1] "en %{count} meses"
+
+#: lib/l10n/translator.ex:283
+msgid "in %{count} second"
+msgid_plural "in %{count} seconds"
+msgstr[0] "en %{count} segundo"
+msgstr[1] "en %{count} segundos"
+
+#: lib/l10n/translator.ex:246
+msgid "in %{count} week"
+msgid_plural "in %{count} weeks"
+msgstr[0] "en %{count} semana"
+msgstr[1] "en %{count} semanas"
+
+#: lib/l10n/translator.ex:234
+msgid "in %{count} year"
+msgid_plural "in %{count} years"
+msgstr[0] "en %{count} año"
+msgstr[1] "en %{count} años"
+
+#: lib/l10n/translator.ex:267
+msgid "last friday"
+msgstr "el viernes pasado"
+
+#: lib/l10n/translator.ex:255
+msgid "last monday"
+msgstr "el lunes pasado"
+
+#: lib/l10n/translator.ex:270
+msgid "last saturday"
+msgstr "el sábado pasado"
+
+#: lib/l10n/translator.ex:273
+msgid "last sunday"
+msgstr "el domingo pasado"
+
+#: lib/l10n/translator.ex:264
+msgid "last thursday"
+msgstr "el jueves pasado"
+
+#: lib/l10n/translator.ex:258
+msgid "last tuesday"
+msgstr "el martes pasado"
+
+#: lib/l10n/translator.ex:261
+msgid "last wednesday"
+msgstr "el miércoles pasado"
+
+#: lib/l10n/translator.ex:269
+msgid "next friday"
+msgstr "el viernes que viene"
+
+#: lib/l10n/translator.ex:257
+msgid "next monday"
+msgstr "el lunes que viene"
+
+#: lib/l10n/translator.ex:272
+msgid "next saturday"
+msgstr "el sábado que viene"
+
+#: lib/l10n/translator.ex:275
+msgid "next sunday"
+msgstr "el domingo que viene"
+
+#: lib/l10n/translator.ex:266
+msgid "next thursday"
+msgstr "el jueves que viene"
+
+#: lib/l10n/translator.ex:260
+msgid "next tuesday"
+msgstr "el martes que viene"
+
+#: lib/l10n/translator.ex:263
+msgid "next wednesday"
+msgstr "el miércoles que viene"
+
+#: lib/l10n/translator.ex:268
+msgid "this friday"
+msgstr "este viernes"
+
+#: lib/l10n/translator.ex:256
+msgid "this monday"
+msgstr "este lunes"
+
+#: lib/l10n/translator.ex:271
+msgid "this saturday"
+msgstr "este sábado"
+
+#: lib/l10n/translator.ex:274
+msgid "this sunday"
+msgstr "este domingo"
+
+#: lib/l10n/translator.ex:265
+msgid "this thursday"
+msgstr "este jueves"
+
+#: lib/l10n/translator.ex:259
+msgid "this tuesday"
+msgstr "este martes"
+
+#: lib/l10n/translator.ex:262
+msgid "this wednesday"
+msgstr "este miércoles"
+
+#: lib/l10n/translator.ex:286
+msgid "now"
+msgstr "ahora"

--- a/priv/translations/es/LC_MESSAGES/symbols.po
+++ b/priv/translations/es/LC_MESSAGES/symbols.po
@@ -1,0 +1,40 @@
+## This file is a PO Template file.
+##
+## `msgid`s here are often extracted from source code.
+## Add new translations manually only if they're dynamic
+## translations that can't be statically extracted.
+##
+## Run `mix gettext.extract` to bring this file up to
+## date. Leave `msgstr`s empty as changing them here as no
+## effect: edit them in PO (`.po`) files instead.
+msgid ""
+msgstr ""
+"Language: es\n"
+
+#: lib/l10n/translator.ex:292
+msgid "+"
+msgstr "+"
+
+#: lib/l10n/translator.ex:290
+msgid ","
+msgstr ","
+
+#: lib/l10n/translator.ex:293
+msgid "-"
+msgstr "-"
+
+#: lib/l10n/translator.ex:289
+msgid "."
+msgstr "."
+
+#: lib/l10n/translator.ex:295
+msgid ":"
+msgstr ":"
+
+#: lib/l10n/translator.ex:291
+msgid ";"
+msgstr ";"
+
+#: lib/l10n/translator.ex:294
+msgid "E"
+msgstr "E"

--- a/priv/translations/es/LC_MESSAGES/units.po
+++ b/priv/translations/es/LC_MESSAGES/units.po
@@ -1,0 +1,72 @@
+## This file is a PO Template file.
+##
+## `msgid`s here are often extracted from source code.
+## Add new translations manually only if they're dynamic
+## translations that can't be statically extracted.
+##
+## Run `mix gettext.extract` to bring this file up to
+## date. Leave `msgstr`s empty as changing them here as no
+## effect: edit them in PO (`.po`) files instead.
+msgid ""
+msgstr ""
+"Language: es\n"
+
+#: lib/l10n/translator.ex:178
+msgid "%{count} day"
+msgid_plural "%{count} days"
+msgstr[0] "%{count} día"
+msgstr[1] "%{count} días"
+
+#: lib/l10n/translator.ex:177
+msgid "%{count} hour"
+msgid_plural "%{count} hours"
+msgstr[0] "%{count} hora"
+msgstr[1] "%{count} horas"
+
+#: lib/l10n/translator.ex:173
+msgid "%{count} microsecond"
+msgid_plural "%{count} microseconds"
+msgstr[0] "%{count} microsegundo"
+msgstr[1] "%{count} microsegundos"
+
+#: lib/l10n/translator.ex:174
+msgid "%{count} millisecond"
+msgid_plural "%{count} milliseconds"
+msgstr[0] "%{count} milisegundo"
+msgstr[1] "%{count} milisegundos"
+
+#: lib/l10n/translator.ex:176
+msgid "%{count} minute"
+msgid_plural "%{count} minutes"
+msgstr[0] "%{count} minuto"
+msgstr[1] "%{count} minutos"
+
+#: lib/l10n/translator.ex:180
+msgid "%{count} month"
+msgid_plural "%{count} months"
+msgstr[0] "%{count} mes"
+msgstr[1] "%{count} meses"
+
+#: lib/l10n/translator.ex:172
+msgid "%{count} nanosecond"
+msgid_plural "%{count} nanoseconds"
+msgstr[0] "%{count} nanosegundo"
+msgstr[1] "%{count} nanosegundos"
+
+#: lib/l10n/translator.ex:175
+msgid "%{count} second"
+msgid_plural "%{count} seconds"
+msgstr[0] "%{count} segundo"
+msgstr[1] "%{count} segundos"
+
+#: lib/l10n/translator.ex:179
+msgid "%{count} week"
+msgid_plural "%{count} weeks"
+msgstr[0] "%{count} semana"
+msgstr[1] "%{count} semanas"
+
+#: lib/l10n/translator.ex:181
+msgid "%{count} year"
+msgid_plural "%{count} years"
+msgstr[0] "%{count} año"
+msgstr[1] "%{count} años"

--- a/priv/translations/es/LC_MESSAGES/weekdays.po
+++ b/priv/translations/es/LC_MESSAGES/weekdays.po
@@ -1,0 +1,68 @@
+## This file is a PO Template file.
+##
+## `msgid`s here are often extracted from source code.
+## Add new translations manually only if they're dynamic
+## translations that can't be statically extracted.
+##
+## Run `mix gettext.extract` to bring this file up to
+## date. Leave `msgstr`s empty as changing them here as no
+## effect: edit them in PO (`.po`) files instead.
+msgid ""
+msgstr ""
+"Language: es\n"
+
+#: lib/l10n/translator.ex:192
+msgid "Fri"
+msgstr "Vie"
+
+#: lib/l10n/translator.ex:200
+msgid "Friday"
+msgstr "Viernes"
+
+#: lib/l10n/translator.ex:188
+msgid "Mon"
+msgstr "Lun"
+
+#: lib/l10n/translator.ex:196
+msgid "Monday"
+msgstr "Lunes"
+
+#: lib/l10n/translator.ex:193
+msgid "Sat"
+msgstr "Sáb"
+
+#: lib/l10n/translator.ex:201
+msgid "Saturday"
+msgstr "Sábado"
+
+#: lib/l10n/translator.ex:194
+msgid "Sun"
+msgstr "Dom"
+
+#: lib/l10n/translator.ex:202
+msgid "Sunday"
+msgstr "Domingo"
+
+#: lib/l10n/translator.ex:191
+msgid "Thu"
+msgstr "Jue"
+
+#: lib/l10n/translator.ex:199
+msgid "Thursday"
+msgstr "Jueves"
+
+#: lib/l10n/translator.ex:189
+msgid "Tue"
+msgstr "Mar"
+
+#: lib/l10n/translator.ex:197
+msgid "Tuesday"
+msgstr "Martes"
+
+#: lib/l10n/translator.ex:190
+msgid "Wed"
+msgstr "Mié"
+
+#: lib/l10n/translator.ex:198
+msgid "Wednesday"
+msgstr "Miércoles"


### PR DESCRIPTION
Hello,

This adds support for the Spanish language.

There is one catch, though.

In English, May (short name) and May (long name) are the same. But in Spanish (at least), May (short name) and Mayo (long name) are different. 

The file months.po does not have a placeholder for the long name for May. I'm not really sure how to tackle this, but it seems the same thing happens in Italian, where Mag and Maggio are different but there's only one placeholder. 

Any thoughts?

Thank you!