### PR TITLE
Fix shifting into December

### DIFF
--- a/lib/datetime/naivedatetime.ex
+++ b/lib/datetime/naivedatetime.ex
@@ -236,7 +236,7 @@ defimpl Timex.Protocol, for: NaiveDateTime do
   defp shift_by(%NaiveDateTime{:year => year, :month => month} = datetime, value, :months) do
     m = month + value
     shifted = cond do
-      m > 0  -> %{datetime | :year => year + div(m, 12), :month => rem(m, 12)}
+      m > 0  -> %{datetime | :year => year + div(m - 1, 12), :month => rem(m - 1, 12) + 1}
       m <= 0 -> %{datetime | :year => year + div(m, 12) - 1, :month => 12 + rem(m, 12)}
     end
 

--- a/test/shift_test.exs
+++ b/test/shift_test.exs
@@ -75,4 +75,9 @@ defmodule ShiftTests do
     assert expected === date
   end
 
+  test "shift by a month from November" do
+    date = Timex.shift(~D[2000-11-01], months: 1)
+    expected = ~D[2000-12-01]
+    assert expected === date
+  end
 end


### PR DESCRIPTION
### Summary of changes

When shifting into December the computation would set the month to 0 which in turn caused a crash:

```elixir
** (FunctionClauseError) no function clause matching in :calendar.last_day_of_the_month1/2
     stacktrace:
       (stdlib) calendar.erl:244: :calendar.last_day_of_the_month1(2001, 0)
       (timex) lib/datetime/naivedatetime.ex:248: Timex.Protocol.NaiveDateTime.shift_by/3
       (timex) lib/datetime/naivedatetime.ex:213: Timex.Protocol.NaiveDateTime.apply_shifts/2
       (timex) lib/date/date.ex:189: Timex.Protocol.Date.shift/2
       test/shift_test.exs:79: (test)
```