### PR TITLE
To datetime with timezone

### DIFF
--- a/lib/datetime/datetime.ex
+++ b/lib/datetime/datetime.ex
@@ -39,7 +39,7 @@ defimpl Timex.Protocol, for: DateTime do
   def to_date(date), do: DateTime.to_date(date)
 
   @spec to_datetime(DateTime.t, timezone :: Types.valid_timezone) :: DateTime.t | {:error, term}
-  def to_datetime(%DateTime{time_zone: time_zone} = d, timezone) when time_zone == timezone, do: d
+  def to_datetime(%DateTime{time_zone: timezone} = d, timezone), do: d
   def to_datetime(%DateTime{} = d, timezone), do: Timezone.convert(d, timezone)
 
   @spec to_naive_datetime(DateTime.t) :: NaiveDateTime.t

--- a/lib/datetime/datetime.ex
+++ b/lib/datetime/datetime.ex
@@ -39,7 +39,8 @@ defimpl Timex.Protocol, for: DateTime do
   def to_date(date), do: DateTime.to_date(date)
 
   @spec to_datetime(DateTime.t, timezone :: Types.valid_timezone) :: DateTime.t | {:error, term}
-  def to_datetime(%DateTime{} = d, _timezone), do: d
+  def to_datetime(%DateTime{time_zone: time_zone} = d, timezone) when time_zone == timezone, do: d
+  def to_datetime(%DateTime{} = d, timezone), do: Timex.Timezone.convert(d, timezone)
 
   @spec to_naive_datetime(DateTime.t) :: NaiveDateTime.t
   def to_naive_datetime(%DateTime{time_zone: nil} = d) do

--- a/lib/datetime/datetime.ex
+++ b/lib/datetime/datetime.ex
@@ -38,7 +38,7 @@ defimpl Timex.Protocol, for: DateTime do
   @spec to_date(DateTime.t) :: Date.t
   def to_date(date), do: DateTime.to_date(date)
 
-  @spec to_datetime(DateTime.t, timezone :: Types.valid_timezone) :: DateTime.t | {:error, term}
+  @spec to_datetime(DateTime.t, timezone :: Types.valid_timezone) :: DateTime.t | AmbiguousDateTime.t | {:error, term}
   def to_datetime(%DateTime{time_zone: timezone} = d, timezone), do: d
   def to_datetime(%DateTime{} = d, timezone), do: Timezone.convert(d, timezone)
 

--- a/lib/datetime/datetime.ex
+++ b/lib/datetime/datetime.ex
@@ -40,7 +40,7 @@ defimpl Timex.Protocol, for: DateTime do
 
   @spec to_datetime(DateTime.t, timezone :: Types.valid_timezone) :: DateTime.t | {:error, term}
   def to_datetime(%DateTime{time_zone: time_zone} = d, timezone) when time_zone == timezone, do: d
-  def to_datetime(%DateTime{} = d, timezone), do: Timex.Timezone.convert(d, timezone)
+  def to_datetime(%DateTime{} = d, timezone), do: Timezone.convert(d, timezone)
 
   @spec to_naive_datetime(DateTime.t) :: NaiveDateTime.t
   def to_naive_datetime(%DateTime{time_zone: nil} = d) do

--- a/test/conversion_test.exs
+++ b/test/conversion_test.exs
@@ -40,6 +40,11 @@ defmodule ConversionTests do
 
     datetime = Timex.to_datetime({{2015,2,28}, {12, 35, 1}}, "Etc/UTC")
     assert ^datetime = Timex.to_datetime(datetime, "Etc/UTC")
+
+    datetime_utc = Timex.to_datetime({{2015,2,28}, {12, 35, 1}}, "Etc/UTC")
+    datetime_berlin = Timex.to_datetime({{2015,2,28}, {13, 35, 1}}, "Europe/Berlin")
+
+    assert ^datetime_berlin = Timex.to_datetime(datetime_utc, "Europe/Berlin")
   end
 
   test "to_unix" do


### PR DESCRIPTION
This changes the behavior of `to_datetime` when called with a `DateTime` struct.

I'm writing an application that needs to convert datetimes to other timezones and I didn't know about `Timex.Timezone.convert/2`

I was surprised by the current behavior:

```elixir
iex(1)> Timex.to_datetime(Timex.now, "Europe/Berlin") 
#<DateTime(2016-10-11T16:05:08.439973Z Etc/UTC)>
```

I was even more surprised by:

```elixir
iex(2)> Timex.to_datetime(Timex.now, "Hello")        
#<DateTime(2016-10-11T16:05:45.608048Z Etc/UTC)>
```

I think the more logical thing to do is to convert the date if the timezone differs from the one in the `DateTime` struct.

What do you think? Is there something I am overlooking?