### PR TITLE
Replace :tzdata with :timex in applications list reference

### DIFF
--- a/docs/Getting Started.md
+++ b/docs/Getting Started.md
@@ -8,7 +8,7 @@ the vast majority of functionality you will care about.
 
 ## Project Setup
 
-To use Timex with your projects, edit your `mix.exs` file and add it as a dependency, as well as add `:tzdata` to your applications list.
+To use Timex with your projects, edit your `mix.exs` file and add it as a dependency, as well as add `:timex` to your applications list.
 
 ```elixir
 def application do


### PR DESCRIPTION
### Summary of changes

I'm new to Elixir & Timex, but I'm fairly certain the `:tzdata` reference in the "Getting Started" doc should be `:timex` instead.  If not, sorry for taking up your time.  Thanks!

### Checklist

- [x] New functions have typespecs, changed functions were updated
- [x] Same for documentation, including moduledocs
- [x] Tests were added or updated to cover changes
- [x] Commits were squashed into a single coherent commit

