### PR TITLE
Type documentation

### DIFF
--- a/lib/timex.ex
+++ b/lib/timex.ex
@@ -892,6 +892,9 @@ defmodule Timex do
   @doc """
   Get the day of the week corresponding to the given name.
 
+  The name can be given as a string of the weekday name or its first three characters
+  (lowercase or capitalized) or as a corresponding atom (lowercase only).
+
   ## Examples
 
       iex> #{__MODULE__}.day_to_num("Monday")
@@ -904,21 +907,25 @@ defmodule Timex do
       1
       iex> #{__MODULE__}.day_to_num(:mon)
       1
+      iex> #{__MODULE__}.day_to_num(:sunday)
+      7
 
   """
-  @spec day_to_num(binary | atom()) :: integer | {:error, :invalid_day_name}
+  @spec day_to_num(binary | atom()) :: Types.weekday | {:error, :invalid_day_name}
   Enum.each(@weekdays, fn {day_name, day_num} ->
     lower      = day_name |> String.downcase
     abbr_cased = day_name |> String.slice(0..2)
     abbr_lower = lower |> String.slice(0..2)
-    symbol     = abbr_lower |> String.to_atom
+    abbr_atom  = abbr_lower |> String.to_atom
+    atom       = lower |> String.to_atom
 
     day_quoted = quote do
       def day_to_num(unquote(day_name)),   do: unquote(day_num)
       def day_to_num(unquote(lower)),      do: unquote(day_num)
       def day_to_num(unquote(abbr_cased)), do: unquote(day_num)
       def day_to_num(unquote(abbr_lower)), do: unquote(day_num)
-      def day_to_num(unquote(symbol)),     do: unquote(day_num)
+      def day_to_num(unquote(abbr_atom)),do: unquote(day_num)
+      def day_to_num(unquote(atom)),     do: unquote(day_num)
     end
     Module.eval_quoted __MODULE__, day_quoted, [], __ENV__
   end)
@@ -1251,7 +1258,8 @@ defmodule Timex do
   @doc """
   Number of days to the beginning of the week
 
-  The weekstart can between 1..7, an atom e.g. :mon, or a string e.g. "Monday"
+  The weekstart determines which is the first day of the week, defaults to monday. It can be a number
+  between 1..7 (1 is monday, 7 is sunday), or any value accepted by `day_to_num/1`.
 
   ## Examples
 

--- a/lib/timex/types.ex
+++ b/lib/timex/types.ex
@@ -4,9 +4,9 @@ defmodule Timex.Types do
   @type year :: Calendar.year
   @type month :: Calendar.month
   @type day :: Calendar.day
-  @type daynum :: non_neg_integer
+  @type daynum :: 1..366
   @type weekday :: 1..7
-  @type weeknum :: non_neg_integer
+  @type weeknum :: 1..53
   # Time types
   @type hour :: Calendar.hour
   @type minute :: Calendar.minute
@@ -15,7 +15,6 @@ defmodule Timex.Types do
   @type timestamp :: {megaseconds, seconds, microseconds }
   @type megaseconds :: non_neg_integer
   @type seconds :: non_neg_integer
-  @type milliseconds :: non_neg_integer
   @type microseconds :: non_neg_integer
   # Timezone types
   @type time_zone :: Calendar.time_zone

--- a/lib/timex/types.ex
+++ b/lib/timex/types.ex
@@ -1,5 +1,4 @@
 defmodule Timex.Types do
-  @moduledoc false
 
   # Date types
   @type year :: Calendar.year

--- a/lib/timex/types.ex
+++ b/lib/timex/types.ex
@@ -6,7 +6,7 @@ defmodule Timex.Types do
   @type month :: Calendar.month
   @type day :: Calendar.day
   @type daynum :: non_neg_integer
-  @type weekday :: non_neg_integer
+  @type weekday :: 1..7
   @type weeknum :: non_neg_integer
   # Time types
   @type hour :: Calendar.hour

--- a/lib/timex/types.ex
+++ b/lib/timex/types.ex
@@ -23,9 +23,8 @@ defmodule Timex.Types do
   @type zone_abbr :: Calendar.zone_abbr
   @type utc_offset :: Calendar.utc_offset
   @type std_offset :: Calendar.std_offset
-  @type tz_offset :: -12..12
-  @type tz_offset_seconds :: integer
-  @type valid_timezone :: String.t | tz_offset | tz_offset_seconds | :utc | :local
+  @type tz_offset :: -14..12
+  @type valid_timezone :: String.t | tz_offset | :utc | :local
   # Complex types
   @type weekday_name :: :monday | :tuesday | :wednesday | :thursday | :friday | :saturday | :sunday
   @type shift_units :: :milliseconds | :seconds | :minutes | :hours | :days | :weeks | :years


### PR DESCRIPTION
With the current setup, the types declared in Timex.Types is displayed in the documentation but the types them selves are not. So there is no way for to see what the types mean in the documentation.

This PR adds the module to the docs, and cleans it up a little.
