### PR TITLE
Fix subtract for small durations

### DIFF
--- a/lib/timex.ex
+++ b/lib/timex.ex
@@ -1364,7 +1364,7 @@ defmodule Timex do
   """
   @spec subtract(Convertable.t, Types.timestamp) :: DateTime.t | {:error, term}
   def subtract(date, %Duration{megaseconds: mega, seconds: sec, microseconds: micro}),
-    do: shift(date, [seconds: (-mega * @million) - sec, microseconds: micro])
+    do: shift(date, [seconds: (-mega * @million) - sec, microseconds: -micro])
 
   @doc """
   A single function for adjusting the date using various units: duration,

--- a/test/timex_test.exs
+++ b/test/timex_test.exs
@@ -32,6 +32,13 @@ defmodule TimexTests do
     assert expected === result
   end
 
+  test "subtract milliseconds" do
+    time = Timex.to_datetime({{2015, 6, 24}, {14, 27, 52}})
+    time = %{time | microsecond: {910_000, 6}}
+    subtracted = Timex.subtract(time, Duration.from_milliseconds(10))
+    assert subtracted.microsecond === {900_000, 1}
+  end
+
   test "weekday" do
     localdate = {{2013,3,17},{11,59,10}}
     assert Timex.weekday(Timex.to_datetime(localdate)) === 7


### PR DESCRIPTION
Smaller durations (less than a second) where added instead of subtracted
