### PR TITLE
Fix pattern matching in Timex.from_iso_triplet/3 error clause

### DIFF
--- a/lib/timex.ex
+++ b/lib/timex.ex
@@ -633,7 +633,7 @@ defmodule Timex do
       {year, month, day} = Helpers.iso_day_to_date_tuple(year, iso_day)
       %Date{year: year, month: month, day: day}
   end
-  def from_iso_triplet(_, _, _), do: {:error, {:from_iso_triplet, :invalid_triplet}}
+  def from_iso_triplet({_, _, _}), do: {:error, {:from_iso_triplet, :invalid_triplet}}
 
   @doc """
   Returns a list of all valid timezone names in the Olson database


### PR DESCRIPTION
### Removed redundant `Timex.from_iso_triplet/3`

There isn't "useful" clause for `Timex.from_iso_triplet/3`, only an error one; so I guess we can safely remove it.

### Checklist

- [x] New functions have typespecs, changed functions were updated
- [x] Same for documentation, including moduledocs
- [x] Tests were added or updated to cover changes
- [x] Commits were squashed into a single coherent commit
