### PR TITLE
Make Humanized formatting for zero duration more informative

### DIFF
--- a/lib/format/duration/formatters/humanized.ex
+++ b/lib/format/duration/formatters/humanized.ex
@@ -87,6 +87,8 @@ defmodule Timex.Format.Duration.Formatters.Humanized do
     micros = Duration.to_microseconds(duration) |> abs
     deconstruct({div(micros, @microsecond), rem(micros, @microsecond)}, [])
   end
+  defp deconstruct({0, 0}, []),
+    do: deconstruct({0, 0}, microsecond: 0)
   defp deconstruct({0, 0}, components),
     do: Enum.reverse(components)
   defp deconstruct({seconds, us}, components) when seconds > 0 do

--- a/test/format_duration_humanized_test.exs
+++ b/test/format_duration_humanized_test.exs
@@ -17,4 +17,8 @@ defmodule DurationFormatHumanizedTest do
     assert "45 years, 6 months, 5 days, 21 hours, 12 minutes, 34 seconds, 590.264 milliseconds" =
         format(-1435, -180354, -590264)
   end
+
+  test "format zero duration" do
+    assert "0 microseconds" = format(0, 0, 0)
+  end
 end


### PR DESCRIPTION
### Summary of changes
Fixes #266

According to the issue, and after reproducing locally, `Timex.Format.Duration.Formatters.Humanized.format/1` for zero duration returns an empty string.
Here it's fixed by defaulting to the smallest unity, `microseconds`.

So after this change, the result would be:
```elixir
iex> Timex.Duration.zero |> Timex.Format.Duration.Formatters.Humanized.format
"0 microseconds"
```

### Checklist

- [x] New functions have typespecs, changed functions were updated
- [x] Same for documentation, including moduledocs
- [x] Tests were added or updated to cover changes
- [x] Commits were squashed into a single coherent commit

Any feedback is welcome, thanks! 😸 