### PR TITLE
Correct return type on Timex.diff

### DIFF
--- a/lib/timex.ex
+++ b/lib/timex.ex
@@ -869,7 +869,7 @@ defmodule Timex do
   and the result will be an integer value of those units or a Duration.
   """
   @spec diff(Comparable.comparable, Comparable.comparable, Comparable.granularity) ::
-    Duration.t | non_neg_integer | {:error, term}
+    Duration.t | integer | {:error, term}
   defdelegate diff(a, b, granularity), to: Timex.Comparable
 
   @doc """


### PR DESCRIPTION
### Summary of changes

The typespec of `Timex.diff` doesn't match the implementation, and the implementation seems correct. Furthermore the typespec differs between `Timex.diff` and `Timex.Comparable.diff`, the latter appearing correct typespec and furthermore being the implementation used by `Timex.diff`.

This causes issues with dialyzer in projects that depend on `diff` potentially being negative.

Take the following example:

```elixir
iex> past = ~D[2017-01-01]
iex> future = ~D[2017-03-01]
iex> Timex.diff(past, future, :days)
-59
```

### Checklist

- [x] New functions have typespecs, changed functions were updated
- [x] Same for documentation, including moduledocs
- ~[ ] Tests were added or updated to cover changes~
- [x] Commits were squashed into a single coherent commit
