### PR TITLE
Brazilian Portuguese added

### DIFF
--- a/priv/translations/pt_BR/LC_MESSAGES/day_periods.po
+++ b/priv/translations/pt_BR/LC_MESSAGES/day_periods.po
@@ -1,0 +1,36 @@
+# # `msgid`s in this file come from POT (.pot) files.
+# #
+# # Do not add, change, or remove `msgid`s manually here as
+# # they're tied to the ones in the corresponding POT file
+# # (with the same domain).
+# #
+# # Use `mix gettext.extract --merge` or `mix gettext.merge`
+# # to merge POT files into PO files.
+msgid ""
+msgstr ""
+"Language: pt_BR\n"
+"Project-Id-Version: \n"
+"POT-Creation-Date: \n"
+"PO-Revision-Date: \n"
+"Last-Translator: Roberto Trevisan <beto@trevisan.me>\n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"X-Generator: Poedit 1.8.8\n"
+
+#: lib/l10n/translator.ex:183
+msgid "AM"
+msgstr "AM"
+
+#: lib/l10n/translator.ex:185
+msgid "PM"
+msgstr "PM"
+
+#: lib/l10n/translator.ex:184
+msgid "am"
+msgstr "am"
+
+#: lib/l10n/translator.ex:186
+msgid "pm"
+msgstr "pm"

--- a/priv/translations/pt_BR/LC_MESSAGES/months.po
+++ b/priv/translations/pt_BR/LC_MESSAGES/months.po
@@ -1,0 +1,68 @@
+# # `msgid`s in this file come from POT (.pot) files.
+# #
+# # Do not add, change, or remove `msgid`s manually here as
+# # they're tied to the ones in the corresponding POT file
+# # (with the same domain).
+# #
+# # Use `mix gettext.extract --merge` or `mix gettext.merge`
+# # to merge POT files into PO files.
+msgid ""
+msgstr ""
+"Language: pt_BR\n"
+"Project-Id-Version: \n"
+"POT-Creation-Date: \n"
+"PO-Revision-Date: \n"
+"Last-Translator: Roberto Trevisan <beto@trevisan.me>\n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"X-Generator: Poedit 1.8.8\n"
+
+#: lib/l10n/translator.ex:220
+msgid "April"
+msgstr "Abril"
+
+#: lib/l10n/translator.ex:224
+msgid "August"
+msgstr "Agosto"
+
+#: lib/l10n/translator.ex:228
+msgid "December"
+msgstr "Dezembro"
+
+#: lib/l10n/translator.ex:218
+msgid "February"
+msgstr "Fevereiro"
+
+#: lib/l10n/translator.ex:217
+msgid "January"
+msgstr "Janeiro"
+
+#: lib/l10n/translator.ex:223
+msgid "July"
+msgstr "Julho"
+
+#: lib/l10n/translator.ex:222
+msgid "June"
+msgstr "Junho"
+
+#: lib/l10n/translator.ex:219
+msgid "March"
+msgstr "Março"
+
+#: lib/l10n/translator.ex:221
+msgid "May"
+msgstr "Maio"
+
+#: lib/l10n/translator.ex:227
+msgid "November"
+msgstr "Novembro"
+
+#: lib/l10n/translator.ex:226
+msgid "October"
+msgstr "Outubro"
+
+#: lib/l10n/translator.ex:225
+msgid "September"
+msgstr "Setembro"

--- a/priv/translations/pt_BR/LC_MESSAGES/months_abbr.po
+++ b/priv/translations/pt_BR/LC_MESSAGES/months_abbr.po
@@ -1,0 +1,59 @@
+## `msgid`s in this file come from POT (.pot) files.
+##
+## Do not add, change, or remove `msgid`s manually here as
+## they're tied to the ones in the corresponding POT file
+## (with the same domain).
+##
+## Use `mix gettext.extract --merge` or `mix gettext.merge`
+## to merge POT files into PO files.
+msgid ""
+msgstr ""
+"Language: pt_BR\n"
+
+#: lib/l10n/translator.ex:207
+msgid "Apr"
+msgstr "Abr"
+
+#: lib/l10n/translator.ex:211
+msgid "Aug"
+msgstr "Ago"
+
+#: lib/l10n/translator.ex:215
+msgid "Dec"
+msgstr "Dez"
+
+#: lib/l10n/translator.ex:205
+msgid "Feb"
+msgstr "Fev"
+
+#: lib/l10n/translator.ex:204
+msgid "Jan"
+msgstr "Jan"
+
+#: lib/l10n/translator.ex:210
+msgid "Jul"
+msgstr "Jul"
+
+#: lib/l10n/translator.ex:209
+msgid "Jun"
+msgstr "Jun"
+
+#: lib/l10n/translator.ex:206
+msgid "Mar"
+msgstr "Mar"
+
+#: lib/l10n/translator.ex:208
+msgid "May"
+msgstr "Mai"
+
+#: lib/l10n/translator.ex:214
+msgid "Nov"
+msgstr "Nov"
+
+#: lib/l10n/translator.ex:213
+msgid "Oct"
+msgstr "Out"
+
+#: lib/l10n/translator.ex:212
+msgid "Sep"
+msgstr "Set"

--- a/priv/translations/pt_BR/LC_MESSAGES/numbers.po
+++ b/priv/translations/pt_BR/LC_MESSAGES/numbers.po
@@ -1,0 +1,15 @@
+## `msgid`s in this file come from POT (.pot) files.
+##
+## Do not add, change, or remove `msgid`s manually here as
+## they're tied to the ones in the corresponding POT file
+## (with the same domain).
+##
+## Use `mix gettext.extract --merge` or `mix gettext.merge`
+## to merge POT files into PO files.
+msgid ""
+msgstr ""
+"Language: pt_BR\n"
+
+#: lib/l10n/translator.ex:298
+msgid "#,##0.###"
+msgstr "#.##0,###"

--- a/priv/translations/pt_BR/LC_MESSAGES/relative_time.po
+++ b/priv/translations/pt_BR/LC_MESSAGES/relative_time.po
@@ -1,0 +1,241 @@
+# # `msgid`s in this file come from POT (.pot) files.
+# #
+# # Do not add, change, or remove `msgid`s manually here as
+# # they're tied to the ones in the corresponding POT file
+# # (with the same domain).
+# #
+# # Use `mix gettext.extract --merge` or `mix gettext.merge`
+# # to merge POT files into PO files.
+msgid ""
+msgstr ""
+"Language: pt_BR\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"Project-Id-Version: \n"
+"POT-Creation-Date: \n"
+"PO-Revision-Date: \n"
+"Last-Translator: Roberto Trevisan <beto@trevisan.me>\n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"X-Generator: Poedit 1.8.8\n"
+
+#: lib/l10n/translator.ex:237
+msgid "last month"
+msgstr "mês passado"
+
+#: lib/l10n/translator.ex:243
+msgid "last week"
+msgstr "semana passada"
+
+#: lib/l10n/translator.ex:231
+msgid "last year"
+msgstr "ano passado"
+
+#: lib/l10n/translator.ex:239
+msgid "next month"
+msgstr "ano que vem"
+
+#: lib/l10n/translator.ex:245
+msgid "next week"
+msgstr "semana que vem"
+
+#: lib/l10n/translator.ex:233
+msgid "next year"
+msgstr "ano que vem"
+
+#: lib/l10n/translator.ex:238
+msgid "this month"
+msgstr "este mês"
+
+#: lib/l10n/translator.ex:244
+msgid "this week"
+msgstr "esta semana"
+
+#: lib/l10n/translator.ex:232
+msgid "this year"
+msgstr "este ano"
+
+#: lib/l10n/translator.ex:250
+msgid "today"
+msgstr "hoje"
+
+#: lib/l10n/translator.ex:251
+msgid "tomorrow"
+msgstr "amanhã"
+
+#: lib/l10n/translator.ex:249
+msgid "yesterday"
+msgstr "ontem"
+
+#: lib/l10n/translator.ex:253
+msgid "%{count} day ago"
+msgid_plural "%{count} days ago"
+msgstr[0] "%{count} dia atrás"
+msgstr[1] "%{count} dias atrás"
+
+#: lib/l10n/translator.ex:278
+msgid "%{count} hour ago"
+msgid_plural "%{count} hours ago"
+msgstr[0] "%{count} hora atrás"
+msgstr[1] "%{count} horas atrás"
+
+#: lib/l10n/translator.ex:281
+msgid "%{count} minute ago"
+msgid_plural "%{count} minutes ago"
+msgstr[0] "%{count} minuto atrás"
+msgstr[1] "%{count} minutos atrás"
+
+#: lib/l10n/translator.ex:241
+msgid "%{count} month ago"
+msgid_plural "%{count} months ago"
+msgstr[0] "%{count} mês atrás"
+msgstr[1] "%{count} meses atrás"
+
+#: lib/l10n/translator.ex:284
+msgid "%{count} second ago"
+msgid_plural "%{count} seconds ago"
+msgstr[0] "%{count} segundo atrás"
+msgstr[1] "%{count} segundos atrás"
+
+#: lib/l10n/translator.ex:247
+msgid "%{count} week ago"
+msgid_plural "%{count} weeks ago"
+msgstr[0] "%{count} semana atrás"
+msgstr[1] "%{count} semanas atrás"
+
+#: lib/l10n/translator.ex:235
+msgid "%{count} year ago"
+msgid_plural "%{count} years ago"
+msgstr[0] "%{count} ano atrás"
+msgstr[1] "%{count} anos atrás"
+
+#: lib/l10n/translator.ex:252
+msgid "in %{count} day"
+msgid_plural "in %{count} days"
+msgstr[0] "em %{count} dia"
+msgstr[1] "em %{count} dias"
+
+#: lib/l10n/translator.ex:277
+msgid "in %{count} hour"
+msgid_plural "in %{count} hours"
+msgstr[0] "em %{count} hora"
+msgstr[1] "em %{count} horas"
+
+#: lib/l10n/translator.ex:280
+msgid "in %{count} minute"
+msgid_plural "in %{count} minutes"
+msgstr[0] "em %{count} minuto"
+msgstr[1] "em %{count} minutos"
+
+#: lib/l10n/translator.ex:240
+msgid "in %{count} month"
+msgid_plural "in %{count} months"
+msgstr[0] "em %{count} mês"
+msgstr[1] "em %{count} meses"
+
+#: lib/l10n/translator.ex:283
+msgid "in %{count} second"
+msgid_plural "in %{count} seconds"
+msgstr[0] "em %{count} segundo"
+msgstr[1] "em %{count} segundos"
+
+#: lib/l10n/translator.ex:246
+msgid "in %{count} week"
+msgid_plural "in %{count} weeks"
+msgstr[0] "em %{count} semana"
+msgstr[1] "em %{count} semanas"
+
+#: lib/l10n/translator.ex:234
+msgid "in %{count} year"
+msgid_plural "in %{count} years"
+msgstr[0] "em %{count} ano"
+msgstr[1] "em %{count} anos"
+
+#: lib/l10n/translator.ex:267
+msgid "last friday"
+msgstr "última sexta-feira"
+
+#: lib/l10n/translator.ex:255
+msgid "last monday"
+msgstr "última segunda-feira"
+
+#: lib/l10n/translator.ex:270
+msgid "last saturday"
+msgstr "último sábado"
+
+#: lib/l10n/translator.ex:273
+msgid "last sunday"
+msgstr "último domingo"
+
+#: lib/l10n/translator.ex:264
+msgid "last thursday"
+msgstr "última quinta-feira"
+
+#: lib/l10n/translator.ex:258
+msgid "last tuesday"
+msgstr "última terça-feira"
+
+#: lib/l10n/translator.ex:261
+msgid "last wednesday"
+msgstr "última quarta-feira"
+
+#: lib/l10n/translator.ex:269
+msgid "next friday"
+msgstr "próxima sexta-feira"
+
+#: lib/l10n/translator.ex:257
+msgid "next monday"
+msgstr "próxima segunda-feira"
+
+#: lib/l10n/translator.ex:272
+msgid "next saturday"
+msgstr "próximo sábado"
+
+#: lib/l10n/translator.ex:275
+msgid "next sunday"
+msgstr "próximo domingo"
+
+#: lib/l10n/translator.ex:266
+msgid "next thursday"
+msgstr "próxima quinta-feira"
+
+#: lib/l10n/translator.ex:260
+msgid "next tuesday"
+msgstr "próxima terça-feira"
+
+#: lib/l10n/translator.ex:263
+msgid "next wednesday"
+msgstr "próxima quarta-feira"
+
+#: lib/l10n/translator.ex:268
+msgid "this friday"
+msgstr "esta sexta-feira"
+
+#: lib/l10n/translator.ex:256
+msgid "this monday"
+msgstr "esta segunda-feira"
+
+#: lib/l10n/translator.ex:271
+msgid "this saturday"
+msgstr "este sábado"
+
+#: lib/l10n/translator.ex:274
+msgid "this sunday"
+msgstr "este domingo"
+
+#: lib/l10n/translator.ex:265
+msgid "this thursday"
+msgstr "esta quinta-feira"
+
+#: lib/l10n/translator.ex:259
+msgid "this tuesday"
+msgstr "esta terça-feira"
+
+#: lib/l10n/translator.ex:262
+msgid "this wednesday"
+msgstr "esta quarta-feira"
+
+#: lib/l10n/translator.ex:286
+msgid "now"
+msgstr ""

--- a/priv/translations/pt_BR/LC_MESSAGES/symbols.po
+++ b/priv/translations/pt_BR/LC_MESSAGES/symbols.po
@@ -1,0 +1,48 @@
+# # `msgid`s in this file come from POT (.pot) files.
+# #
+# # Do not add, change, or remove `msgid`s manually here as
+# # they're tied to the ones in the corresponding POT file
+# # (with the same domain).
+# #
+# # Use `mix gettext.extract --merge` or `mix gettext.merge`
+# # to merge POT files into PO files.
+msgid ""
+msgstr ""
+"Language: pt_BR\n"
+"Project-Id-Version: \n"
+"POT-Creation-Date: \n"
+"PO-Revision-Date: \n"
+"Last-Translator: Roberto Trevisan <beto@trevisan.me>\n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"X-Generator: Poedit 1.8.8\n"
+
+#: lib/l10n/translator.ex:292
+msgid "+"
+msgstr "+"
+
+#: lib/l10n/translator.ex:290
+msgid ","
+msgstr "."
+
+#: lib/l10n/translator.ex:293
+msgid "-"
+msgstr "-"
+
+#: lib/l10n/translator.ex:289
+msgid "."
+msgstr ","
+
+#: lib/l10n/translator.ex:295
+msgid ":"
+msgstr ":"
+
+#: lib/l10n/translator.ex:291
+msgid ";"
+msgstr ";"
+
+#: lib/l10n/translator.ex:294
+msgid "E"
+msgstr "E"

--- a/priv/translations/pt_BR/LC_MESSAGES/units.po
+++ b/priv/translations/pt_BR/LC_MESSAGES/units.po
@@ -1,0 +1,81 @@
+# # `msgid`s in this file come from POT (.pot) files.
+# #
+# # Do not add, change, or remove `msgid`s manually here as
+# # they're tied to the ones in the corresponding POT file
+# # (with the same domain).
+# #
+# # Use `mix gettext.extract --merge` or `mix gettext.merge`
+# # to merge POT files into PO files.
+msgid ""
+msgstr ""
+"Language: pt_BR\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"Project-Id-Version: \n"
+"POT-Creation-Date: \n"
+"PO-Revision-Date: \n"
+"Last-Translator: Roberto Trevisan <beto@trevisan.me>\n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"X-Generator: Poedit 1.8.8\n"
+
+#: lib/l10n/translator.ex:178
+msgid "%{count} day"
+msgid_plural "%{count} days"
+msgstr[0] "%{count} dia"
+msgstr[1] "%{count} dias"
+
+#: lib/l10n/translator.ex:177
+msgid "%{count} hour"
+msgid_plural "%{count} hours"
+msgstr[0] "%{count} hora"
+msgstr[1] "%{count} horas"
+
+#: lib/l10n/translator.ex:173
+msgid "%{count} microsecond"
+msgid_plural "%{count} microseconds"
+msgstr[0] "%{count} microssegundo"
+msgstr[1] "%{count} microssegundos"
+
+#: lib/l10n/translator.ex:174
+msgid "%{count} millisecond"
+msgid_plural "%{count} milliseconds"
+msgstr[0] "%{count} milissegundo"
+msgstr[1] "%{count} milissegundos"
+
+#: lib/l10n/translator.ex:176
+msgid "%{count} minute"
+msgid_plural "%{count} minutes"
+msgstr[0] "%{count} minuto"
+msgstr[1] "%{count} minutos"
+
+#: lib/l10n/translator.ex:180
+msgid "%{count} month"
+msgid_plural "%{count} months"
+msgstr[0] "%{count} mês"
+msgstr[1] "%{count} meses"
+
+#: lib/l10n/translator.ex:172
+msgid "%{count} nanosecond"
+msgid_plural "%{count} nanoseconds"
+msgstr[0] "%{count} nanossegundo"
+msgstr[1] "%{count} nanossegundos"
+
+#: lib/l10n/translator.ex:175
+msgid "%{count} second"
+msgid_plural "%{count} seconds"
+msgstr[0] "%{count} segundo"
+msgstr[1] "%{count} segundos"
+
+#: lib/l10n/translator.ex:179
+msgid "%{count} week"
+msgid_plural "%{count} weeks"
+msgstr[0] "%{count} semana"
+msgstr[1] "%{count} semanas"
+
+#: lib/l10n/translator.ex:181
+msgid "%{count} year"
+msgid_plural "%{count} years"
+msgstr[0] "%{count} ano"
+msgstr[1] "%{count} anos"

--- a/priv/translations/pt_BR/LC_MESSAGES/weekdays.po
+++ b/priv/translations/pt_BR/LC_MESSAGES/weekdays.po
@@ -1,0 +1,76 @@
+# # `msgid`s in this file come from POT (.pot) files.
+# #
+# # Do not add, change, or remove `msgid`s manually here as
+# # they're tied to the ones in the corresponding POT file
+# # (with the same domain).
+# #
+# # Use `mix gettext.extract --merge` or `mix gettext.merge`
+# # to merge POT files into PO files.
+msgid ""
+msgstr ""
+"Language: pt_BR\n"
+"Project-Id-Version: \n"
+"POT-Creation-Date: \n"
+"PO-Revision-Date: \n"
+"Last-Translator: Roberto Trevisan <beto@trevisan.me>\n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"X-Generator: Poedit 1.8.8\n"
+
+#: lib/l10n/translator.ex:192
+msgid "Fri"
+msgstr "Sex"
+
+#: lib/l10n/translator.ex:200
+msgid "Friday"
+msgstr "Sexta-feira"
+
+#: lib/l10n/translator.ex:188
+msgid "Mon"
+msgstr "Seg"
+
+#: lib/l10n/translator.ex:196
+msgid "Monday"
+msgstr "Segunda-feira"
+
+#: lib/l10n/translator.ex:193
+msgid "Sat"
+msgstr "Sab"
+
+#: lib/l10n/translator.ex:201
+msgid "Saturday"
+msgstr "Sábado"
+
+#: lib/l10n/translator.ex:194
+msgid "Sun"
+msgstr "Dom"
+
+#: lib/l10n/translator.ex:202
+msgid "Sunday"
+msgstr "Domingo"
+
+#: lib/l10n/translator.ex:191
+msgid "Thu"
+msgstr "Qui"
+
+#: lib/l10n/translator.ex:199
+msgid "Thursday"
+msgstr "Quinta-feira"
+
+#: lib/l10n/translator.ex:189
+msgid "Tue"
+msgstr "Ter"
+
+#: lib/l10n/translator.ex:197
+msgid "Tuesday"
+msgstr "Terça-feira"
+
+#: lib/l10n/translator.ex:190
+msgid "Wed"
+msgstr "Qua"
+
+#: lib/l10n/translator.ex:198
+msgid "Wednesday"
+msgstr "Quarta-feira"


### PR DESCRIPTION
### Summary of changes

Besides for Timex the translations are the same, pt and pt_BR are different locales and usually we will use pt_BR translations on gettext, than it is easier to use Gettext.get_locale as input parameter of Timex.lformat when needed.

I also think that we should use the ll_CC standard (https://www.gnu.org/software/gettext/manual/html_node/Locale-Names.html) for all translations, but it will probably be a breaking changes, this is way I'm doing this only for Brazilian and let pt/ folder as is.