### PR TITLE
Add granularity option to Timex.equal?

### DIFF
--- a/lib/timex.ex
+++ b/lib/timex.ex
@@ -771,8 +771,11 @@ defmodule Timex do
 
   @doc """
   Returns a boolean indicating whether the two `Timex.Comparable` values are equivalent.
-  Equality here implies that the two Comparables represent the same moment in time,
-  not equality of the data structure.
+
+  Equality here implies that the two Comparables represent the same moment in time (with
+  the given granularity), not equality of the data structure.
+
+  The options for granularity is the same as for `compare/3`, defaults to `:seconds`.
 
   ## Examples
 
@@ -786,9 +789,10 @@ defmodule Timex do
       ...> #{__MODULE__}.equal?(date1, date2)
       true
   """
-  @spec equal?(Comparable.comparable, Comparable.comparable) :: boolean | {:error, :badarg}
-  def equal?(a, a), do: true
-  def equal?(a, b), do: Comparable.compare(a, b, :seconds) == 0
+  @spec equal?(Comparable.comparable, Comparable.comparable, Comparable.granularity) :: boolean | {:error, :badarg}
+  def equal?(a, a, granularity \\ :seconds)
+  def equal?(a, a, _granularity), do: true
+  def equal?(a, b, granularity), do: Comparable.compare(a, b, granularity) == 0
 
   @doc """
   See docs for `compare/3`

--- a/lib/timex.ex
+++ b/lib/timex.ex
@@ -825,7 +825,9 @@ defmodule Timex do
   - :hours
   - :minutes
   - :seconds
-  - :timestamp
+  - :milliseconds
+  - :microseconds (default)
+  - :duration
 
   and the dates will be compared with the cooresponding accuracy.
   The default granularity is :microseconds.

--- a/test/timex_test.exs
+++ b/test/timex_test.exs
@@ -220,6 +220,13 @@ defmodule TimexTests do
     refute Timex.equal?(Timex.today, Timex.epoch)
     assert Timex.equal?(Timex.today, Timex.today)
     refute Timex.equal?(Timex.now, Timex.epoch)
+
+    date1 = Timex.to_datetime({{2013,3,18},{13,44,0, 50000}}, 2)
+    date2 = Timex.to_datetime({{2013,3,18},{8,44,0}}, -3)
+    date3 = Timex.to_datetime({{2013,3,18},{7,45,0}}, -3)
+    assert Timex.equal?(date1, date2)
+    refute Timex.equal?(date1, date2, :microseconds)
+    assert Timex.equal?(date2, date3, :hours)
   end
 
   test "diff" do


### PR DESCRIPTION
### Summary of changes

Fixes https://github.com/bitwalker/timex/issues/302 as suggested in the issue.

I'n not sure if `:seconds` is the correct default option, since compare and diff uses `:microseconds` as the default granularity. But using seconds means we don't change the current behaviour.

Also fixes a documentation error for compare/3. It was a mismatch between Timex.compare and Timex.Comparable.compare.

### Checklist

- [x] New functions have typespecs, changed functions were updated
- [x] Same for documentation, including moduledocs
- [x] Tests were added or updated to cover changes
- [ ] Commits were squashed into a single coherent commit
