### PR TITLE
Fix from_iso_triplet logic

### DIFF
--- a/lib/timex/macros.ex
+++ b/lib/timex/macros.ex
@@ -242,6 +242,67 @@ defmodule Timex.Macros do
   end
 
   @doc """
+  A guard macro which asserts that the given value is a valid iso day for the given year.
+  For a leap year this would be in the range of 1-366. For a regular year this would be
+  in the range of 1-365.
+
+  ## Examples
+
+      iex> import Timex.Macros
+      ...> is_iso_day_of_year(2001, 1)
+      true
+
+      iex> import Timex.Macros
+      ...> is_iso_day_of_year(2001, 0)
+      false
+
+      iex> import Timex.Macros
+      ...> is_iso_day_of_year(2012, 366)
+      true
+
+      iex> import Timex.Macros
+      ...> is_iso_day_of_year(2011, 366)
+      false
+
+      iex> import Timex.Macros
+      ...> is_iso_day_of_year(2012, 367)
+      false
+  """
+  defmacro is_iso_day_of_year(y, d) do
+    quote do
+      is_integer_in_range(unquote(d), 1, 365) or
+      (unquote(d) == 366 and is_leap_year(unquote(y)))
+    end
+  end
+
+  @doc """
+  A guard macro which returns true if the given value is a leap year
+
+  ## Examples
+
+      iex> import Timex.Macros
+      ...> is_leap_year(2001)
+      false
+
+      iex> import Timex.Macros
+      ...> is_leap_year(2000)
+      true
+
+      iex> import Timex.Macros
+      ...> is_leap_year(2004)
+      true
+
+      iex> import Timex.Macros
+      ...> is_leap_year(1900)
+      false
+  """
+  defmacro is_leap_year(y) do
+    quote do
+      (rem(unquote(y), 4) == 0 and rem(unquote(y), 100) != 0) or rem(unquote(y), 400) == 0
+    end
+  end
+
+  @doc """
   A guard macro which asserts that the given value is an integer in the range of 1-53
   """
   defmacro is_week_of_year(w) do

--- a/test/helpers_test.exs
+++ b/test/helpers_test.exs
@@ -21,4 +21,55 @@ defmodule HelpersTests do
     assert 3 = Helpers.round_month(3)
     assert 11 = Helpers.round_month(-1)
   end
+
+  describe ".iso_day_to_date_tuple" do
+    test "last day of year is beginning of iso week" do
+      assert {2007, 12, 31} === Helpers.iso_day_to_date_tuple(2007, 365)
+    end
+    test "last day of leap year is beginning of iso week" do
+      assert {2040, 12, 31} === Helpers.iso_day_to_date_tuple(2040, 366)
+    end
+    test "last day of year is iso day 365 and end of iso week" do
+      assert {2027, 12, 31} === Helpers.iso_day_to_date_tuple(2027, 365)
+    end
+    test "last day of leap year is iso day 366 and end of iso week" do
+      assert {2028, 12, 31} === Helpers.iso_day_to_date_tuple(2028, 366)
+    end
+
+    test "first day of year is iso day 1 and beginning of iso week" do
+      assert {2001, 1, 1} === Helpers.iso_day_to_date_tuple(2001, 1)
+    end
+    test "first day of leap year is iso day 1 and beginning of iso week" do
+      assert {2024, 1, 1} === Helpers.iso_day_to_date_tuple(2024, 1)
+    end
+    test "first day of year is iso day 1 and end of iso week" do
+      assert {2023, 1, 1} === Helpers.iso_day_to_date_tuple(2023, 1)
+    end
+    test "first day of leap year is iso day 1 and end of iso week" do
+      assert {2012, 1, 1} === Helpers.iso_day_to_date_tuple(2012, 1)
+    end
+
+    test "first day of iso week is leap day" do
+      assert {2016, 2, 29} === Helpers.iso_day_to_date_tuple(2016, 60)
+    end
+    test "last day of iso week is leap day" do
+      assert {2032, 2, 29} === Helpers.iso_day_to_date_tuple(2032, 60)
+    end
+
+    test "iso day 0 is an invalid day" do
+      assert {:error, :invalid_day} === Helpers.iso_day_to_date_tuple(1, 0)
+    end
+    test "iso day 367 is an invalid day" do
+      assert {:error, :invalid_day} === Helpers.iso_day_to_date_tuple(1, 367)
+    end
+    test "year -1 is an invalid year" do
+      assert {:error, :invalid_year} === Helpers.iso_day_to_date_tuple(-1, 1)
+    end
+    test "year -1 and day 0 is an invalid day and year" do
+      assert {:error, :invalid_year_and_day} === Helpers.iso_day_to_date_tuple(-1, 0)
+    end
+    test "day that is valid on leap year that isn't on regular year is invalid" do
+      assert {:error, :invalid_day} === Helpers.iso_day_to_date_tuple(1, 366)
+    end
+  end
 end

--- a/test/timex_test.exs
+++ b/test/timex_test.exs
@@ -71,6 +71,30 @@ defmodule TimexTests do
     assert Timex.iso_triplet(Timex.epoch()) === {1970,1,4}
   end
 
+  describe "from_iso_triplet" do
+    test "first day of first iso week is first day of the year" do
+      assert Timex.from_iso_triplet({2001, 1, 1}) === Timex.to_date({2001, 1, 1})
+    end
+    test "first iso week includes the maximum number of days from the previous year" do
+      assert Timex.from_iso_triplet({2004, 1, 1}) === Timex.to_date({2003, 12, 29})
+    end
+    test "last iso week includes the maximum number of days in the next year" do
+      assert Timex.from_iso_triplet({2026, 53, 7}) === Timex.to_date({2027, 1, 3})
+    end
+    test "last iso week of leap year includes the maximum number of days in the next year" do
+      assert Timex.from_iso_triplet({2020, 53, 7}) === Timex.to_date({2021, 1, 3})
+    end
+    test "iso week that includes a leap day" do
+      assert Timex.from_iso_triplet({2000, 9, 2}) === Timex.to_date({2000, 2, 29})
+    end
+    test "first iso week starts on the last day of the year" do
+      assert Timex.from_iso_triplet({2013, 1, 1}) === Timex.to_date({2012, 12, 31})
+    end
+    test "last day of last iso week ends on last day of the year" do
+      assert Timex.from_iso_triplet({2028, 52, 7}) == Timex.to_date({2028, 12, 31})
+    end
+  end
+
   test "days_in_month" do
     localdate = {{2013,2,17},{11,59,10}}
     assert Timex.days_in_month(Timex.to_datetime(localdate)) === 28


### PR DESCRIPTION
Shoutout to https://github.com/ericworkman who paired with me on all of this.

When implementing a feature that used `from_iso_triplet` to get the first day of an iso week, a case was found around the boundary of the year where `from_iso_triplet` generated a match error when it called `iso_day_to_date_tuple`. This is because before `from_iso_triplet` calls this method it calculates an offset for the day, which it then adds to the day, which can result in a day that is < 1 or greater than > 366. `iso_day_to_date_tuple`'s guard clause prohibits such days.

The fix to that problem was to make a conversion from ordinal_day after the offset has been applied to iso day, accounting for all situations where the ordinal_day crosses the year boundary (taking into account leap years).

In the process of implementing this fix, a bug was found in the implementation of `iso_day_to_date_tuple` that resulted in wrong resulting dates. Tests around all boundaries were added and ultimately, it was determined that the guard clause should be tighter to account for leap and non-leap years. So a day of 366 is no longer a valid input to `iso_day_to_date_tuple` if the year is a non-leap year, but it is if the year is a leap year.

Guard macros for `is_leap_year` and `is_iso_day_of_year` were added to deal with this, and ultimately should be good utility functions for the public Timex API. 

from_iso_triplet now works for dates that cross year boundaries.

The updated `iso_day_to_date_tuple` method now errors with error tuples
for invalid days (< 1 or > 366, depending on leap years) rather than
match errors, so the input to that function needs to be controlled more
tightly. An ordinal date to year and iso_day conversion step was added to
ensure this. When the day or year is invalid for `iso_day_to_date_tuple`, an appropriate error tuple is now returned rather than simple a match error that is less than informative. I tried to match the surrounding style of error tuples, but please let me know if you think they should be more specific (perhaps indicating by which direction the day or year is invalid).

Of note, I think that the `iso_day_to_date_tuple` function might not belong in Helpers any longer, as it could be a useful function for the public Timex API, and its certainly robust enough now.  That said, I think that's a decision for a separate PR.

Single Commit:

Add test cases around iso_day_to_date_tuple

Add is_leap_year guard macro

Add is_iso_day_of_year guard macro

Change iso_day_to_date_tuple guard clause to use is_iso_day_of_year
instead of is_day_of_year to more correctly bound possible matched input
values. This allows the removal of the first cond in
iso_day_to_date_tuple.

Add error tuples to iso_day_to_date_tuple for days and years which are
invalid.

### Summary of changes

I'll review the commits, so I mostly want to understand the "why" rather than the "what"

### Checklist

- [x] New functions have typespecs, changed functions were updated
- [x] Same for documentation, including moduledocs
- [x] Tests were added or updated to cover changes
- [x] Commits were squashed into a single coherent commit
