### PR TITLE
Fix typo in typespec for Timex.shift

### DIFF
--- a/lib/timex.ex
+++ b/lib/timex.ex
@@ -1413,7 +1413,7 @@ defmodule Timex do
     weeks: integer,
     years: integer
   ]
-  @spec shift(Types.valid_datetimes, shift_options) :: Types.valid_datetimes | {:error, term}
+  @spec shift(Types.valid_datetime, shift_options) :: Types.valid_datetime | {:error, term}
   defdelegate shift(date, options), to: Timex.Protocol
 
   @doc """


### PR DESCRIPTION
### Summary of changes

The typespec for `Timex.shift` used `Types.valid_datetimes` but the type defined there is `Types.valid_datetime`. This caused dialyzer to generate a warning in downstream projects.

Is there some reason why dialyzer is not part of the travis build? I could try to assemble a PR  adding that if you're interested.

