### PR TITLE
correct Russian translations

### DIFF
--- a/lib/format/duration/formatters/humanized.ex
+++ b/lib/format/duration/formatters/humanized.ex
@@ -47,11 +47,11 @@ defmodule Timex.Format.Duration.Formatters.Humanized do
 
       iex> use Timex
       ...> Duration.from_erl({0, 65, 0}) |> #{__MODULE__}.lformat("ru")
-      "1 минута  5 секунды"
+      "1 минута  5 секунд"
 
       iex> use Timex
       ...> Duration.from_erl({1435, 180354, 590264}) |> #{__MODULE__}.lformat("ru")
-      "45 года  6 месяца  5 днем  21 час  12 минуты  34 секунды  590.264 миллисекунды"
+      "45 лет  6 месяцев  5 дней  21 час  12 минут  34 секунды  590.264 миллисекунд"
 
   """
   @spec lformat(Duration.t, String.t) :: String.t | {:error, term}

--- a/lib/l10n/translator.ex
+++ b/lib/l10n/translator.ex
@@ -41,7 +41,7 @@ defmodule Timex.Translator do
   ## Examples
 
       iex> Timex.Translator.translate_plural("ru", "relative_time", "in %{count} second", "in %{count} seconds", 5)
-      "через 5 секунды"
+      "через 5 секунд"
 
       iex> Timex.Translator.translate_plural("it", "relative_time", "in %{count} second", "in %{count} seconds", 5)
       "in 5 secondi"

--- a/priv/translations/ru/LC_MESSAGES/months.po
+++ b/priv/translations/ru/LC_MESSAGES/months.po
@@ -21,7 +21,7 @@ msgstr ""
 
 #: lib/l10n/translator.ex:220
 msgid "April"
-msgstr "апрель"
+msgstr "апреля"
 
 #: lib/l10n/translator.ex:224
 msgid "August"

--- a/priv/translations/ru/LC_MESSAGES/relative_time.po
+++ b/priv/translations/ru/LC_MESSAGES/relative_time.po
@@ -73,55 +73,55 @@ msgid "%{count} day ago"
 msgid_plural "%{count} days ago"
 msgstr[0] "%{count} день назад"
 msgstr[1] "%{count} дня назад"
-msgstr[2] "%{count} дня назад"
+msgstr[2] "%{count} дней назад"
 
 #: lib/l10n/translator.ex:278
 msgid "%{count} hour ago"
 msgid_plural "%{count} hours ago"
 msgstr[0] "%{count} час назад"
 msgstr[1] "%{count} часа назад"
-msgstr[2] "%{count} часа назад"
+msgstr[2] "%{count} часов назад"
 
 #: lib/l10n/translator.ex:281
 msgid "%{count} minute ago"
 msgid_plural "%{count} minutes ago"
 msgstr[0] "%{count} минуту назад"
 msgstr[1] "%{count} минуты назад"
-msgstr[2] "%{count} минуты назад"
+msgstr[2] "%{count} минут назад"
 
 #: lib/l10n/translator.ex:241
 msgid "%{count} month ago"
 msgid_plural "%{count} months ago"
 msgstr[0] "%{count} месяц назад"
 msgstr[1] "%{count} месяца назад"
-msgstr[2] "%{count} месяца назад"
+msgstr[2] "%{count} месяцев назад"
 
 #: lib/l10n/translator.ex:284
 msgid "%{count} second ago"
 msgid_plural "%{count} seconds ago"
 msgstr[0] "%{count} секунду назад"
 msgstr[1] "%{count} секунды назад"
-msgstr[2] "%{count} секунды назад"
+msgstr[2] "%{count} секунд назад"
 
 #: lib/l10n/translator.ex:247
 msgid "%{count} week ago"
 msgid_plural "%{count} weeks ago"
 msgstr[0] "%{count} неделю назад"
 msgstr[1] "%{count} недели назад"
-msgstr[2] "%{count} недели назад"
+msgstr[2] "%{count} недель назад"
 
 #: lib/l10n/translator.ex:235
 msgid "%{count} year ago"
 msgid_plural "%{count} years ago"
 msgstr[0] "%{count} год назад"
 msgstr[1] "%{count} года назад"
-msgstr[2] "%{count} года назад"
+msgstr[2] "%{count} лет назад"
 
 #: lib/l10n/translator.ex:252
 msgid "in %{count} day"
 msgid_plural "in %{count} days"
 msgstr[0] "через %{count} день"
-msgstr[1] "через %{count} дней"
+msgstr[1] "через %{count} дня"
 msgstr[2] "через %{count} дней"
 
 #: lib/l10n/translator.ex:277
@@ -129,42 +129,42 @@ msgid "in %{count} hour"
 msgid_plural "in %{count} hours"
 msgstr[0] "через %{count} час"
 msgstr[1] "через %{count} часа"
-msgstr[2] "через %{count} часа"
+msgstr[2] "через %{count} часов"
 
 #: lib/l10n/translator.ex:280
 msgid "in %{count} minute"
 msgid_plural "in %{count} minutes"
 msgstr[0] "через %{count} минуту"
 msgstr[1] "через %{count} минуты"
-msgstr[2] "через %{count} минуты"
+msgstr[2] "через %{count} минут"
 
 #: lib/l10n/translator.ex:240
 msgid "in %{count} month"
 msgid_plural "in %{count} months"
 msgstr[0] "через %{count} месяц"
 msgstr[1] "через %{count} месяца"
-msgstr[2] "через %{count} месяца"
+msgstr[2] "через %{count} месяцев"
 
 #: lib/l10n/translator.ex:283
 msgid "in %{count} second"
 msgid_plural "in %{count} seconds"
 msgstr[0] "через %{count} секунду"
 msgstr[1] "через %{count} секунды"
-msgstr[2] "через %{count} секунды"
+msgstr[2] "через %{count} секунд"
 
 #: lib/l10n/translator.ex:246
 msgid "in %{count} week"
 msgid_plural "in %{count} weeks"
 msgstr[0] "через %{count} неделю"
 msgstr[1] "через %{count} недели"
-msgstr[2] "через %{count} недели"
+msgstr[2] "через %{count} недель"
 
 #: lib/l10n/translator.ex:234
 msgid "in %{count} year"
 msgid_plural "in %{count} years"
 msgstr[0] "через %{count} год"
 msgstr[1] "через %{count} года"
-msgstr[2] "через %{count} года"
+msgstr[2] "через %{count} лет"
 
 #: lib/l10n/translator.ex:267
 msgid "last friday"

--- a/priv/translations/ru/LC_MESSAGES/units.po
+++ b/priv/translations/ru/LC_MESSAGES/units.po
@@ -24,68 +24,68 @@ msgstr ""
 msgid "%{count} day"
 msgid_plural "%{count} days"
 msgstr[0] "%{count} день"
-msgstr[1] "%{count} днем"
-msgstr[2] "%{count} днем"
+msgstr[1] "%{count} дня"
+msgstr[2] "%{count} дней"
 
 #: lib/l10n/translator.ex:177
 msgid "%{count} hour"
 msgid_plural "%{count} hours"
 msgstr[0] "%{count} час"
 msgstr[1] "%{count} часа"
-msgstr[2] "%{count} часа"
+msgstr[2] "%{count} часов"
 
 #: lib/l10n/translator.ex:173
 msgid "%{count} microsecond"
 msgid_plural "%{count} microseconds"
 msgstr[0] "%{count} микросекунда"
 msgstr[1] "%{count} микросекунды"
-msgstr[2] "%{count} микросекунды"
+msgstr[2] "%{count} микросекунд"
 
 #: lib/l10n/translator.ex:174
 msgid "%{count} millisecond"
 msgid_plural "%{count} milliseconds"
 msgstr[0] "%{count} миллисекунда"
 msgstr[1] "%{count} миллисекунды"
-msgstr[2] "%{count} миллисекунды"
+msgstr[2] "%{count} миллисекунд"
 
 #: lib/l10n/translator.ex:176
 msgid "%{count} minute"
 msgid_plural "%{count} minutes"
 msgstr[0] "%{count} минута"
 msgstr[1] "%{count} минуты"
-msgstr[2] "%{count} минуты"
+msgstr[2] "%{count} минут"
 
 #: lib/l10n/translator.ex:180
 msgid "%{count} month"
 msgid_plural "%{count} months"
 msgstr[0] "%{count} месяц"
 msgstr[1] "%{count} месяца"
-msgstr[2] "%{count} месяца"
+msgstr[2] "%{count} месяцев"
 
 #: lib/l10n/translator.ex:172
 msgid "%{count} nanosecond"
 msgid_plural "%{count} nanoseconds"
 msgstr[0] "%{count} наносекунда"
 msgstr[1] "%{count} наносекунды"
-msgstr[2] "%{count} наносекунды"
+msgstr[2] "%{count} наносекунд"
 
 #: lib/l10n/translator.ex:175
 msgid "%{count} second"
 msgid_plural "%{count} seconds"
 msgstr[0] "%{count} секунда"
 msgstr[1] "%{count} секунды"
-msgstr[2] "%{count} секунды"
+msgstr[2] "%{count} секунд"
 
 #: lib/l10n/translator.ex:179
 msgid "%{count} week"
 msgid_plural "%{count} weeks"
 msgstr[0] "%{count} неделя"
 msgstr[1] "%{count} недели"
-msgstr[2] "%{count} недели"
+msgstr[2] "%{count} недель"
 
 #: lib/l10n/translator.ex:181
 msgid "%{count} year"
 msgid_plural "%{count} years"
 msgstr[0] "%{count} год"
 msgstr[1] "%{count} года"
-msgstr[2] "%{count} года"
+msgstr[2] "%{count} лет"


### PR DESCRIPTION
### Summary of changes

The Russian plurals have been corrected for both units of measures and relative times. Also, in its full form April was in the accusative case instead of genitive like all other months. The associated documentation/tests have been corrected accordingly.

### Checklist

- [*] New functions have typespecs, changed functions were updated
- [*] Same for documentation, including moduledocs
- [*] Tests were added or updated to cover changes
- [*] Commits were squashed into a single coherent commit
