### PR TITLE
Fix converting a map without microseconds

### DIFF
--- a/lib/convert/convert.ex
+++ b/lib/convert/convert.ex
@@ -22,7 +22,7 @@ defmodule Timex.Convert do
               hour ->
                 minute = Map.get(datetime_map, :minute, 0)
                 second = Map.get(datetime_map, :second, 0)
-                us     = Map.get(datetime_map, :microsecond, {0, 0})
+                us     = Map.get(datetime_map, :microsecond, 0)
                 tz     = Map.get(datetime_map, :time_zone, nil)
                 case tz do
                   s when is_binary(s) ->

--- a/test/conversion_test.exs
+++ b/test/conversion_test.exs
@@ -82,4 +82,14 @@ defmodule ConversionTests do
     assert 0 == Timex.to_unix({{1970,1,1}, {0,0,0}})
   end
 
+
+  ## Map conversions
+
+  test "map with timezone to_datetime" do
+    datetime = %{"year" => "2015", "month" => "2",
+      "day" => "28", "hour" => "13", "minute" => "37",
+      "time_zone" => "Europe/Copenhagen"}
+    |> Timex.Convert.convert_map
+    assert ^datetime = Timex.to_datetime(~N[2015-02-28T13:37:00], "Europe/Copenhagen")
+  end
 end


### PR DESCRIPTION
### Summary of changes

I have a model with a `Timex.Ecto.DateTimeWithTimezone` field and a map from Phoenix' `datetime_select`:
```elixir
%{"day" => "6", "hour" => "06", "minute" => "00", "month" => "2", "year" => "2017"}
```
This can be cast just fine to the field.
I add a `time_zone` value to that map:
```elixir
%{"day" => "6", "hour" => "06", "minute" => "00", "month" => "2", "year" => "2017",
"time_zone" => "Europe/Copenhagen"}
```
Casting this to the field fails with
```
** (FunctionClauseError) no function clause matching in Timex.DateTime.Helpers.precision/1
         (timex) lib/datetime/helpers.ex:63: Timex.DateTime.Helpers.precision({0, 0})
         (timex) lib/datetime/helpers.ex:61: Timex.DateTime.Helpers.construct_microseconds/1
         (timex) lib/datetime/helpers.ex:41: Timex.DateTime.Helpers.construct/2
         (timex) lib/datetime/map.ex:34: Timex.Protocol.Map.to_datetime/2
    (timex_ecto) lib/types/datetimetz.ex:110: Timex.Ecto.DateTimeWithTimezone.cast/1
```

The error happens because of the interaction between the default value for microseconds in `Timex.Convert.convert_map` and the `Timex.DateTime.Helpers.Construct_microseconds` function.

I have fixed it by changing the default value. It could also be fixed by changing the helper function to allow an already tupled microseconds value.

I added a test that fails before applying this fix and passes after. I'm not sure if the test is placed correctly though.

### Checklist

- [X] Tests were added or updated to cover changes
- [X] Commits were squashed into a single coherent commit