### PR TITLE
Add support for weeks in iso8601 duration parser (#350)

### DIFF
--- a/lib/parse/duration/parsers/iso8601.ex
+++ b/lib/parse/duration/parsers/iso8601.ex
@@ -77,6 +77,7 @@ defmodule Timex.Parse.Duration.Parsers.ISO8601Parser do
   def parse(<<c::utf8, _::binary>>), do: {:error, "expected P, got #{<<c::utf8>>}"}
   def parse(s) when is_binary(s), do: {:error, "unexpected end of input"}
 
+  @spec parse_components(binary, [{integer, number}]) :: [{integer, number}] | {:error, String.t}
   defp parse_components(<<>>, acc),
     do: Enum.reverse(acc)
   defp parse_components(<<?T>>, _acc),
@@ -96,6 +97,7 @@ defmodule Timex.Parse.Duration.Parsers.ISO8601Parser do
   defp parse_components(<<c::utf8, _::binary>>, _acc),
     do: {:error, "expected numeric, but got #{<<c::utf8>>}"}
 
+  @spec parse_component(binary, binary) :: {integer, number, binary}
   defp parse_component(<<c::utf8>>, _acc) when c in @numeric,
     do: {:error, "unexpected end of input at #{<<c::utf8>>}"}
   defp parse_component(<<c::utf8>>, acc) when c in 'WYMDHS' do


### PR DESCRIPTION
According to the ISO 8601, there are two formats for representing a duration:

> In both basic and extended format the complete representation of the expression for duration shall be [PnnW] or [PnnYnnMnnDTnnHnnMnnS].

This PR implements the first of those, as requested in #350.

    iex(1)> Timex.Duration.parse("P2W")
    {:ok, #<Duration(P14D)>}

However, I'm unsure about how to handle mixing the formats. While the ISO standard does not explicitly prohibit combining the two formats, it does clearly distinguish them, suggesting that they should be used separately. Because of this, I am inclined to treat any combination of the two formats as invalid input. However, both the Nodejs library linked to in the issue and Python's `isodate` (to give another example), _do_ support this, in different ways:

The node library will ignore the `W` designator, or everything except `W`, depending on which comes first.

The Python library will take into account both. From the library's test suite:

> ```
> (parse_duration("P1Y1M5W"),
>    [...should equal the difference between...]
>    date(2000, 1, 30),
>    date(2001, 4, 4)),
> ```

I also added some typespecs for the internal parsing functions in a different commit. It took me a while to understand those, so I thought the specs could be helpful. I'd be happy to remove them though.


### Checklist

- [x] New functions have typespecs, changed functions were updated
- [x] Same for documentation, including moduledocs
- [x] Tests were added or updated to cover changes
- [ ] Commits were squashed into a single coherent commit
