### PR TITLE
Fix relative formatter documation

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,9 @@ Here's a few simple examples:
 > {:ok, default_str} = Timex.format(datetime, "{ISO:Extended}")
 {:ok, "2016-02-29T12:30:30.120+00:00"}
 
+> {:ok, relative_str} = Timex.shift(datetime, minutes: -3) |> Timex.format("{relative}", :relative)
+{:ok, "3 minutes ago"}
+
 > strftime_str = Timex.format!(datetime, "%FT%T%:z", :strftime)
 "2016-02-29T12:30:30+00:00"
 

--- a/lib/format/datetime/formatters/relative.ex
+++ b/lib/format/datetime/formatters/relative.ex
@@ -44,8 +44,8 @@ defmodule Timex.Format.DateTime.Formatters.Relative do
 
   ## Examples
 
-      iex> #{__MODULE__}.format(Timex.shift(Timex.now, minutes: -1))
-      "1 minute ago"
+      iex> #{__MODULE__}.format(Timex.shift(Timex.now, minutes: -1), "{relative}")
+      {:ok, "1 minute ago"}
   """
   @spec format(Types.calendar_types, String.t) :: {:ok, String.t} | {:error, term}
   def format(date, format_string),  do: lformat(date, format_string, Translator.default_locale)

--- a/test/timex/format/date_time/formatters/relative_test.exs
+++ b/test/timex/format/date_time/formatters/relative_test.exs
@@ -1,0 +1,5 @@
+defmodule Timex.Format.DateTime.Formatters.RelativeTest do
+  use ExUnit.Case, async: true
+  alias Timex.Format.DateTime.Formatters.Relative
+  doctest Relative
+end


### PR DESCRIPTION
### Summary of changes

I had some trouble figuring out how to use the relative formatter initially. First, the docs were pretty buried. Then, when I found them, they had a mistake. So I:

- added a valid example to the readme
- fixed the broken example in the formatter module
- added doctest to prove example correctness

Not sure how you'll feel about the doctest sense there is no precedence. Might be worth doing this for all the modules. I can take a stab if you're interested :)