### PR TITLE
Bugfix: Should not crash when parsing ISO string with missing fractions

### DIFF
--- a/lib/parse/datetime/parsers/iso8601_extended.ex
+++ b/lib/parse/datetime/parsers/iso8601_extended.ex
@@ -131,6 +131,9 @@ defmodule Timex.Parse.DateTime.Parsers.ISO8601Extended do
     digit >= ?0 and digit <= ?9 do
       parse_fractional_seconds(rest, count+1, <<acc::binary,digit::utf8>>)
   end
+  def parse_fractional_seconds(_rest, count, "") do
+    {:error, "Expected at least one digit after the decimal sign, but found none", count}
+  end
   def parse_fractional_seconds(rest, count, acc) do
     {:ok, acc, count, rest}
   end

--- a/test/parse_default_test.exs
+++ b/test/parse_default_test.exs
@@ -334,6 +334,7 @@ defmodule DateFormatTest.ParseDefault do
     assert {:ok, ^date1} = parse("2014-08-14T12:34:33+00", "{ISO:Extended}")
     assert {:ok, ^date1} = parse("2014-08-14T12:34:33Z", "{ISO:Extended}")
     assert {:ok, ^date1} = parse("2014-08-14T12:34:33Z", "{ISO:Extended:Z}")
+    assert {:error, "Expected at least one digit" <> _} = parse("2014-08-14T12:34:33.Z", "{ISO:Extended}")
 
     assert {:ok, ^date2} = parse("2014-08-14T12:34:33.199+00:00", "{ISO:Extended}")
     assert {:ok, ^date2} = parse("2014-08-14T12:34:33.199+0000", "{ISO:Extended}")


### PR DESCRIPTION
### Summary of changes

Found this by fixing a warning from dialyzer

### Checklist

- [x] New functions have typespecs, changed functions were updated
- [x] Same for documentation, including moduledocs
- [x] Tests were added or updated to cover changes
- [x] Commits were squashed into a single coherent commit
