### PR TITLE
Update combine v0.7 -> v0.10

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -38,7 +38,7 @@ defmodule Timex.Mixfile do
 
   def deps do
     [{:tzdata, "~> 0.1.8 or ~> 0.5"},
-     {:combine, "~> 0.7"},
+     {:combine, "~> 0.10"},
      {:gettext, "~> 0.10"},
      {:ex_doc, "~> 0.13", only: :dev},
      {:benchfella, "~> 0.3", only: :dev},

--- a/mix.lock
+++ b/mix.lock
@@ -1,6 +1,6 @@
 %{"benchfella": {:hex, :benchfella, "0.3.5", "b2122c234117b3f91ed7b43b6e915e19e1ab216971154acd0a80ce0e9b8c05f5", [:mix], [], "hexpm"},
   "certifi": {:hex, :certifi, "2.0.0", "a0c0e475107135f76b8c1d5bc7efb33cd3815cb3cf3dea7aefdd174dabead064", [:rebar3], [], "hexpm"},
-  "combine": {:hex, :combine, "0.9.6", "8d1034a127d4cbf6924c8a5010d3534d958085575fa4d9b878f200d79ac78335", [:mix], [], "hexpm"},
+  "combine": {:hex, :combine, "0.10.0", "eff8224eeb56498a2af13011d142c5e7997a80c8f5b97c499f84c841032e429f", [:mix], [], "hexpm"},
   "dialyze": {:hex, :dialyze, "0.2.1", "9fb71767f96649020d769db7cbd7290059daff23707d6e851e206b1fdfa92f9d", [:mix], [], "hexpm"},
   "earmark": {:hex, :earmark, "1.2.2", "f718159d6b65068e8daeef709ccddae5f7fdc770707d82e7d126f584cd925b74", [:mix], [], "hexpm"},
   "ex_doc": {:hex, :ex_doc, "0.16.2", "3b3e210ebcd85a7c76b4e73f85c5640c011d2a0b2f06dcdf5acdb2ae904e5084", [:mix], [{:earmark, "~> 1.1", [hex: :earmark, repo: "hexpm", optional: false]}], "hexpm"},


### PR DESCRIPTION
### Summary of changes

Update combine v0.7 -> v0.10. Cleans up deprecation errors related to `filter_map`.

All tests are still passing.