### PR TITLE
bump gettext version

### DIFF
--- a/lib/l10n/translator.ex
+++ b/lib/l10n/translator.ex
@@ -153,7 +153,7 @@ defmodule Timex.Translator do
 
   @spec get_domain_text(locale :: String.t, domain :: String.t, msgid :: String.t) :: String.t
   defp get_domain_text(locale, domain, msgid) do
-    case Timex.Gettext.lgettext(locale, domain, msgid) do
+    case Timex.Gettext.lgettext(locale, domain, msgid, %{}) do
       {:ok, translated}   -> translated
       {:default, default} -> default
     end

--- a/mix.lock
+++ b/mix.lock
@@ -6,7 +6,7 @@
   "ex_doc": {:hex, :ex_doc, "0.13.0", "aa2f8fe4c6136a2f7cfc0a7e06805f82530e91df00e2bff4b4362002b43ada65", [:mix], [{:earmark, "~> 1.0", [hex: :earmark, optional: false]}]},
   "excoveralls": {:hex, :excoveralls, "0.5.6", "35a903f6f78619ee7f951448dddfbef094b3a0d8581657afaf66465bc930468e", [:mix], [{:exjsx, "~> 3.0", [hex: :exjsx, optional: false]}, {:hackney, ">= 0.12.0", [hex: :hackney, optional: false]}]},
   "exjsx": {:hex, :exjsx, "3.2.0", "7136cc739ace295fc74c378f33699e5145bead4fdc1b4799822d0287489136fb", [:mix], [{:jsx, "~> 2.6.2", [hex: :jsx, optional: false]}]},
-  "gettext": {:hex, :gettext, "0.11.0", "80c1dd42d270482418fa158ec5ba073d2980e3718bacad86f3d4ad71d5667679", [:mix], []},
+  "gettext": {:hex, :gettext, "0.12.1", "c0624f52763469ef7a3674919ae28b8286d88195b90fa1516180f31bbbd26d14", [:mix], []},
   "hackney": {:hex, :hackney, "1.6.1", "ddd22d42db2b50e6a155439c8811b8f6df61a4395de10509714ad2751c6da817", [:rebar3], [{:certifi, "0.4.0", [hex: :certifi, optional: false]}, {:idna, "1.2.0", [hex: :idna, optional: false]}, {:metrics, "1.0.1", [hex: :metrics, optional: false]}, {:mimerl, "1.0.2", [hex: :mimerl, optional: false]}, {:ssl_verify_fun, "1.1.0", [hex: :ssl_verify_fun, optional: false]}]},
   "idna": {:hex, :idna, "1.2.0", "ac62ee99da068f43c50dc69acf700e03a62a348360126260e87f2b54eced86b2", [:rebar3], []},
   "jsx": {:hex, :jsx, "2.6.2", "213721e058da0587a4bce3cc8a00ff6684ced229c8f9223245c6ff2c88fbaa5a", [:mix, :rebar], []},

--- a/test/format_default_test.exs
+++ b/test/format_default_test.exs
@@ -456,6 +456,13 @@ defmodule DateFormatTest.FormatDefault do
     assert expected == formatted
   end
 
+  test "issue #228 - update of gettext causes exception" do
+    date = Timex.to_datetime({{2015,1,14},{12,0,0}}, "Etc/UTC")
+    formatted = Timex.format!(date, "{Mfull} {D} {YYYY}, {h12}:{m}{am}")
+    expected = "January 14 2015, 12:00pm"
+    assert expected == formatted
+  end
+
   defp format(date, fmt) do
     Timex.format(date, fmt)
   end


### PR DESCRIPTION
### Summary of changes

use `lgettext/4` instead of `lgettext/3`, since no bindings are needed an empty map does the trick.

fixes #228 

### Checklist

- [x] New functions have typespecs, changed functions were updated
- [x] Same for documentation, including moduledocs
- [x] Tests were added or updated to cover changes
- [x] Commits were squashed into a single coherent commit
