### PR TITLE
Fix default granularity from :seconds to :microseconds in docs

### DIFF
--- a/lib/comparable/comparable.ex
+++ b/lib/comparable/comparable.ex
@@ -30,7 +30,7 @@ defprotocol Timex.Comparable do
   - :duration
 
   and the dates will be compared with the cooresponding accuracy.
-  The default granularity is :seconds.
+  The default granularity is :microseconds.
 
     - 0:  when equal
     - -1: when the first date/time comes before the second

--- a/lib/timex.ex
+++ b/lib/timex.ex
@@ -803,7 +803,7 @@ defmodule Timex do
   - :timestamp
 
   and the dates will be compared with the cooresponding accuracy.
-  The default granularity is :seconds.
+  The default granularity is :microseconds.
 
   ## Examples
 


### PR DESCRIPTION
According to https://github.com/bitwalker/timex/blob/f41b008352f1a3a5ee7c6d50b3520769f9d102c3/lib/comparable/comparable.ex#L43