### PR TITLE
Fix typespecs for formatting functions.

### DIFF
--- a/docs/Erlang Interop.md
+++ b/docs/Erlang Interop.md
@@ -39,8 +39,10 @@ iex> time |> Duration.to_seconds |> Timex.from_unix
 
 ### Converting DateTimes to Erlang datetime tuples
 
+`Timex.to_erl/1` converts any valid Timex date/datetime to an erlang date or
+datetime tuple.
+
 ```elixir
-# Use the Timex.Convertable module (it's API is exposed via the Timex module as well)
 iex> date = Timex.now
 ...> Timex.to_erl(date)
 {{2015, 6, 24}, {4, 18, 33}}

--- a/lib/format/datetime/formatter.ex
+++ b/lib/format/datetime/formatter.ex
@@ -37,7 +37,7 @@ defmodule Timex.Format.DateTime.Formatter do
 
   If an error is encountered during formatting, `lformat!` will raise
   """
-  @spec lformat!(Types.calendar_types, String.t, String.t, atom | nil) :: String.t | no_return
+  @spec lformat!(Types.valid_datetime, String.t, String.t, atom | nil) :: String.t | no_return
   def lformat!(date, format_string, locale, formatter \\ Default)
 
   def lformat!({:error, _} = err, _format_string, _locale, _formatter),
@@ -65,7 +65,7 @@ defmodule Timex.Format.DateTime.Formatter do
   locale, and formatter. If the locale provided does not have translations, "en" is used by
   default. If a formatter is not provided, the formatter used is `Timex.Format.DateTime.Formatters.DefaultFormatter`
   """
-  @spec lformat(Types.calendar_types, String.t, String.t, atom | nil) :: {:ok, String.t} | {:error, term}
+  @spec lformat(Types.valid_datetime, String.t, String.t, atom | nil) :: {:ok, String.t} | {:error, term}
   def lformat(date, format_string, locale, formatter \\ Default)
 
   def lformat({:error, _} = err, _format_string, _locale, _formatter),
@@ -100,7 +100,7 @@ defmodule Timex.Format.DateTime.Formatter do
 
   If an error is encountered during formatting, `format!` will raise.
   """
-  @spec format!(Types.calendar_types, String.t, atom | nil) :: String.t | no_return
+  @spec format!(Types.valid_datetime, String.t, atom | nil) :: String.t | no_return
   def format!(date, format_string, formatter \\ Default)
 
   def format!(date, format_string, formatter),
@@ -113,7 +113,7 @@ defmodule Timex.Format.DateTime.Formatter do
 
   Formatting will use the configured default locale, "en" if no other default is given.
   """
-  @spec format(Types.calendar_types, String.t, atom | nil) :: {:ok, String.t} | {:error, term}
+  @spec format(Types.valid_datetime, String.t, atom | nil) :: {:ok, String.t} | {:error, term}
   def format(date, format_string, formatter \\ Default)
 
   def format(datetime, format_string, :strftime),

--- a/lib/format/datetime/formatters/relative.ex
+++ b/lib/format/datetime/formatters/relative.ex
@@ -64,7 +64,7 @@ defmodule Timex.Format.DateTime.Formatters.Relative do
     end
   end
 
-  @spec lformat(Types.calendar_types, String.t, String.t) :: String.t | no_return
+  @spec lformat!(Types.calendar_types, String.t, String.t) :: String.t | no_return
   def lformat!(date, format_string, locale) do
     case lformat(date, format_string, locale) do
       {:ok, result}    -> result
@@ -92,7 +92,6 @@ defmodule Timex.Format.DateTime.Formatters.Relative do
   @year @month * 12
 
   defp do_format(_locale, _date, _relative, [], result),             do: {:ok, result}
-  defp do_format(_locale, _date, _relative, _, {:error, _} = error), do: error
   defp do_format(locale, date, relative, [%Directive{type: :literal, value: char} | dirs], result) when is_binary(char) do
     do_format(locale, date, relative, dirs, <<result::binary, char::binary>>)
   end

--- a/lib/timex/types.ex
+++ b/lib/timex/types.ex
@@ -34,6 +34,7 @@ defmodule Timex.Types do
   @type date :: { year, month, day }
   @type datetime :: { date, time }
   @type iso_triplet :: { year, weeknum, weekday }
+  @type calendar_types :: Date.t | DateTime.t | NaiveDateTime.t
   @type valid_datetime :: Date.t | DateTime.t | NaiveDateTime.t | datetime | date
   @type weekstart :: weekday | binary | atom
 end


### PR DESCRIPTION
These typespecs does not seem to be updated since the Timex updates for
Elixir 1.3. The Convertable type/behaviour does not exist any more.

I have reintroduced `Types.calendar_types`, since it's what the
implementations of Timex.Format.DateTime.Formatter need to handle in
their callbacks. They don't need to handle all valid Timex data types such as tuples and maps.

The duration formatter works with durations, not timestamps.

### Checklist

- [x] New functions have typespecs, changed functions were updated
- [x] Same for documentation, including moduledocs
- [x] Tests were added or updated to cover changes
- [x] Commits were squashed into a single coherent commit
