### PR TITLE
Make sure all datetimes are converted before formatting

### DIFF
--- a/lib/format/datetime/formatter.ex
+++ b/lib/format/datetime/formatter.ex
@@ -46,13 +46,14 @@ defmodule Timex.Format.DateTime.Formatter do
     do: lformat!(datetime, format_string, locale, Strftime)
   def lformat!(datetime, format_string, locale, :relative),
     do: lformat!(datetime, format_string, locale, Relative)
-  def lformat!(datetime, format_string, locale, formatter)
-    when is_tuple(datetime),
-    do: lformat!(Timex.to_naive_datetime(datetime), format_string, locale, formatter)
   def lformat!(date, format_string, locale, formatter)
     when is_binary(format_string) and is_binary(locale) and is_atom(formatter)
     do
-      case formatter.lformat(date, format_string, locale) do
+      date = case date do
+         %{__struct__: struct} when struct in [Date, DateTime, NaiveDateTime] -> date
+         _other -> Timex.to_naive_datetime(date)
+      end
+      case formatter.lformat(date, format_string, locale)do
         {:ok, result}    -> result
         {:error, reason} -> raise FormatError, message: reason
       end

--- a/test/format_test.exs
+++ b/test/format_test.exs
@@ -9,6 +9,13 @@ defmodule DateFormatTest.GeneralFormatting do
     assert Timex.from_now(utc_date, ref_date) == Timex.from_now(cst_date, ref_date)
   end
 
+  test "converts maps and tuples before formatting" do
+    map = %{day: 9, hour: 15, min: 40, month: 7, sec: 33, usec: 0, year: 2017}
+    tuple = {{2017, 7, 9}, {15, 40, 33}} = Timex.to_erl(map)
+    assert "15:40:33" == Timex.format!(map, "{h24}:{m}:{s}")
+    assert "15:40:33" == Timex.format!(tuple, "{h24}:{m}:{s}")
+  end
+
   test "fractional seconds padding obeys formatting rules" do
     t = Timex.parse!("2017-06-28 20:21:22.000000", "%F %T.%f", :strftime)
     assert {0, 6} = t.microsecond


### PR DESCRIPTION
Fixes https://github.com/bitwalker/timex/issues/335

The formatters only support native date types, but we only
converted tuples. Maps (and Ecto.DateTime structs) were sent
as is, which caused issues when the keys where not the same as
in the native structs.

### Checklist

- [x] New functions have typespecs, changed functions were updated
- [x] Same for documentation, including moduledocs
- [x] Tests were added or updated to cover changes
- [x] Commits were squashed into a single coherent commit
