### PR TITLE
Bugfix: Don't return bool on before? or after? on error

### DIFF
--- a/lib/timex.ex
+++ b/lib/timex.ex
@@ -745,13 +745,23 @@ defmodule Timex do
   Returns a boolean indicating whether the first `Timex.Comparable` occurs before the second
   """
   @spec before?(Comparable.comparable, Comparable.comparable) :: boolean | {:error, term}
-  def before?(a, b), do: Comparable.compare(a, b) == -1
+  def before?(a, b) do
+    case Comparable.compare(a, b) do
+      result when is_integer(result) -> result == -1
+      {:error, _} = res -> res
+    end
+  end
 
   @doc """
   Returns a boolean indicating whether the first `Timex.Comparable` occurs after the second
   """
   @spec after?(Comparable.comparable, Comparable.comparable) :: boolean | {:error, term}
-  def after?(a, b), do: Comparable.compare(a, b) == 1
+  def after?(a, b) do
+    case Comparable.compare(a, b) do
+      result when is_integer(result) -> result == 1
+      {:error, _} = res -> res
+    end
+  end
 
   @doc """
   Returns a boolean indicating whether the first `Timex.Comparable` occurs between the second and third

--- a/test/timex_test.exs
+++ b/test/timex_test.exs
@@ -215,6 +215,19 @@ defmodule TimexTests do
     assert Timex.compare(date3, date4, :seconds) === -1
   end
 
+  test "before?/after?" do
+    now = Timex.now()
+    assert false == Timex.before?(now, now)
+    assert false == Timex.after?(now, now)
+    assert true == Timex.before?(Timex.epoch, now)
+    assert false == Timex.after?(Timex.epoch, now)
+
+    assert true == Timex.before?({{2013, 1, 1}, {1, 1, 1}}, {{2013, 1, 1}, {1, 1, 2}})
+    assert true == Timex.after?({{2013, 1, 1}, {1, 1, 2}}, {{2013, 1, 1}, {1, 1, 1}})
+    assert {:error, :invalid_date} == Timex.before?({}, {{2013, 1, 1}, {1, 1, 2}})
+    assert {:error, :invalid_date} == Timex.after?({{2013, 1, 1}, {1, 1, 2}}, {})
+  end
+
   test "equal" do
     assert Timex.equal?(Timex.today, Timex.today)
     refute Timex.equal?(Timex.today, Timex.epoch)


### PR DESCRIPTION
### Summary of changes

Found this while fixing dialyzer issues. Comparable.compare might return an error tuple, which should not be used for sorting.

### Checklist

- [x] New functions have typespecs, changed functions were updated
- [x] Same for documentation, including moduledocs
- [x] Tests were added or updated to cover changes
- [x] Commits were squashed into a single coherent commit
