### PR TITLE
Take open and closed ends of Interval into consideration when checking membership

### DIFF
--- a/lib/interval/interval.ex
+++ b/lib/interval/interval.ex
@@ -194,15 +194,20 @@ defmodule Timex.Interval do
       do_reduce({get_starting_date(interval), interval.until, interval.right_open, interval.step}, acc, fun)
     end
 
-    def member?(%Timex.Interval{from: from, until: until}, value) do
-      # Just tests for set membership (date is within the provided (inclusive) range)
+    def member?(%Timex.Interval{} = interval, value) do
       result = cond do
-        Timex.compare(value, from) < 1  -> false
-        Timex.compare(value, until) > 0 -> false
+        before?(interval, value) -> false
+        after?(interval, value) -> false
         :else -> true
       end
       {:ok, result}
     end
+
+    defp before?(%Timex.Interval{from: from, left_open: true}, value), do: Timex.compare(value, from) <= 0
+    defp before?(%Timex.Interval{from: from, left_open: false}, value), do: Timex.compare(value, from) < 0
+
+    defp after?(%Timex.Interval{until: until, right_open: true}, value), do: Timex.compare(value, until) >= 0
+    defp after?(%Timex.Interval{until: until, right_open: false}, value), do: Timex.compare(value, until) > 0
 
     def count(_interval) do
       {:error, __MODULE__}

--- a/test/interval_test.exs
+++ b/test/interval_test.exs
@@ -39,4 +39,31 @@ defmodule IntervalTests do
                |> Interval.duration(:duration)
     assert Duration.from_minutes(20) == duration
   end
+
+  describe "member" do
+    test "membership includes start date" do
+      interval = Interval.new(from: ~D[2014-09-22], until: [days: 3])
+      assert ~D[2014-09-22] in interval
+    end
+
+    test "membership does not include end date" do
+      interval = Interval.new(from: ~D[2014-09-22], until: [days: 3])
+      refute ~D[2014-09-25] in interval
+    end
+
+    test "can exclude start date from membership" do
+      interval = Interval.new(from: ~D[2014-09-22], until: [days: 3], left_open: true)
+      refute ~D[2014-09-22] in interval
+    end
+
+    test "can include end date in membership" do
+      interval = Interval.new(from: ~D[2014-09-22], until: [days: 3], right_open: false)
+      assert ~D[2014-09-25] in interval
+    end
+
+    test "open and closed interval" do
+      interval = Interval.new(from: ~D[2014-09-22], until: ~D[2014-09-22])
+      refute ~D[2014-09-22] in interval
+    end
+  end
 end

--- a/test/interval_test.exs
+++ b/test/interval_test.exs
@@ -11,16 +11,16 @@ defmodule IntervalTests do
     assert ["2014-09-22", "2014-09-23", "2014-09-24"] == dates
   end
 
-  test "can exclude end date" do
-    dates = Interval.new(from: ~D[2014-09-22], until: [days: 3], left_open: false, right_open: false)
+  test "can include end date" do
+    dates = Interval.new(from: ~D[2014-09-22], until: [days: 3], right_open: false)
             |> Enum.map(&(Timex.format!(&1, "%Y-%m-%d", :strftime)))
     assert ["2014-09-22", "2014-09-23", "2014-09-24", "2014-09-25"] == dates
   end
 
   test "can exclude start date" do
-    dates = Interval.new(from: ~D[2014-09-22], until: [days: 3], left_open: true, right_open: false)
+    dates = Interval.new(from: ~D[2014-09-22], until: [days: 3], left_open: true)
             |> Enum.map(&(Timex.format!(&1, "%Y-%m-%d", :strftime)))
-    assert ["2014-09-23", "2014-09-24", "2014-09-25"] == dates
+    assert ["2014-09-23", "2014-09-24"] == dates
   end
 
   test "can enumerate by other units in an interval" do


### PR DESCRIPTION
### Summary of changes

The Interval `member?` does not take into consideration the open and closed ends (`left_open` and `right_open` fields). On top of that, the current implementation excludes the left end of the interval despite including the right end (this is the opposite of the defaults).
 
```elixir
iex(1)> ~D[2017-03-24] in Timex.Interval.new(from: ~D[2017-03-24], until: ~D[2017-03-26])
false
iex(2)> ~D[2017-03-26] in Timex.Interval.new(from: ~D[2017-03-24], until: ~D[2017-03-26])
true
iex(5)> ~D[2017-03-26] in Timex.Interval.new(from: ~D[2017-03-24], until: ~D[2017-03-26], right_open: true)
true
```

This changes the implementation to take the right and left ends into consideration when checking membership.

### Checklist

- [ ] New functions have typespecs, changed functions were updated
- [ ] Same for documentation, including moduledocs
- [ ] Tests were added or updated to cover changes
- [ ] Commits were squashed into a single coherent commit
