### PR TITLE
Add typespecs for Timex.Protocol and adjust irregularities

### DIFF
--- a/lib/date/date.ex
+++ b/lib/date/date.ex
@@ -9,18 +9,18 @@ defimpl Timex.Protocol, for: Date do
 
   @epoch_seconds :calendar.datetime_to_gregorian_seconds({{1970,1,1},{0,0,0}})
 
-  @spec to_julian(Date.t) :: integer
+  @spec to_julian(Date.t) :: float
   def to_julian(%Date{:year => y, :month => m, :day => d}) do
     Timex.Calendar.Julian.julian_date(y, m, d)
   end
 
-  @spec to_gregorian_seconds(Date.t) :: integer
+  @spec to_gregorian_seconds(Date.t) :: non_neg_integer
   def to_gregorian_seconds(date), do: to_seconds(date, :zero)
 
-  @spec to_gregorian_microseconds(Date.t) :: integer
+  @spec to_gregorian_microseconds(Date.t) :: non_neg_integer
   def to_gregorian_microseconds(date), do: (to_seconds(date, :zero) * (1_000*1_000))
 
-  @spec to_unix(Date.t) :: integer
+  @spec to_unix(Date.t) :: non_neg_integer
   def to_unix(date), do: trunc(to_seconds(date, :epoch))
 
   @spec to_date(Date.t) :: Date.t
@@ -78,7 +78,7 @@ defimpl Timex.Protocol, for: Date do
 
   @spec beginning_of_quarter(Date.t) :: Date.t
   def beginning_of_quarter(%Date{month: month} = date) do
-    month = 1 + (3 * (quarter(month) - 1))
+    month = 1 + (3 * (Timex.quarter(month) - 1))
     %{date | :month => month, :day => 1}
   end
 
@@ -96,7 +96,7 @@ defimpl Timex.Protocol, for: Date do
   def end_of_month(%Date{} = date),
     do: %{date | :day => days_in_month(date)}
 
-  @spec quarter(Date.t) :: integer
+  @spec quarter(Date.t) :: 1..4
   def quarter(%Date{month: month}), do: Timex.quarter(month)
 
   def days_in_month(%Date{:year => y, :month => m}), do: Timex.days_in_month(y, m)
@@ -115,9 +115,9 @@ defimpl Timex.Protocol, for: Date do
   def iso_week(%Date{:year => y, :month => m, :day => d}),
     do: Timex.iso_week(y, m, d)
 
-  def from_iso_day(%Date{year: year} = date, day) when is_day_of_year(day) do
+  def from_iso_day(%Date{year: year}, day) when is_day_of_year(day) do
     {year, month, day_of_month} = Timex.Helpers.iso_day_to_date_tuple(year, day)
-    %{date | :year => year, :month => month, :day => day_of_month}
+    %Date{year: year, month: month, day: day_of_month}
   end
 
   @doc """

--- a/lib/datetime/datetime.ex
+++ b/lib/datetime/datetime.ex
@@ -18,21 +18,21 @@ defimpl Timex.Protocol, for: DateTime do
 
   @epoch_seconds :calendar.datetime_to_gregorian_seconds({{1970,1,1},{0,0,0}})
 
-  @spec to_julian(DateTime.t) :: integer
+  @spec to_julian(DateTime.t) :: float
   def to_julian(%DateTime{:year => y, :month => m, :day => d}) do
     Timex.Calendar.Julian.julian_date(y, m, d)
   end
 
-  @spec to_gregorian_seconds(DateTime.t) :: integer
+  @spec to_gregorian_seconds(DateTime.t) :: non_neg_integer
   def to_gregorian_seconds(date), do: to_seconds(date, :zero)
 
-  @spec to_gregorian_microseconds(DateTime.t) :: integer
+  @spec to_gregorian_microseconds(DateTime.t) :: non_neg_integer
   def to_gregorian_microseconds(%DateTime{microsecond: {us,_}} = date) do
     s = to_seconds(date, :zero)
     (s*(1_000*1_000))+us
   end
 
-  @spec to_unix(DateTime.t) :: integer
+  @spec to_unix(DateTime.t) :: non_neg_integer
   def to_unix(date), do: trunc(to_seconds(date, :epoch))
 
   @spec to_date(DateTime.t) :: Date.t
@@ -132,7 +132,7 @@ defimpl Timex.Protocol, for: DateTime do
   def end_of_month(%DateTime{year: year, month: month, time_zone: tz} = date),
     do: Timex.DateTime.Helpers.construct({{year, month, days_in_month(date)},{23,59,59,999_999}}, tz)
 
-  @spec quarter(DateTime.t) :: integer
+  @spec quarter(DateTime.t) :: 1..4
   def quarter(%DateTime{month: month}), do: Timex.quarter(month)
 
   def days_in_month(%DateTime{:year => y, :month => m}), do: Timex.days_in_month(y, m)

--- a/lib/datetime/erlang.ex
+++ b/lib/datetime/erlang.ex
@@ -4,7 +4,7 @@ defimpl Timex.Protocol, for: Tuple do
 
   @epoch :calendar.datetime_to_gregorian_seconds({{1970,1,1},{0,0,0}})
 
-  @spec to_julian(Types.date | Types.datetime) :: integer
+  @spec to_julian(Types.date | Types.datetime) :: float | {:error, term}
   def to_julian({y,m,d}) when is_date(y,m,d) do
     Timex.Calendar.Julian.julian_date(y, m, d)
   end
@@ -13,7 +13,7 @@ defimpl Timex.Protocol, for: Tuple do
   end
   def to_julian(_), do: {:error, :invalid_date}
 
-  @spec to_gregorian_seconds(Types.date | Types.datetime) :: integer
+  @spec to_gregorian_seconds(Types.date | Types.datetime) :: non_neg_integer
   def to_gregorian_seconds({y,m,d} = date) when is_date(y,m,d),
     do: :calendar.datetime_to_gregorian_seconds({date,{0,0,0}})
   def to_gregorian_seconds({{y,m,d},{h,mm,s}} = dt) when is_datetime(y,m,d,h,mm,s),
@@ -22,7 +22,7 @@ defimpl Timex.Protocol, for: Tuple do
     do: :calendar.datetime_to_gregorian_seconds({{y,m,d},{h,mm,s}})
   def to_gregorian_seconds(_), do: {:error, :invalid_date}
 
-  @spec to_gregorian_microseconds(Types.date | Types.datetime) :: integer
+  @spec to_gregorian_microseconds(Types.date | Types.datetime) :: non_neg_integer
   def to_gregorian_microseconds({y,m,d} = date) when is_date(y,m,d),
     do: (to_gregorian_seconds(date)*(1_000*1_000))
   def to_gregorian_microseconds({{y,m,d},{h,mm,s}} = date) when is_datetime(y,m,d,h,mm,s),
@@ -31,7 +31,7 @@ defimpl Timex.Protocol, for: Tuple do
     do: (to_gregorian_seconds(date)*(1_000*1_000))+us
   def to_gregorian_microseconds(_), do: {:error, :invalid_date}
 
-  @spec to_unix(Types.date | Types.datetime) :: integer
+  @spec to_unix(Types.date | Types.datetime) :: non_neg_integer
   def to_unix({y,m,d} = date) when is_date(y,m,d),
     do: (:calendar.datetime_to_gregorian_seconds({date,{0,0,0}}) - @epoch)
   def to_unix({{y,m,d},{h,mm,s}} = dt) when is_datetime(y,m,d,h,mm,s),
@@ -124,7 +124,7 @@ defimpl Timex.Protocol, for: Tuple do
         shift(date, [days: days_to_end])
     end
   end
-  def end_of_week({{y,m,d} = date,_}, weekstart) when is_date(y,m,d) do
+  def end_of_week({{y,m,d},_} = date, weekstart) when is_date(y,m,d) do
     case Timex.days_to_end_of_week(date, weekstart) do
       {:error, _} = err -> err
       days_to_end ->
@@ -152,13 +152,13 @@ defimpl Timex.Protocol, for: Tuple do
     month = 1 + (3 * (Timex.quarter(m) - 1))
     {y,month,1}
   end
-  def beginning_of_quarter({{y,m,d},{h,mm,s} = time}) when is_datetime(y,m,d,h,mm,s) do
+  def beginning_of_quarter({{y,m,d},{h,mm,s} = _time}) when is_datetime(y,m,d,h,mm,s) do
     month = 1 + (3 * (Timex.quarter(m) - 1))
-    {{y,month,1},time}
+    {{y,month,1},{0,0,0}}
   end
-  def beginning_of_quarter({{y,m,d},{h,mm,s,_us} = time}) when is_datetime(y,m,d,h,mm,s) do
+  def beginning_of_quarter({{y,m,d},{h,mm,s,_us} = _time}) when is_datetime(y,m,d,h,mm,s) do
     month = 1 + (3 * (Timex.quarter(m) - 1))
-    {{y,month,1},time}
+    {{y,month,1},{0,0,0,0}}
   end
   def beginning_of_quarter(_), do: {:error, :invalid_date}
 
@@ -191,7 +191,7 @@ defimpl Timex.Protocol, for: Tuple do
     do: {{y,m,days_in_month(date)},{23,59,59}}
   def end_of_month(_), do: {:error, :invalid_date}
 
-  @spec quarter(Types.date | Types.datetime) :: integer
+  @spec quarter(Types.date | Types.datetime) :: 1..4
   def quarter({y,m,d}) when is_date(y,m,d), do: Timex.quarter(m)
   def quarter({{y,m,d},_}) when is_date(y,m,d), do: Timex.quarter(m)
   def quarter(_), do: {:error, :invalid_date}

--- a/lib/datetime/naivedatetime.ex
+++ b/lib/datetime/naivedatetime.ex
@@ -12,21 +12,21 @@ defimpl Timex.Protocol, for: NaiveDateTime do
     Timex.to_naive_datetime(Timex.from_unix(:os.system_time, :native))
   end
 
-  @spec to_julian(NaiveDateTime.t) :: integer
+  @spec to_julian(NaiveDateTime.t) :: float
   def to_julian(%NaiveDateTime{:year => y, :month => m, :day => d}) do
     Timex.Calendar.Julian.julian_date(y, m, d)
   end
 
-  @spec to_gregorian_seconds(NaiveDateTime.t) :: integer
+  @spec to_gregorian_seconds(NaiveDateTime.t) :: non_neg_integer
   def to_gregorian_seconds(date), do: to_seconds(date, :zero)
 
-  @spec to_gregorian_microseconds(NaiveDateTime.t) :: integer
+  @spec to_gregorian_microseconds(NaiveDateTime.t) :: non_neg_integer
   def to_gregorian_microseconds(%NaiveDateTime{microsecond: {us,_}} = date) do
     s = to_seconds(date, :zero)
     (s*(1_000*1_000))+us
   end
 
-  @spec to_unix(NaiveDateTime.t) :: integer
+  @spec to_unix(NaiveDateTime.t) :: non_neg_integer
   def to_unix(date), do: trunc(to_seconds(date, :epoch))
 
   @spec to_date(NaiveDateTime.t) :: Date.t
@@ -108,7 +108,7 @@ defimpl Timex.Protocol, for: NaiveDateTime do
   def end_of_month(%NaiveDateTime{} = date),
     do: %{date | :day => days_in_month(date), :hour => 23, :minute => 59, :second => 59, :microsecond => {999_999, 6}}
 
-  @spec quarter(NaiveDateTime.t) :: integer
+  @spec quarter(NaiveDateTime.t) :: 1..4
   def quarter(%NaiveDateTime{month: month}), do: Timex.quarter(month)
 
   def days_in_month(%NaiveDateTime{:year => y, :month => m}), do: Timex.days_in_month(y, m)

--- a/lib/protocol.ex
+++ b/lib/protocol.ex
@@ -9,37 +9,46 @@ defprotocol Timex.Protocol do
   @doc """
   Convert a date/time value to a Julian calendar date number
   """
+  @spec to_julian(Types.valid_datetime) :: float | {:error, term}
   def to_julian(datetime)
 
   @doc """
   Convert a date/time value to gregorian seconds (seconds since start of year zero)
   """
+  @spec to_gregorian_seconds(Types.valid_datetime) :: non_neg_integer | {:error, term}
   def to_gregorian_seconds(datetime)
 
   @doc """
   Convert a date/time value to gregorian microseconds (microseconds since the start of year zero)
   """
+  @spec to_gregorian_microseconds(Types.valid_datetime) :: non_neg_integer | {:error, term}
   def to_gregorian_microseconds(datetime)
 
   @doc """
   Convert a date/time value to seconds since the UNIX Epoch
   """
+  @spec to_unix(Types.valid_datetime) :: non_neg_integer | {:error, term}
   def to_unix(datetime)
 
   @doc """
   Convert a date/time value to a Date
   """
+  @spec to_date(Types.valid_datetime) :: Date.t | {:error, term}
   def to_date(datetime)
 
   @doc """
   Convert a date/time value to a DateTime.
   An optional timezone can be provided, UTC will be assumed if one is not provided.
   """
+  @spec to_datetime(Types.valid_datetime) :: DateTime.t | {:error, term}
+  @spec to_datetime(Types.valid_datetime, Types.valid_timezone) ::
+    DateTime.t | AmbiguousDateTime.t | {:error, term}
   def to_datetime(datetime, timezone \\ :utc)
 
   @doc """
   Convert a date/time value to a NaiveDateTime
   """
+  @spec to_naive_datetime(Types.valid_datetime) :: NaiveDateTime.t | {:error, term}
   def to_naive_datetime(datetime)
 
   @doc """
@@ -47,118 +56,143 @@ defprotocol Timex.Protocol do
   i.e. Date becomes `{y,m,d}`, DateTime/NaiveDateTime become
   `{{y,m,d},{h,mm,s}}`
   """
+  @spec to_erl(Types.valid_datetime) :: Types.date | Types.datetime | {:error, term}
   def to_erl(datetime)
 
   @doc """
   Get the century a date/time value is in
   """
+  @spec century(Types.year | Types.valid_datetime) :: non_neg_integer | {:error, term}
   def century(datetime)
 
   @doc """
   Return a boolean indicating whether the date/time value is in a leap year
   """
+  @spec is_leap?(Types.valid_datetime | Types.year) :: boolean | {:error, term}
   def is_leap?(datetime)
 
   @doc """
   Shift a date/time value using a list of shift unit/value pairs
   """
+  @spec shift(Types.valid_datetime, Timex.shift_options) ::
+    Types.valid_datetime | AmbiguousDateTime.t | {:error, term}
   def shift(datetime, options)
 
   @doc """
   Set fields on a date/time value using a list of unit/value pairs
   """
+  @spec set(Types.valid_datetime, Timex.  set_options) :: Types.valid_datetime
   def set(datetime, options)
 
   @doc """
   Get a new version of the date/time value representing the beginning of the day
   """
+  @spec beginning_of_day(Types.valid_datetime) :: Types.valid_datetime | {:error, term}
   def beginning_of_day(datetime)
 
   @doc """
   Get a new version of the date/time value representing the end of the day
   """
+  @spec end_of_day(Types.valid_datetime) :: Types.valid_datetime | {:error, term}
   def end_of_day(datetime)
 
   @doc """
   Get a new version of the date/time value representing the beginning of it's week,
   providing a weekday name (as an atom) for the day which starts the week, i.e. `:mon`.
   """
+  @spec beginning_of_week(Types.valid_datetime, Types.weekstart) :: Types.valid_datetime | {:error, term}
   def beginning_of_week(datetime, weekstart)
 
   @doc """
   Get a new version of the date/time value representing the ending of it's week,
   providing a weekday name (as an atom) for the day which starts the week, i.e. `:mon`.
   """
+  @spec end_of_week(Types.valid_datetime, Types.weekstart) :: Types.valid_datetime | {:error, term}
   def end_of_week(datetime, weekstart)
 
   @doc """
   Get a new version of the date/time value representing the beginning of it's year
   """
+  @spec beginning_of_year(Types.year | Types.valid_datetime) :: Types.valid_datetime | {:error, term}
   def beginning_of_year(datetime)
 
   @doc """
   Get a new version of the date/time value representing the ending of it's year
   """
+  @spec end_of_year(Types.year | Types.valid_datetime) :: Types.valid_datetime | {:error, term}
   def end_of_year(datetime)
 
   @doc """
   Get a new version of the date/time value representing the beginning of it's quarter
   """
+  @spec beginning_of_quarter(Types.valid_datetime) :: Types.valid_datetime | {:error, term}
   def beginning_of_quarter(datetime)
 
   @doc """
   Get a new version of the date/time value representing the ending of it's quarter
   """
+  @spec end_of_quarter(Types.valid_datetime) :: Types.valid_datetime | {:error, term}
   def end_of_quarter(datetime)
 
   @doc """
   Get a new version of the date/time value representing the beginning of it's month
   """
+  @spec beginning_of_month(Types.valid_datetime) :: Types.valid_datetime | {:error, term}
   def beginning_of_month(datetime)
 
   @doc """
   Get a new version of the date/time value representing the ending of it's month
   """
+  @spec end_of_month(Types.valid_datetime) :: Types.valid_datetime | {:error, term}
   def end_of_month(datetime)
 
   @doc """
   Get the quarter for the given date/time value
   """
+  @spec quarter(Types.month | Types.valid_datetime) :: 1..4 | {:error, term}
   def quarter(datetime)
 
   @doc """
   Get the number of days in the month for the given date/time value
   """
+  @spec days_in_month(Types.valid_datetime) :: Types.num_of_days | {:error, term}
   def days_in_month(datetime)
 
   @doc """
   Get the week number of the given date/time value, starting at 1
   """
+  @spec week_of_month(Types.valid_datetime) :: Types.week_of_month
   def week_of_month(datetime)
 
   @doc """
   Get the ordinal weekday number of the given date/time value
   """
+  @spec weekday(Types.valid_datetime) :: Types.weekday | {:error, term}
   def weekday(datetime)
 
   @doc """
   Get the ordinal day number of the given date/time value
   """
+  @spec day(Types.valid_datetime) :: Types.daynum | {:error, term}
   def day(datetime)
 
   @doc """
   Determine if the provided date/time value is valid.
   """
+  @spec is_valid?(Types.valid_datetime) :: boolean | {:error, term}
   def is_valid?(datetime)
 
   @doc """
   Return a pair {year, week number} (as defined by ISO 8601) that the given date/time value falls on.
   """
+  @spec iso_week(Types.valid_datetime) :: {Types.year, Types.weeknum} | {:error, term}
   def iso_week(datetime)
 
   @doc """
   Shifts the given date/time value to the ISO day given
   """
+  @spec from_iso_day(Types.valid_datetime, non_neg_integer) ::
+    Types.valid_datetime | {:error, term}
   def from_iso_day(datetime, day)
 end
 

--- a/lib/timex.ex
+++ b/lib/timex.ex
@@ -98,13 +98,13 @@ defmodule Timex do
   @doc """
   Convert a date/time value to a Date struct.
   """
-  @spec to_date(Types.calendar_types | Types.date | Types.datetime) :: Date.t
+  @spec to_date(Types.valid_datetime) :: Date.t | {:error, term}
   defdelegate to_date(date), to: Timex.Protocol
 
   @doc """
   Convert a date/time value to a NaiveDateTime struct.
   """
-  @spec to_naive_datetime(Types.calendar_types | Types.date | Types.datetime) :: NaiveDateTime.t
+  @spec to_naive_datetime(Types.valid_datetime) :: NaiveDateTime.t | {:error, term}
   defdelegate to_naive_datetime(date), to: Timex.Protocol
 
   @doc """
@@ -114,8 +114,8 @@ defmodule Timex do
 
   If no timezone is provided, "Etc/UTC" will be used
   """
-  @spec to_datetime(Types.calendar_types | Types.date | Types.datetime) :: DateTime.t | {:error, term}
-  @spec to_datetime(Types.calendar_types | Types.date | Types.datetime, Types.valid_timezone) ::
+  @spec to_datetime(Types.valid_datetime) :: DateTime.t | {:error, term}
+  @spec to_datetime(Types.valid_datetime, Types.valid_timezone) ::
     DateTime.t | AmbiguousDateTime.t | {:error, term}
   def to_datetime(from), do: Timex.Protocol.to_datetime(from, "Etc/UTC")
   defdelegate to_datetime(from, timezone), to: Timex.Protocol
@@ -128,13 +128,13 @@ defmodule Timex do
   @doc """
   Convert a date/time value to it's Erlang representation
   """
-  @spec to_date(Types.valid_datetime) :: Types.date | Types.datetime
+  @spec to_erl(Types.valid_datetime) :: Types.date | Types.datetime | {:error, term}
   defdelegate to_erl(date), to: Timex.Protocol
 
   @doc """
   Convert a date/time value to a Julian calendar date number
   """
-  @spec to_julian(Types.valid_datetime) :: integer
+  @spec to_julian(Types.valid_datetime) :: integer | {:error, term}
   defdelegate to_julian(datetime), to: Timex.Protocol
 
   @doc """
@@ -466,7 +466,7 @@ defmodule Timex do
       21
 
   """
-  @spec century() :: non_neg_integer
+  @spec century() :: non_neg_integer | {:error, term}
   def century(), do: century(:calendar.universal_time())
 
   @doc """
@@ -482,7 +482,7 @@ defmodule Timex do
       21
 
   """
-  @spec century(Types.year | Types.valid_datetime) :: non_neg_integer
+  @spec century(Types.year | Types.valid_datetime) :: non_neg_integer | {:error, term}
   def century(year) when is_integer(year) do
     base_century = div(year, 100)
     years_past   = rem(year, 100)
@@ -667,7 +667,7 @@ defmodule Timex do
       {"Etc/GMT-2", "+02"}
 
   """
-  @spec timezone(Types.valid_timezone, Convertable.t) ::
+  @spec timezone(Types.valid_timezone, Types.valid_datetime) ::
     TimezoneInfo.t | AmbiguousTimezoneInfo.t | {:error, term}
   def timezone(:utc, _),      do: %TimezoneInfo{}
   def timezone("UTC", _),     do: %TimezoneInfo{}
@@ -706,7 +706,7 @@ defmodule Timex do
       false
 
   """
-  @spec is_valid?(Convertable.t) :: boolean
+  @spec is_valid?(Types.valid_datetime) :: boolean | {:error, term}
   defdelegate is_valid?(datetime), to: Timex.Protocol
 
   @doc """
@@ -1401,7 +1401,7 @@ defmodule Timex do
   Add time to a date using a Duration
   Same as `shift(date, Duration.from_minutes(5), :duration)`.
   """
-  @spec add(Convertable.t, Duration.t) ::
+  @spec add(Types.valid_datetime, Duration.t) ::
     Types.valid_datetime | AmbiguousDateTime.t | {:error, term}
   def add(date, %Duration{megaseconds: mega, seconds: sec, microseconds: micro}),
     do: shift(date, [seconds: (mega * @million) + sec, microseconds: micro])
@@ -1410,7 +1410,7 @@ defmodule Timex do
   Subtract time from a date using a Duration
   Same as `shift(date, Duration.from_minutes(5) |> Duration.invert, :timestamp)`.
   """
-  @spec subtract(Convertable.t, Types.timestamp) ::
+  @spec subtract(Types.valid_datetime, Duration.t) ::
     Types.valid_datetime | AmbiguousDateTime.t | {:error, term}
   def subtract(date, %Duration{megaseconds: mega, seconds: sec, microseconds: micro}),
     do: shift(date, [seconds: (-mega * @million) - sec, microseconds: -micro])


### PR DESCRIPTION
Adding the typespecs to the protocol will enable dialyzer
to verify the typespecs of the implementations as well as
the calls from the main Timex module.

The typespecs in the Timex module was updated to use
Types.valid_datetime instead of the more verbose multi type
version (also Types.calendar_types does not exist).

Error tuple returns was added to those missing it in the
Timex module.

The protocol implementations type specifications is
narrowed down to match those of the protocol/caller module.

The typespecs for to_julian was changed to float, which is
what is returned.

Also fixes a few bugs:

* from_iso_day for Date now returns a Date struct instead of a map
* beginning_of_quarter for Date now works instead of crashes
* beginning_of_quarter now returns the correct time for erlang datetimes
* end_of_week now returns a erlang datetime instead of a date for erlang datetimes

### Summary of changes

I have som more typespec changes coming up, but think that this is a good start to build upon an merge separately.

This greatly improves dialyzers ability to find errors in the typespecs for all the implementations and calling code. A possible downside is if any client implements their own implementation of the protocol, in which case I think they will get dialyzer errors since their types are not the expected types. Is this a dealbreaker? 

### Checklist

- [x] New functions have typespecs, changed functions were updated
- [x] Same for documentation, including moduledocs
- [x] Tests were added or updated to cover changes
- [x] Commits were squashed into a single coherent commit
