### PR TITLE
Add comparison options to Timex.between?

### DIFF
--- a/lib/timex.ex
+++ b/lib/timex.ex
@@ -765,17 +765,29 @@ defmodule Timex do
   end
 
   @doc """
-  Returns a boolean indicating whether the first `Timex.Comparable` occurs between the second and third
+  Returns a boolean indicating whether the first `Timex.Comparable` occurs between the second
+  and third.
+
+  By default, the `start`and `ending` bounds are *exclusive*. You can opt for inclusive bounds
+  by setting the `:inclusive` option to `true`.
+
   """
-  @spec between?(Comparable.comparable, Comparable.comparable, Comparable.comparable) ::
+  @type between_options :: [
+    inclusive: boolean
+  ]
+  @spec between?(Comparable.comparable, Comparable.comparable, Comparable.comparable, between_options) ::
     boolean | {:error, term}
-  def between?(a, start, ending) do
-    is_after_start? = after?(a, start)
-    is_before_end?  = before?(a, ending)
-    case {is_after_start?, is_before_end?} do
-      {{:error, _} = err, _} -> err
-      {_, {:error, _} = err} -> err
-      {true, true} -> true
+  def between?(a, start, ending, options \\ []) do
+    inclusive = Keyword.get(options, :inclusive, false)
+
+    after_start = compare(a, start)
+    before_ending = compare(a, ending)
+
+    case {inclusive, after_start, before_ending} do
+      {_, {:error, _} = err, _} -> err
+      {_, _, {:error, _} = err} -> err
+      {true, lo, hi} when lo >= 0 and hi <= 0 -> true
+      {false, 1, -1} -> true
       _ -> false
     end
   end

--- a/test/timex_test.exs
+++ b/test/timex_test.exs
@@ -238,6 +238,23 @@ defmodule TimexTests do
     assert {:error, :invalid_date} == Timex.after?({{2013, 1, 1}, {1, 1, 2}}, {})
   end
 
+  test "between?" do
+    date1 = Timex.to_datetime({{2013,1,1},{0, 0, 0}})
+    date2 = Timex.to_datetime({{2013,1,5},{0, 0, 0}})
+    date3 = Timex.to_datetime({{2013,1,9},{0, 0, 0}})
+
+    assert true == Timex.between?(date2, date1, date3)
+
+    assert false == Timex.between?(date1, date2, date3)
+    assert false == Timex.between?(date3, date1, date2)
+    assert false == Timex.between?(date1, date1, date3)
+    assert false == Timex.between?(date3, date1, date3)
+
+    assert {:error, :invalid_date} == Timex.between?({}, {{2013, 1, 1}, {1, 1, 2}}, {{2013, 1, 1}, {1, 1, 2}})
+    assert {:error, :invalid_date} == Timex.between?({{2013, 1, 1}, {1, 1, 2}}, {}, {{2013, 1, 1}, {1, 1, 2}})
+    assert {:error, :invalid_date} == Timex.between?({{2013, 1, 1}, {1, 1, 2}}, {{2013, 1, 1}, {1, 1, 2}}, {})
+  end
+
   test "equal" do
     assert Timex.equal?(Timex.today, Timex.today)
     refute Timex.equal?(Timex.today, Timex.epoch)

--- a/test/timex_test.exs
+++ b/test/timex_test.exs
@@ -255,6 +255,25 @@ defmodule TimexTests do
     assert {:error, :invalid_date} == Timex.between?({{2013, 1, 1}, {1, 1, 2}}, {{2013, 1, 1}, {1, 1, 2}}, {})
   end
 
+  test "between? inclusive" do
+    date1 = Timex.to_datetime({{2013,1,1},{0, 0, 0}})
+    date2 = Timex.to_datetime({{2013,1,5},{0, 0, 0}})
+    date3 = Timex.to_datetime({{2013,1,9},{0, 0, 0}})
+
+    options = [inclusive: true]
+
+    assert true == Timex.between?(date2, date1, date3, options)
+    assert true == Timex.between?(date1, date1, date3, options)
+    assert true == Timex.between?(date3, date1, date3, options)
+
+    assert false == Timex.between?(date1, date2, date3, options)
+    assert false == Timex.between?(date3, date1, date2, options)
+
+    assert {:error, :invalid_date} == Timex.between?({}, {{2013, 1, 1}, {1, 1, 2}}, {{2013, 1, 1}, {1, 1, 2}}, options)
+    assert {:error, :invalid_date} == Timex.between?({{2013, 1, 1}, {1, 1, 2}}, {}, {{2013, 1, 1}, {1, 1, 2}}, options)
+    assert {:error, :invalid_date} == Timex.between?({{2013, 1, 1}, {1, 1, 2}}, {{2013, 1, 1}, {1, 1, 2}}, {}, options)
+  end
+
   test "equal" do
     assert Timex.equal?(Timex.today, Timex.today)
     refute Timex.equal?(Timex.today, Timex.epoch)


### PR DESCRIPTION
### Summary of changes

Adds the `:inclusive` and  `:granularity` options to `Timex.between?`, as discussed in #340.

### Checklist

- [X] New functions have typespecs, changed functions were updated
- [X] Same for documentation, including moduledocs
- [X] Tests were added or updated to cover changes
- [ ] Commits were squashed into a single coherent commit
