### PR TITLE
Partially fix incorrect typespecs

### DIFF
--- a/lib/convert/convert.ex
+++ b/lib/convert/convert.ex
@@ -5,7 +5,7 @@ defmodule Timex.Convert do
   Converts a map to a Date, NaiveDateTime or DateTime, depending on the amount
   of date/time information in the map.
   """
-  @spec convert_map(Map.t) :: Date.t | DateTime.t | NaiveDateTime.t | {:error, term}
+  @spec convert_map(map) :: Date.t | DateTime.t | NaiveDateTime.t | {:error, term}
   def convert_map(map) when is_map(map) do
     case convert_keys(map) do
       {:error, _} = err ->

--- a/lib/datetime/datetime.ex
+++ b/lib/datetime/datetime.ex
@@ -80,7 +80,7 @@ defimpl Timex.Protocol, for: DateTime do
     Timex.Timezone.end_of_day(datetime)
   end
 
-  @spec beginning_of_week(DateTime.t, Types.weekstart) :: DateTime.t | AmbiguousDateTime.t
+  @spec beginning_of_week(DateTime.t, Types.weekstart) :: DateTime.t | AmbiguousDateTime.t | {:error, term}
   def beginning_of_week(%DateTime{} = date, weekstart) do
     case Timex.days_to_beginning_of_week(date, weekstart) do
       {:error, _} = err -> err
@@ -88,7 +88,7 @@ defimpl Timex.Protocol, for: DateTime do
     end
   end
 
-  @spec end_of_week(DateTime.t, Types.weekstart) :: DateTime.t | AmbiguousDateTime.t
+  @spec end_of_week(DateTime.t, Types.weekstart) :: DateTime.t | AmbiguousDateTime.t | {:error, term}
   def end_of_week(%DateTime{} = date, weekstart) do
     case Timex.days_to_end_of_week(date, weekstart) do
       {:error, _} = err -> err

--- a/lib/interval/interval.ex
+++ b/lib/interval/interval.ex
@@ -78,7 +78,7 @@ defmodule Timex.Interval do
       "[15:30, 15:50]"
 
   """
-  @spec new(Keyword.t) :: Interval.t | {:error, :invalid_until} | {:error, :invalid_step}
+  @spec new(Keyword.t) :: t | {:error, :invalid_until} | {:error, :invalid_step}
   def new(options \\ []) do
     from = case Keyword.get(options, :from) do
       nil -> Timex.Protocol.NaiveDateTime.now()
@@ -105,7 +105,7 @@ defmodule Timex.Interval do
     build_struct_or_error(attrs)
   end
 
-  @spec build_struct_or_error(map()) :: Interval.t | {:error, atom()}
+  @spec build_struct_or_error(map()) :: t | {:error, atom()}
   defp build_struct_or_error(%{until: err = {:error, _}}), do: err
   defp build_struct_or_error(%{step:  err = {:error, _}}), do: err
   defp build_struct_or_error(valid_attrs),                 do: struct(__MODULE__, valid_attrs)
@@ -170,7 +170,7 @@ defmodule Timex.Interval do
       ["2014-09-22", "2014-09-25"]
 
   """
-  @spec with_step(Interval.t, any()) :: Interval.t | {:error, :invalid_step}
+  @spec with_step(t, any()) :: t | {:error, :invalid_step}
   def with_step(%__MODULE__{} = interval, step) do
     case valid_step_or_error(step) do
       error = {:error, _} -> error

--- a/lib/protocol.ex
+++ b/lib/protocol.ex
@@ -6,6 +6,8 @@ defprotocol Timex.Protocol do
 
   @fallback_to_any true
 
+  alias Timex.Types
+
   @doc """
   Convert a date/time value to a Julian calendar date number
   """
@@ -42,7 +44,7 @@ defprotocol Timex.Protocol do
   """
   @spec to_datetime(Types.valid_datetime) :: DateTime.t | {:error, term}
   @spec to_datetime(Types.valid_datetime, Types.valid_timezone) ::
-    DateTime.t | AmbiguousDateTime.t | {:error, term}
+    DateTime.t | Timex.AmbiguousDateTime.t | {:error, term}
   def to_datetime(datetime, timezone \\ :utc)
 
   @doc """
@@ -75,13 +77,13 @@ defprotocol Timex.Protocol do
   Shift a date/time value using a list of shift unit/value pairs
   """
   @spec shift(Types.valid_datetime, Timex.shift_options) ::
-    Types.valid_datetime | AmbiguousDateTime.t | {:error, term}
+    Types.valid_datetime | Timex.AmbiguousDateTime.t | {:error, term}
   def shift(datetime, options)
 
   @doc """
   Set fields on a date/time value using a list of unit/value pairs
   """
-  @spec set(Types.valid_datetime, Timex.  set_options) :: Types.valid_datetime
+  @spec set(Types.valid_datetime, Timex.set_options) :: Types.valid_datetime | {:error, term}
   def set(datetime, options)
 
   @doc """
@@ -161,7 +163,7 @@ defprotocol Timex.Protocol do
   @doc """
   Get the week number of the given date/time value, starting at 1
   """
-  @spec week_of_month(Types.valid_datetime) :: Types.week_of_month
+  @spec week_of_month(Types.valid_datetime) :: Types.week_of_month | {:error, term}
   def week_of_month(datetime)
 
   @doc """

--- a/lib/timex.ex
+++ b/lib/timex.ex
@@ -668,7 +668,7 @@ defmodule Timex do
       {"Etc/GMT-2", "+02"}
 
   """
-  @spec timezone(Types.valid_timezone, Types.valid_datetime) ::
+  @spec timezone(Types.valid_timezone | TimezoneInfo.t, Types.valid_datetime) ::
     TimezoneInfo.t | AmbiguousTimezoneInfo.t | {:error, term}
   def timezone(:utc, _),      do: %TimezoneInfo{}
   def timezone("UTC", _),     do: %TimezoneInfo{}

--- a/lib/timex/helpers.ex
+++ b/lib/timex/helpers.ex
@@ -2,6 +2,7 @@ defmodule Timex.Helpers do
   @moduledoc false
   use Timex.Constants
   import Timex.Macros
+  alias Timex.Types
 
   @doc """
   Given a {year, day} tuple where the day is the iso day of that year, returns 

--- a/lib/timex/types.ex
+++ b/lib/timex/types.ex
@@ -4,7 +4,9 @@ defmodule Timex.Types do
   @type year :: Calendar.year
   @type month :: Calendar.month
   @type day :: Calendar.day
+  @type num_of_days :: 28..31
   @type daynum :: 1..366
+  @type week_of_month :: 1..5
   @type weekday :: 1..7
   @type weeknum :: 1..53
   # Time types

--- a/lib/timezone/ambiguous_timezone_info.ex
+++ b/lib/timezone/ambiguous_timezone_info.ex
@@ -4,9 +4,14 @@ defmodule Timex.AmbiguousTimezoneInfo do
   point in time.
   """
   alias Timex.TimezoneInfo
+
+  @type t :: %__MODULE__{before: TimezoneInfo.t,
+                         after: TimezoneInfo.t}
+
   defstruct before: nil,
             after: nil
 
+  @spec new(before_tz :: TimezoneInfo.t, after_tz :: TimezoneInfo.t) :: t
   def new(%TimezoneInfo{} = before_tz, %TimezoneInfo{} = after_tz) do
     %__MODULE__{before: before_tz, after: after_tz}
   end


### PR DESCRIPTION
This is attempt to fix warnings that Dialyzer emits in this project. Initially I tried to upgrade one of our projects to OTP 20, but after upgrade Dialyzer started complaining about `unknown type 'Elixir.Map'.t` (we run Dialyzer with flag `-Wunknown`). I found few occurrences of `Map.t` in dependencies, one of which is Timex.

So I cloned the repo and ran `mix dialyze --unknown` and got a red screen of warnings :) I've fixed few of them, but more emerged. Unfortunately, I don't know the codebase of `timex` too well to fix all the warnings, but I hope I made a step in right direction.

In its current state, Dialyzer emits 6 warnings without `-Wunknown` flag and 26 warnings with `-Wunknown` flag.
