### PR TITLE
Bugfix: Fix match errors in Timex.Protocol implementation for tuples

### DIFF
--- a/lib/datetime/erlang.ex
+++ b/lib/datetime/erlang.ex
@@ -240,11 +240,11 @@ defimpl Timex.Protocol, for: Tuple do
   def from_iso_day(_,_), do: {:error, :invalid_date}
 
   @spec set(Types.date | Types.datetime, list({atom(), term})) :: Types.date | Types.datetime | {:error, term}
-  def set({y,m,d} = d, options) when is_date(y,m,d),
-    do: do_set({d,{0,0,0}}, options, :date)
-  def set({{y,m,d},{h,mm,s}} = d, options) when is_datetime(y,m,d,h,mm,s),
-    do: do_set(d, options, :datetime)
-  def set({{y,m,d},{h,mm,s,us}} = d, options) when is_datetime(y,m,d,h,mm,s) do
+  def set({y,m,d} = date, options) when is_date(y,m,d),
+    do: do_set({date,{0,0,0}}, options, :date)
+  def set({{y,m,d},{h,mm,s}} = datetime, options) when is_datetime(y,m,d,h,mm,s),
+    do: do_set(datetime, options, :datetime)
+  def set({{y,m,d},{h,mm,s,us}}, options) when is_datetime(y,m,d,h,mm,s) do
     {date,{h,mm,s}} = do_set({{y,m,d},{h,mm,s}}, options, :datetime)
     {date,{h,mm,s,us}}
   end

--- a/test/timex_test.exs
+++ b/test/timex_test.exs
@@ -171,6 +171,7 @@ defmodule TimexTests do
 
     assert {{1,1,1},{13,26,59}} == Timex.to_erl(Timex.set(date, [date: {1,1,1}, hour: 13, second: 61, timezone: utc]))
     assert {{0,1,1},{23,26,59}} == Timex.to_erl(Timex.set(date, [date: {-1,-2,-3}, hour: 33, second: 61, timezone: utc]))
+    assert {{0,1,1},{23,26,59}} == Timex.to_erl(Timex.set(Timex.to_erl(date), [date: {-1,-2,-3}, hour: 33, second: 61, timezone: utc]))
   end
 
   test "compare" do


### PR DESCRIPTION
`d` was used both for the full date/datetime tuple and the day
item within it. It could never match.

### Checklist

- [x] New functions have typespecs, changed functions were updated
- [x] Same for documentation, including moduledocs
- [x] Tests were added or updated to cover changes
- [x] Commits were squashed into a single coherent commit
