### PR TITLE
Fix issue #349: crash on `Timex.local` on input with ambiguous wall time

### DIFF
--- a/lib/timex.ex
+++ b/lib/timex.ex
@@ -58,29 +58,14 @@ defmodule Timex do
   Returns a DateTime representing the current moment in time in the local timezone.
   """
   @spec local() :: DateTime.t | AmbiguousDateTime.t | {:error, term}
-  def local() do
-    case Timezone.local(:calendar.local_time) do
-      %AmbiguousTimezoneInfo{after: a, before: b} ->
-        d = now()
-        ad = Timezone.convert(d, a.full_name)
-        bd = Timezone.convert(d, b.full_name)
-        %AmbiguousDateTime{after: ad, before: bd}
-      %TimezoneInfo{full_name: tz} ->
-        now(tz)
-      {:error, _} = err -> err
-    end
-  end
+  def local(), do: local(now())
 
   @doc """
   Returns a DateTime representing the given date/time in the local timezone
   """
   @spec local(Types.valid_datetime) :: DateTime.t | AmbiguousDateTime.t | {:error, term}
   def local(date) do
-    reference_date = to_erl(date)
-    case Timezone.local(reference_date) do
-      {:error, _} = err -> err
-      tz -> Timezone.convert(date, tz.full_name)
-    end
+    Timezone.convert(date, :local)
   end
 
   @doc """

--- a/test/timex_test.exs
+++ b/test/timex_test.exs
@@ -3,6 +3,39 @@ defmodule TimexTests do
   use Timex
   doctest Timex
 
+  describe "local" do
+    test "without argument" do
+      date = %DateTime{} = Timex.local()
+      assert Timex.equal?(Timex.now(), date)
+    end
+
+    test "with now" do
+      now = Timex.now()
+      assert Timex.equal?(Timex.local(now), now)
+    end
+
+    test "with ambiguous datetime" do
+      Application.put_env(:timex, :local_timezone, "America/Sao_Paulo")
+      naive_datetime1 = ~N[2017-02-18T22:30:00]
+      naive_datetime2 = Timex.shift(naive_datetime1, hours: 1)
+      naive_datetime3 = Timex.shift(naive_datetime1, hours: 2)
+      naive_datetime4 = Timex.shift(naive_datetime1, hours: 3)
+      naive_datetime5 = Timex.shift(naive_datetime1, hours: 4)
+
+      datetime1 = %DateTime{} = Timex.Timezone.convert(naive_datetime1, "America/Sao_Paulo")
+      datetime2 = %DateTime{} = Timex.Timezone.convert(naive_datetime2, "America/Sao_Paulo")
+      datetime3 = %DateTime{} = Timex.Timezone.convert(naive_datetime3, "America/Sao_Paulo")
+      datetime4 = %DateTime{} = Timex.Timezone.convert(naive_datetime4, "America/Sao_Paulo")
+      datetime5 = %DateTime{} = Timex.Timezone.convert(naive_datetime5, "America/Sao_Paulo")
+      assert datetime1 == Timex.local(naive_datetime1)
+      assert datetime2 == Timex.local(naive_datetime2)
+      assert datetime3 == Timex.local(naive_datetime3)
+      assert datetime4 == Timex.local(naive_datetime4)
+      assert datetime5 == Timex.local(naive_datetime5)
+      Application.put_env(:timex, :local_timezone, nil)
+    end
+  end
+
   test "century" do
     assert 21 === Timex.century
 


### PR DESCRIPTION
Previously, the timezone checked for ambiguity on the input date before
converting it to the actual timezone, so the local function could get
an AmbiguousTimezoneInfo for dates that aren't actually ambiguous in
the target timezone.

As far as I can see, `Timex.local/1` is just syntactic sugar for
`Timex.Timezone.convert(date, :local)`, which is the solution I've used.

The tests on this is intended to check that a DateTime can be safely converted to the local timezone even if the input or output time matches an ambiguous wall time period. These tests will fail right now, since they depend on the changes I suggested in https://github.com/bitwalker/timex/pull/353. If that is rejected, I'll rewrite the tests.

### Checklist

- [x] New functions have typespecs, changed functions were updated
- [x] Same for documentation, including moduledocs
- [x] Tests were added or updated to cover changes
- [x] Commits were squashed into a single coherent commit
