### PR TITLE
Always pad microseconds with zeroes to 6 digits

### DIFF
--- a/lib/format/datetime/formatter.ex
+++ b/lib/format/datetime/formatter.ex
@@ -552,15 +552,11 @@ defmodule Timex.Format.DateTime.Formatter do
         pad_numeric(Timex.to_unix(date), flags, width)
     end
   end
-  def format_token(_locale, :us, %{microsecond: {us, precision}}, _modifiers, flags, width) do
-    p = cond do
-      width > precision -> precision
-      :else -> width
-    end
-    pad_numeric(us, flags, width_spec(p..p))
+  def format_token(_locale, :us, %{microsecond: {us, _precision}}, _modifiers, _flags, _width) do
+    pad_numeric(us, [padding: :zeroes], width_spec(6..6))
   end
-  def format_token(_locale, :us, _date, _modifiers, flags, width) do
-    pad_numeric(0, flags, width)
+  def format_token(_locale, :us, _date, _modifiers, _flags, _width) do
+    pad_numeric(0, [padding: :zeroes], width_spec(6..6))
   end
   def format_token(locale, :am, %{hour: hour}, _modifiers, _flags, _width) do
     day_periods = Translator.get_day_periods(locale)

--- a/test/format_strftime_test.exs
+++ b/test/format_strftime_test.exs
@@ -385,6 +385,11 @@ defmodule DateFormatTest.FormatStrftime do
     assert format(dt, "%j") == {:ok, "366"}
   end
 
+  test "issue #322 - should pad with zeroes even if microseconds = 0" do
+    dt = Timex.to_datetime({{2014, 11, 3}, {1, 41, 2}})
+    assert format(dt, "%f") == {:ok, "000000"}
+  end
+
   defp format(date, fmt) do
     Timex.format(date, fmt, :strftime)
   end


### PR DESCRIPTION
Fixes #322

### Summary of changes

Just as title says.
As I was upgrading from timex 2.2.1, strftime formatter stopped padding microseconds when fractional part was equal to zero.

### Checklist

- [x] New functions have typespecs, changed functions were updated
- [x] Same for documentation, including moduledocs
- [x] Tests were added or updated to cover changes
- [x] Commits were squashed into a single coherent commit