### PR TITLE
adds support for month and year steps in Timex.Interval

### DIFF
--- a/lib/interval/interval.ex
+++ b/lib/interval/interval.ex
@@ -22,7 +22,9 @@ defmodule Timex.Interval do
                                [minutes:      integer()] |
                                [hours:        integer()] |
                                [days:         integer()] |
-                               [weeks:        integer()]
+                               [weeks:        integer()] |
+                               [months:       integer()] |
+                               [year:         integer()]
 
   @enforce_keys [:from, :until]
   defstruct from:       nil,
@@ -78,7 +80,7 @@ defmodule Timex.Interval do
       "[15:30, 15:50]"
 
   """
-  @spec new(Keyword.t) :: t | {:error, :invalid_until} | {:error, :invalid_step}
+  @spec new(Keyword.t) :: Interval.t | {:error, :invalid_until} | {:error, :invalid_step}
   def new(options \\ []) do
     from = case Keyword.get(options, :from) do
       nil -> Timex.Protocol.NaiveDateTime.now()
@@ -105,7 +107,7 @@ defmodule Timex.Interval do
     build_struct_or_error(attrs)
   end
 
-  @spec build_struct_or_error(map()) :: t | {:error, atom()}
+  @spec build_struct_or_error(map()) :: Interval.t | {:error, atom()}
   defp build_struct_or_error(%{until: err = {:error, _}}), do: err
   defp build_struct_or_error(%{step:  err = {:error, _}}), do: err
   defp build_struct_or_error(valid_attrs),                 do: struct(__MODULE__, valid_attrs)
@@ -118,6 +120,8 @@ defmodule Timex.Interval do
   defp valid_step_or_error(step = [hours: _]),        do: step
   defp valid_step_or_error(step = [days: _]),         do: step
   defp valid_step_or_error(step = [weeks: _]),        do: step
+  defp valid_step_or_error(step = [months: _]),       do: step
+  defp valid_step_or_error(step = [years: _]),       do: step
   defp valid_step_or_error(_),                        do: {:error, :invalid_step}
 
   @doc """
@@ -170,7 +174,7 @@ defmodule Timex.Interval do
       ["2014-09-22", "2014-09-25"]
 
   """
-  @spec with_step(t, any()) :: t | {:error, :invalid_step}
+  @spec with_step(Interval.t, any()) :: Interval.t | {:error, :invalid_step}
   def with_step(%__MODULE__{} = interval, step) do
     case valid_step_or_error(step) do
       error = {:error, _} -> error

--- a/test/interval_test.exs
+++ b/test/interval_test.exs
@@ -18,6 +18,8 @@ defmodule IntervalTests do
       assert %Interval{step: [hours: 5]}        = Interval.new(step: [hours: 5])
       assert %Interval{step: [days: 5]}         = Interval.new(step: [days: 5])
       assert %Interval{step: [weeks: 5]}        = Interval.new(step: [weeks: 5])
+      assert %Interval{step: [months: 5]}       = Interval.new(step: [months: 5])
+      assert %Interval{step: [years: 5]}       =  Interval.new(step: [years: 5])
     end
 
     test "returns an error tuple when given an invalid step" do
@@ -55,6 +57,8 @@ defmodule IntervalTests do
       assert %Interval{step: [hours: 5]}        = Interval.with_step(interval, [hours: 5])
       assert %Interval{step: [days: 5]}         = Interval.with_step(interval, [days: 5])
       assert %Interval{step: [weeks: 5]}        = Interval.with_step(interval, [weeks: 5])
+      assert %Interval{step: [months: 5]}       = Interval.with_step(interval, [months: 5])
+      assert %Interval{step: [years: 5]}       =  Interval.with_step(interval, [years: 5])
     end
 
     test "returns error tuple when given invalid step unit" do


### PR DESCRIPTION
adds support for month and year as a valid step for the Timex.Interval,
both in the “new” and “with_step” function. Also adds the given tests
into interval_test to make sure that the step type is correctly created.

### Summary of changes

The documentation of _Timex.Interval.with_step_ states "The step should be a keyword list valid for use with Timex.Date.shift.", but does not not support having a step size by months/years. This PR just adds those two step sizes

### Checklist

- [x] New functions have typespecs, changed functions were updated
- [x] Same for documentation, including moduledocs
- [x] Tests were added or updated to cover changes
- [x] Commits were squashed into a single coherent commit
