### PR TITLE
fix @doc formatting

### DIFF
--- a/lib/format/duration/formatter.ex
+++ b/lib/format/duration/formatter.ex
@@ -39,9 +39,9 @@ defmodule Timex.Format.Duration.Formatter do
 
   ## Examples
 
-    iex> d = Timex.Duration.from_erl({1435, 180354, 590264})
-    ...> #{__MODULE__}.format(d, :humanized)
-    "45 years, 6 months, 5 days, 21 hours, 12 minutes, 34 seconds, 590.264 milliseconds"
+      iex> d = Timex.Duration.from_erl({1435, 180354, 590264})
+      ...> #{__MODULE__}.format(d, :humanized)
+      "45 years, 6 months, 5 days, 21 hours, 12 minutes, 34 seconds, 590.264 milliseconds"
   """
   @spec format(Duration.t, atom) :: String.t | {:error, term}
   def format(duration, formatter), do: lformat(duration, Translator.default_locale, formatter)

--- a/lib/time/time.ex
+++ b/lib/time/time.ex
@@ -8,8 +8,8 @@ defmodule Timex.Time do
 
   ## Examples
 
-  iex> Timex.Time.to_12hour_clock(23)
-  {11, :pm}
+      iex> Timex.Time.to_12hour_clock(23)
+      {11, :pm}
 
   """
   @spec to_12hour_clock(0..24) :: {1..12, :am | :pm}
@@ -27,8 +27,8 @@ defmodule Timex.Time do
 
   ## Examples
 
-  iex> Timex.Time.to_24hour_clock(7, :pm)
-  19
+      iex> Timex.Time.to_24hour_clock(7, :pm)
+      19
 
   """
   @spec to_24hour_clock(1..12, :am | :pm) :: 0..23

--- a/lib/timex.ex
+++ b/lib/timex.ex
@@ -452,8 +452,8 @@ defmodule Timex do
 
   ## Examples
 
-  iex> #{__MODULE__}.century
-  21
+      iex> #{__MODULE__}.century
+      21
 
   """
   @spec century() :: non_neg_integer
@@ -464,12 +464,12 @@ defmodule Timex do
 
   ## Examples
 
-  iex> Timex.today |> #{__MODULE__}.century
-  21
-  iex> Timex.now |> #{__MODULE__}.century
-  21
-  iex> #{__MODULE__}.century(2016)
-  21
+      iex> Timex.today |> #{__MODULE__}.century
+      21
+      iex> Timex.now |> #{__MODULE__}.century
+      21
+      iex> #{__MODULE__}.century(2016)
+      21
 
   """
   @spec century(Types.year | Types.valid_datetime) :: non_neg_integer
@@ -999,8 +999,8 @@ defmodule Timex do
 
   ## Examples
 
-  iex> Timex.epoch |> #{__MODULE__}.weekday
-  4 # (i.e. Thursday)
+      iex> Timex.epoch |> #{__MODULE__}.weekday
+      4 # (i.e. Thursday)
 
   """
   @spec weekday(Types.valid_datetime) :: Types.weekday | {:error, term}
@@ -1011,8 +1011,8 @@ defmodule Timex do
 
   ## Examples
 
-  iex> Timex.day(~D[2015-06-26])
-  177
+      iex> Timex.day(~D[2015-06-26])
+      177
   """
   @spec day(Types.valid_datetime) :: Types.daynum | {:error, term}
   defdelegate day(datetime), to: Timex.Protocol
@@ -1068,9 +1068,9 @@ defmodule Timex do
   @doc """
   Given a date returns a date at the beginning of the month.
 
-    iex> date = Timex.to_datetime({{2015, 6, 15}, {12,30,0}}, "Europe/Paris")
-    iex> Timex.beginning_of_month(date)
-    Timex.to_datetime({{2015, 6, 1}, {0, 0, 0}}, "Europe/Paris")
+      iex> date = Timex.to_datetime({{2015, 6, 15}, {12,30,0}}, "Europe/Paris")
+      iex> Timex.beginning_of_month(date)
+      Timex.to_datetime({{2015, 6, 1}, {0, 0, 0}}, "Europe/Paris")
 
   """
   @spec beginning_of_month(Types.valid_datetime) :: Types.valid_datetime | {:error, term}
@@ -1088,9 +1088,9 @@ defmodule Timex do
   @doc """
   Given a date returns a date at the end of the month.
 
-    iex> date = ~N[2015-06-15T12:30:00Z]
-    iex> Timex.end_of_month(date)
-    ~N[2015-06-30T23:59:59.999999Z]
+      iex> date = ~N[2015-06-15T12:30:00Z]
+      iex> Timex.end_of_month(date)
+      ~N[2015-06-30T23:59:59.999999Z]
 
   """
   @spec end_of_month(Types.valid_datetime) :: Types.valid_datetime | {:error, term}
@@ -1133,9 +1133,9 @@ defmodule Timex do
   @doc """
   Given a date returns a date at the beginning of the quarter.
 
-    iex> date = Timex.to_datetime({{2015, 6, 15}, {12,30,0}}, "America/Chicago")
-    iex> Timex.beginning_of_quarter(date)
-    Timex.to_datetime({{2015, 4, 1}, {0, 0, 0}}, "America/Chicago")
+      iex> date = Timex.to_datetime({{2015, 6, 15}, {12,30,0}}, "America/Chicago")
+      iex> Timex.beginning_of_quarter(date)
+      Timex.to_datetime({{2015, 4, 1}, {0, 0, 0}}, "America/Chicago")
 
   """
   @spec beginning_of_quarter(Types.valid_datetime) :: Types.valid_datetime | {:error, term}
@@ -1144,12 +1144,12 @@ defmodule Timex do
   @doc """
   Given a date or a year and month returns a date at the end of the quarter.
 
-    iex> date = ~N[2015-06-15T12:30:00]
-    ...> Timex.end_of_quarter(date)
-    ~N[2015-06-30T23:59:59.999999]
+      iex> date = ~N[2015-06-15T12:30:00]
+      ...> Timex.end_of_quarter(date)
+      ~N[2015-06-30T23:59:59.999999]
 
-    iex> Timex.end_of_quarter(2015, 4)
-    ~D[2015-06-30]
+      iex> Timex.end_of_quarter(2015, 4)
+      ~D[2015-06-30]
 
   """
   @spec end_of_quarter(Types.valid_datetime) :: Types.valid_datetime | {:error, term}

--- a/mix.lock
+++ b/mix.lock
@@ -12,5 +12,5 @@
   "jsx": {:hex, :jsx, "2.8.0", "749bec6d205c694ae1786d62cea6cc45a390437e24835fd16d12d74f07097727", [:mix, :rebar], []},
   "metrics": {:hex, :metrics, "1.0.1", "25f094dea2cda98213cecc3aeff09e940299d950904393b2a29d191c346a8486", [:rebar3], []},
   "mimerl": {:hex, :mimerl, "1.0.2", "993f9b0e084083405ed8252b99460c4f0563e41729ab42d9074fd5e52439be88", [:rebar3], []},
-  "ssl_verify_fun": {:hex, :ssl_verify_fun, "1.1.1", "28a4d65b7f59893bc2c7de786dec1e1555bd742d336043fe644ae956c3497fbe", [:rebar, :make], []},
-  "tzdata": {:hex, :tzdata, "0.5.9", "575be217b039057a47e133b72838cbe104fb5329b19906ea4e66857001c37edb", [], [{:hackney, "~> 1.0", [hex: :hackney, optional: false]}]}}
+  "ssl_verify_fun": {:hex, :ssl_verify_fun, "1.1.1", "28a4d65b7f59893bc2c7de786dec1e1555bd742d336043fe644ae956c3497fbe", [:make, :rebar], []},
+  "tzdata": {:hex, :tzdata, "0.5.9", "575be217b039057a47e133b72838cbe104fb5329b19906ea4e66857001c37edb", [:mix], [{:hackney, "~> 1.0", [hex: :hackney, optional: false]}]}}


### PR DESCRIPTION
### Summary of changes

Changed spacing so the doc formatting looks good in `mix docs` generation.

### Checklist

- [ ] New functions have typespecs, changed functions were updated
- [x] Same for documentation, including moduledocs
- [ ] Tests were added or updated to cover changes
- [x] Commits were squashed into a single coherent commit
