### PR TITLE
Clarify and make sure that four-tuple times are accepted

### DIFF
--- a/lib/datetime/helpers.ex
+++ b/lib/datetime/helpers.ex
@@ -22,6 +22,7 @@ defmodule Timex.DateTime.Helpers do
   """
   @spec construct(Types.date, Types.valid_timezone) :: DateTime.t | AmbiguousDateTime.t | {:error, term}
   @spec construct(Types.datetime, Types.valid_timezone) :: DateTime.t | AmbiguousDateTime.t | {:error, term}
+  @spec construct(Types.microsecond_datetime, Types.valid_timezone) :: DateTime.t | AmbiguousDateTime.t | {:error, term}
   def construct({_, _, _} = date, timezone) do
     construct({date, {0,0,0,0}}, timezone)
   end

--- a/lib/timex/types.ex
+++ b/lib/timex/types.ex
@@ -31,10 +31,12 @@ defmodule Timex.Types do
   @type shift_units :: :milliseconds | :seconds | :minutes | :hours | :days | :weeks | :years
   @type time_units :: :microseconds | :milliseconds | :seconds | :minutes | :hours | :days | :weeks | :years
   @type time :: { hour, minute, second }
+  @type microsecond_time :: { hour, minute, second, microsecond | microseconds}
   @type date :: { year, month, day }
   @type datetime :: { date, time }
+  @type microsecond_datetime :: { date, microsecond_time }
   @type iso_triplet :: { year, weeknum, weekday }
   @type calendar_types :: Date.t | DateTime.t | NaiveDateTime.t
-  @type valid_datetime :: Date.t | DateTime.t | NaiveDateTime.t | datetime | date
+  @type valid_datetime :: Date.t | DateTime.t | NaiveDateTime.t | datetime | date | microsecond_datetime
   @type weekstart :: weekday | binary | atom
 end


### PR DESCRIPTION
The fourth element is treated as microseconds, either as a raw integer
or as an elixir `Calendar.microsecond` tuple.

Adds helper functions to make it easier to implement all the erlang
compliant functions.

As mentioned in https://github.com/bitwalker/timex/pull/321, we don't have typespecs for tuples containing microseconds, although most/some of the tuple implementation functions accept it.

This is fairly opinionated, and explicitly allows microseconds in all tuple functions for the Timex protocol.

I opted for allowing both integer microseconds and microsecond tuples, since it was easy and since that is what we accept to the construct-function (in the helpers) and in the map implementation.

### Checklist

- [x] New functions have typespecs, changed functions were updated
- [x] Same for documentation, including moduledocs
- [x] Tests were added or updated to cover changes
- [x] Commits were squashed into a single coherent commit
