### PR TITLE
Test, refactor and fix bugs in Timex.Convert.convert_map

### DIFF
--- a/lib/datetime/helpers.ex
+++ b/lib/datetime/helpers.ex
@@ -57,6 +57,7 @@ defmodule Timex.DateTime.Helpers do
     end
   end
 
+  def construct_microseconds({us, p} = us_tuple) when is_integer(us) and is_integer(p), do: us_tuple
   def construct_microseconds(0), do: {0,0}
   def construct_microseconds(n), do: {n, precision(n)}
 


### PR DESCRIPTION
This bumps the test coverage of convert.ex to 100%.

In doing so, I also noticed and fixed a few bugs:

* If the input map missed hour date, the expected Date was wrapped in
  {:ok, date} tuple.
* If the input map missed both timezone and microseconds, the returned
  NaiveDateTime had a default microseconds of {0, 6}. If the timezone was
  declared, the default microsecond was {0, 0}.
* `Timex.Convert.convert_map` crashed when a microsecond was included,
  since it accepted or generated a `Calendar.microsecond` tuple while
  the `Timex.DateTime.Helpers.construct` function only accepted integer
  microseconds.

### Summary of changes

See commit message above.

Should there be type specs for internal, private, functions?

It looks like the typespecs for some functions using erlang datetime tuples is wrong. The `Types.time` only allows for `{ hour, minute, second }` while many functions such as `Timex.Helpers.construct` accepts `{ hour, minute, second, microsecond }`. Its only partially related to this PR (the use of four tuple times is distributed in the codebase), but it's worth mentioning. It also seems that the four tuple times are sometimes treated as milliseconds and sometimes as microseconds.

### Checklist

- [ ] New functions have typespecs, changed functions were updated
- [x] Same for documentation, including moduledocs
- [x] Tests were added or updated to cover changes
- [x] Commits were squashed into a single coherent commit
