### PR TITLE
Fix #356 - parsing of milliseconds

### DIFF
--- a/lib/parse/datetime/helpers.ex
+++ b/lib/parse/datetime/helpers.ex
@@ -55,7 +55,8 @@ defmodule Timex.Parse.DateTime.Helpers do
   end
 
   def parse_milliseconds(ms) do
-    n = ms |> String.trim("0") |> String.to_integer
+    n = ms |> String.trim_leading("0")
+    n = if n == "", do: 0, else: String.to_integer(n)
     n = n * 1_000
     [sec_fractional: Timex.DateTime.Helpers.construct_microseconds(n)]
   end

--- a/test/parse_strftime_test.exs
+++ b/test/parse_strftime_test.exs
@@ -37,6 +37,16 @@ defmodule DateFormatTest.ParseStrftime do
     assert {:ok, ^date} = parse("20150713 14:01:21.038", "%Y%m%d %H:%M:%S.%L")
   end
 
+  test "issue #356 - millisecond parsing" do
+    {:ok, ms1} = parse("000", "%L")
+    {:ok, ms2} = parse("010", "%L")
+    {:ok, ms3} = parse("100", "%L")
+
+    assert elem(ms1.microsecond, 0) == 0
+    assert elem(ms2.microsecond, 0) == 10 * 1_000
+    assert elem(ms3.microsecond, 0) == 100 * 1_000
+  end
+
   defp parse(date, fmt) do
     Timex.parse(date, fmt, :strftime)
   end


### PR DESCRIPTION
### Summary of changes

This fixes issue #356.

The use of `ms |> String.trim("0")` could result in an empty string when
the input was "000", which in turn made `String.to_integer` complain.

Since `trim` removes zeros from both ends of the string, milliseconds
ending in `0` or `00` were incorrectly parsed as well.

This commit changes `String.trim` to `String.trim_leading` and adds
a safety-clause to protect against the "000" input.

I tried to keep the changes minimal: I added a failing test to demonstrate the problem and then made it pass. I'm still very new to Elixir so the test is probably much uglier than it could be. I think `elem(x, 0)` is a smell here, but the second element of the tuple (the required precision) changed in ways I did not quite understand. I'd be happy to update the pull request with any needed changes.

I hope the pull request is acceptable without added typespecs -- still trying to figure those out.

### Checklist

- [ ] New functions have typespecs, changed functions were updated
- [ ] Same for documentation, including moduledocs
- [x] Tests were added or updated to cover changes
- [x] Commits were squashed into a single coherent commit
