### PR TITLE
Fix #358: Do not try to convert Time to a NaiveDateTime before formatting

### DIFF
--- a/lib/format/datetime/formatter.ex
+++ b/lib/format/datetime/formatter.ex
@@ -50,7 +50,7 @@ defmodule Timex.Format.DateTime.Formatter do
     when is_binary(format_string) and is_binary(locale) and is_atom(formatter)
     do
       date = case date do
-         %{__struct__: struct} when struct in [Date, DateTime, NaiveDateTime] -> date
+         %{__struct__: struct} when struct in [Date, DateTime, NaiveDateTime, Time] -> date
          _other -> Timex.to_naive_datetime(date)
       end
       case formatter.lformat(date, format_string, locale)do

--- a/test/format_test.exs
+++ b/test/format_test.exs
@@ -16,6 +16,11 @@ defmodule DateFormatTest.GeneralFormatting do
     assert "15:40:33" == Timex.format!(tuple, "{h24}:{m}:{s}")
   end
 
+  test "issue #358 - formatting a Time returns wrong result" do
+    time = ~T[17:00:00]
+    assert "17:00:00" == Timex.format!(time,"{h24}:{m}:{s}")
+  end
+
   test "fractional seconds padding obeys formatting rules" do
     t = Timex.parse!("2017-06-28 20:21:22.000000", "%F %T.%f", :strftime)
     assert {0, 6} = t.microsecond


### PR DESCRIPTION
[`41b46b81`](https://github.com/bitwalker/timex/pull/336/commits/41b46b8193ec9d4c97cef7a172f65cae874d55f4)/#336 adds a whitelist of native date types, and converts everything else to a `NaiveDateTime` before formatting. The `Time` type/struct was omitted from the list.

I assume the intention was to whitelist `Time` as well, as it is also a native "date" type. It also cannot be converted to a `NaiveDateTime`, as it represents only a time of day.

I've also added a test in the style of other issue fixes I've seen.

I'm new to both Elixir and Timex, so please let me know if I'm missing anything, and don't hesitate to request any changes! Thanks!
