### PR TITLE
Parse a string of zeroes as valid microseconds

### DIFF
--- a/lib/parse/datetime/helpers.ex
+++ b/lib/parse/datetime/helpers.ex
@@ -61,14 +61,13 @@ defmodule Timex.Parse.DateTime.Helpers do
   end
   def parse_microseconds(us) do
     n_width = byte_size(us)
-    leading = n_width - byte_size(String.trim_leading(us, "0"))
     trailing = n_width - byte_size(String.trim_trailing(us, "0"))
     cond do
-      n_width - leading - trailing == 0 ->
-        [sec_fractional: {0,0}]
+      n_width == trailing ->
+        [sec_fractional: {0, n_width}]
       :else ->
-        n = us |> String.trim("0") |> String.to_integer
         p = n_width - trailing
+        n = us |> String.trim("0") |> String.to_integer
         [sec_fractional: {n * trunc(:math.pow(10, 6-p)), p}]
     end
   end

--- a/test/parse_strftime_test.exs
+++ b/test/parse_strftime_test.exs
@@ -19,6 +19,10 @@ defmodule DateFormatTest.ParseStrftime do
     assert {:ok, ^date2} = parse("Mon Jul 06 2015 00:00:00 GMT +0200 (CST)", "%a %b %d %Y %H:%M:%S %Z %z (%Z)")
   end
 
+  test "issue #319 - should parse microseconds even if 0" do
+    assert {:ok, %NaiveDateTime{microsecond: {0, 6}}} = parse("2017-06-15T12:42:20.000000", "%FT%T.%f")
+  end
+
   test "parse format with microseconds" do
     date = Timex.to_naive_datetime({{2015,7,13}, {14,1,21}})
     date = %{date | :microsecond => {53021, 6}}


### PR DESCRIPTION
The precision should be the given number of zeroes.

Fixes https://github.com/bitwalker/timex/issues/319

### Additional note

This only fixes `parse_microseconds`. It seems that [`parse_milliseconds`](https://github.com/bitwalker/timex/blob/dfd230c2e1380f5e544404e75c7d71747204d56d/lib/parse/datetime/helpers.ex#L57) in the same module would also crash on a string of zeroes.

I didn't touch it since I didn't really understand how it is used.

### Checklist

- [x] New functions have typespecs, changed functions were updated
- [x] Same for documentation, including moduledocs
- [x] Tests were added or updated to cover changes
- [x] Commits were squashed into a single coherent commit
