### PR TITLE
The full name for May in Italian is Maggio

### DIFF
--- a/priv/translations/it/LC_MESSAGES/months.po
+++ b/priv/translations/it/LC_MESSAGES/months.po
@@ -53,7 +53,7 @@ msgstr "Marzo"
 
 #: lib/l10n/translator.ex:221
 msgid "May"
-msgstr "Mag"
+msgstr "Maggio"
 
 #: lib/l10n/translator.ex:227
 msgid "November"


### PR DESCRIPTION
Just a minor typo in the translation files: the full name for May in Italian is Maggio   
