### PR TITLE
Improved implementation of calculating diff in months and years

### DIFF
--- a/test/comparable_test.exs
+++ b/test/comparable_test.exs
@@ -36,10 +36,13 @@ defmodule ComparableTests do
   end
 
   test "calculate difference in months" do
-    assert   0 == Comparable.diff({2017,4,30}, {2017,3,31}, :months)
-    assert   1 == Comparable.diff({2017,4,30}, {2017,3,30}, :months)
-    assert  12 == Comparable.diff({2017,5, 1}, {2016,4,30}, :months)
-    assert -12 == Comparable.diff({2016,4,30}, {2017,5, 1}, :months)
+    assert   0 == Comparable.diff({2017, 4,30}, {2017, 3,31}, :months)
+    assert   1 == Comparable.diff({2017, 4,30}, {2017, 3,30}, :months)
+    assert   1 == Comparable.diff({2017, 1, 1}, {2016,12, 1}, :months)
+    assert  -2 == Comparable.diff({2015,12,29}, {2016, 2,29}, :months)
+    assert   2 == Comparable.diff({2016, 3,28}, {2015,12,29}, :months)
+    assert  12 == Comparable.diff({2017, 5, 1}, {2016, 4,30}, :months)
+    assert -12 == Comparable.diff({2016, 4,30}, {2017, 5, 1}, :months)
   end
 
   test "calculate difference in years" do
@@ -47,4 +50,5 @@ defmodule ComparableTests do
     assert   0 == Comparable.diff({2017,4, 10}, {2016,4,15}, :years)
     assert  -1 == Comparable.diff({2015,2, 28}, {2016,2,28}, :years)
   end
+
 end

--- a/test/comparable_test.exs
+++ b/test/comparable_test.exs
@@ -34,4 +34,17 @@ defmodule ComparableTests do
     assert 0 = Comparable.compare(lmt_jwst, lmt_jwst)
     assert {:error, {:ambiguous_comparison, _}} = Comparable.compare(lmt_jwst, Timex.to_naive_datetime({2015, 1, 1}))
   end
+
+  test "calculate difference in months" do
+    assert   0 == Comparable.diff({2017,4,30}, {2017,3,31}, :months)
+    assert   1 == Comparable.diff({2017,4,30}, {2017,3,30}, :months)
+    assert  12 == Comparable.diff({2017,5, 1}, {2016,4,30}, :months)
+    assert -12 == Comparable.diff({2016,4,30}, {2017,5, 1}, :months)
+  end
+
+  test "calculate difference in years" do
+    assert   1 == Comparable.diff({2017,3,  1}, {2016,2,29}, :years)
+    assert   0 == Comparable.diff({2017,4, 10}, {2016,4,15}, :years)
+    assert  -1 == Comparable.diff({2015,2, 28}, {2016,2,28}, :years)
+  end
 end


### PR DESCRIPTION
The fix in calculating the diff in months as a reply to the corner case mentioned in issue #271 introduces a new "bug" in calculating the diff in years, namely a year is not the same as 12 months of 30 days.

So for example the diff of {2017, 4, 10} and {2016, 4, 15} is five days less than a year and should therefor not result in 1.