### PR TITLE
Add months to typespec for Timex.shift

### DIFF
--- a/lib/timex.ex
+++ b/lib/timex.ex
@@ -1411,6 +1411,7 @@ defmodule Timex do
     hours: integer,
     days: integer,
     weeks: integer,
+    months: integer,
     years: integer
   ]
   @spec shift(Types.valid_datetime, shift_options) :: Types.valid_datetime | {:error, term}


### PR DESCRIPTION
### Summary of changes

The option list typespec didn't allow months despite it clearly working. Sorry for not noticing this when I changed this earlier.


