### PR TITLE
Fix typespecs for beginning_of_week and friends

### DIFF
--- a/lib/date/date.ex
+++ b/lib/date/date.ex
@@ -51,7 +51,7 @@ defimpl Timex.Protocol, for: Date do
   @spec end_of_day(Date.t) :: Date.t
   def end_of_day(%Date{} = date), do: date
 
-  @spec beginning_of_week(Date.t, Types.weekday) :: Date.t
+  @spec beginning_of_week(Date.t, Types.weekstart) :: Date.t
   def beginning_of_week(%Date{} = date, weekstart) do
     case Timex.days_to_beginning_of_week(date, weekstart) do
       {:error, _} = err -> err
@@ -59,7 +59,7 @@ defimpl Timex.Protocol, for: Date do
     end
   end
 
-  @spec end_of_week(Date.t, Types.weekday) :: Date.t
+  @spec end_of_week(Date.t, Types.weekstart) :: Date.t
   def end_of_week(%Date{} = date, weekstart) do
     case Timex.days_to_end_of_week(date, weekstart) do
       {:error, _} = err -> err

--- a/lib/datetime/datetime.ex
+++ b/lib/datetime/datetime.ex
@@ -80,7 +80,7 @@ defimpl Timex.Protocol, for: DateTime do
     Timex.Timezone.end_of_day(datetime)
   end
 
-  @spec beginning_of_week(DateTime.t, Types.weekday) :: DateTime.t | AmbiguousDateTime.t
+  @spec beginning_of_week(DateTime.t, Types.weekstart) :: DateTime.t | AmbiguousDateTime.t
   def beginning_of_week(%DateTime{} = date, weekstart) do
     case Timex.days_to_beginning_of_week(date, weekstart) do
       {:error, _} = err -> err
@@ -88,7 +88,7 @@ defimpl Timex.Protocol, for: DateTime do
     end
   end
 
-  @spec end_of_week(DateTime.t, Types.weekday) :: DateTime.t | AmbiguousDateTime.t
+  @spec end_of_week(DateTime.t, Types.weekstart) :: DateTime.t | AmbiguousDateTime.t
   def end_of_week(%DateTime{} = date, weekstart) do
     case Timex.days_to_end_of_week(date, weekstart) do
       {:error, _} = err -> err

--- a/lib/datetime/erlang.ex
+++ b/lib/datetime/erlang.ex
@@ -101,7 +101,7 @@ defimpl Timex.Protocol, for: Tuple do
     do: {date, {23,59,59}}
   def end_of_day(_), do: {:error, :invalid_date}
 
-  @spec beginning_of_week(Types.date | Types.datetime, Types.weekday) :: Types.date | Types.datetime
+  @spec beginning_of_week(Types.date | Types.datetime, Types.weekstart) :: Types.date | Types.datetime
   def beginning_of_week({y,m,d} = date, weekstart) when is_date(y,m,d) do
     case Timex.days_to_beginning_of_week(date, weekstart) do
       {:error, _} = err -> err
@@ -116,7 +116,7 @@ defimpl Timex.Protocol, for: Tuple do
   end
   def beginning_of_week(_,_), do: {:error, :invalid_date}
 
-  @spec end_of_week(Types.date | Types.datetime, Types.weekday) :: Types.date | Types.datetime
+  @spec end_of_week(Types.date | Types.datetime, Types.weekstart) :: Types.date | Types.datetime
   def end_of_week({y,m,d} = date, weekstart) when is_date(y,m,d) do
     case Timex.days_to_end_of_week(date, weekstart) do
       {:error, _} = err -> err

--- a/lib/datetime/naivedatetime.ex
+++ b/lib/datetime/naivedatetime.ex
@@ -60,7 +60,7 @@ defimpl Timex.Protocol, for: NaiveDateTime do
     %{datetime | :hour => 23, :minute => 59, :second => 59, :microsecond => {999_999, 6}}
   end
 
-  @spec beginning_of_week(NaiveDateTime.t, Types.weekday) :: NaiveDateTime.t
+  @spec beginning_of_week(NaiveDateTime.t, Types.weekstart) :: NaiveDateTime.t
   def beginning_of_week(%NaiveDateTime{} = date, weekstart) do
     case Timex.days_to_beginning_of_week(date, weekstart) do
       {:error, _} = err -> err
@@ -69,7 +69,7 @@ defimpl Timex.Protocol, for: NaiveDateTime do
     end
   end
 
-  @spec end_of_week(NaiveDateTime.t, Types.weekday) :: NaiveDateTime.t
+  @spec end_of_week(NaiveDateTime.t, Types.weekstart) :: NaiveDateTime.t
   def end_of_week(%NaiveDateTime{} = date, weekstart) do
     case Timex.days_to_end_of_week(date, weekstart) do
       {:error, _} = err -> err

--- a/lib/timex.ex
+++ b/lib/timex.ex
@@ -1242,7 +1242,7 @@ defmodule Timex do
       1
 
   """
-  @spec days_to_beginning_of_week(Types.valid_datetime, Types.weekday) :: integer | {:error, term}
+  @spec days_to_beginning_of_week(Types.valid_datetime, Types.weekstart) :: integer | {:error, term}
   def days_to_beginning_of_week(date, weekstart \\ 1)
 
   def days_to_beginning_of_week(date, weekstart) when is_atom(weekstart) or is_binary(weekstart)  do
@@ -1282,7 +1282,7 @@ defmodule Timex do
       5
 
   """
-  @spec days_to_end_of_week(Types.valid_datetime, Types.weekday) :: integer | {:error, term}
+  @spec days_to_end_of_week(Types.valid_datetime, Types.weekstart) :: integer | {:error, term}
   def days_to_end_of_week(date, weekstart \\ :mon) do
     case days_to_beginning_of_week(date, weekstart) do
       {:error, _} = err -> err
@@ -1306,7 +1306,7 @@ defmodule Timex do
       ~D[2015-11-29]
 
   """
-  @spec beginning_of_week(Types.valid_datetime, Types.weekday) :: Types.valid_datetime | {:error, term}
+  @spec beginning_of_week(Types.valid_datetime, Types.weekstart) :: Types.valid_datetime | {:error, term}
   defdelegate beginning_of_week(date, weekstart \\ :mon), to: Timex.Protocol
 
   @doc """
@@ -1327,7 +1327,7 @@ defmodule Timex do
       ~D[2015-12-05]
 
   """
-  @spec end_of_week(Types.valid_datetime, Types.weekday) :: Types.valid_datetime | {:error, term}
+  @spec end_of_week(Types.valid_datetime, Types.weekstart) :: Types.valid_datetime | {:error, term}
   defdelegate end_of_week(datetime, weekstart \\ 1), to: Timex.Protocol
 
   @doc """

--- a/lib/timex/types.ex
+++ b/lib/timex/types.ex
@@ -35,4 +35,5 @@ defmodule Timex.Types do
   @type datetime :: { date, time }
   @type iso_triplet :: { year, weeknum, weekday }
   @type valid_datetime :: Date.t | DateTime.t | NaiveDateTime.t | datetime | date
+  @type weekstart :: weekday | binary | atom
 end


### PR DESCRIPTION
### Summary of changes

When running dialyzer against [my project](https://github.com/randycoulman/invoice_tracker), I discovered that the type spec for `Timex.beginning_of_week/2` was not correct.  The docs state:

> The weekstart can between 1..7, an atom e.g. :mon, or a string e.g. “Monday”

But the typespec only allows for `Timex.Types.weekday`, which is defined to be `non_neg_integer`.

Further investigation indicates that the same issue affects `end_of_week`, `days_to_beginning_of_week` and `days_to_end_of_week` as well.

### Checklist

- [x] New functions have typespecs, changed functions were updated
- [x] Same for documentation, including moduledocs
- [x] Tests were added or updated to cover changes
- [x] Commits were squashed into a single coherent commit

### Details

There's not really a way to write tests for this that I can think of, but before making my changes, running `mix dialyze` reports a number of warnings, including:

```
lib/timex.ex:1286: Function days_to_end_of_week/1 has no local return

lib/timex.ex:1286: The call 'Elixir.Timex':days_to_end_of_week(x0@1::any(),'mon')
will never return since the success typing is ({{integer(),integer(),integer()},{byte(),byte(),byte()}} |
{integer(),integer(),integer()} | #{'__struct__':='Elixir.Date' | 'Elixir.DateTime' | 'Elixir.NaiveDateTime',
'calendar':=atom(), 'day':=integer(), 'month':=integer(), 'year':=integer(), 'hour'=>byte(),
'microsecond'=>{char(),0 | 1 | 2 | 3 | 4 | 5 | 6}, 'minute'=>byte(), 'second'=>byte(),
'std_offset'=>integer(), 'time_zone'=>binary(), 'utc_offset'=>integer(),
'zone_abbr'=>binary()},non_neg_integer()) -> non_neg_integer() | {'error',_} and the contract is
('Elixir.Timex.Types':valid_datetime(),'Elixir.Timex.Types':weekday()) -> integer() | {'error',term()}
```
After making these changes, those two warnings are gone.

Similarly, in my project I was getting these warnings for this code:

```elixir
def for_current_status(today \\ local_today()) do
  Timex.beginning_of_week(today, :fri)
end
```

```
lib/invoice_tracker/default_date.ex:37: Function for_current_status/0 has no local return
lib/invoice_tracker/default_date.ex:37: Function for_current_status/1 has no local return
lib/invoice_tracker/default_date.ex:39: The call 'Elixir.Timex':beginning_of_week(today@1::any(),'fri')
breaks the contract ('Elixir.Timex.Types':valid_datetime(),'Elixir.Timex.Types':weekday()) ->
'Elixir.Timex.Types':valid_datetime() | {'error',term()}
```
Those warnings are now gone with these changes.

An interesting side note: `mix dialyze` is only complaining about `days_to_end_of_week` and not `days_to_beginning_of_week`.  That's because `days_to_end_of_week` uses `:mon` as its default weekstart value, whereas `days_to_beginning_of_week` uses `1` instead.  I didn't change this to be consistent, though I could if that's desirable.