### PR TITLE
Correct spurious Tuple.to_date/2

### DIFF
--- a/lib/datetime/erlang.ex
+++ b/lib/datetime/erlang.ex
@@ -45,7 +45,7 @@ defimpl Timex.Protocol, for: Tuple do
   def to_datetime({{y,m,d},{h,mm,s,_us}} = dt, timezone) when is_datetime(y,m,d,h,mm,s) do
     Timex.DateTime.Helpers.construct(dt, timezone)
   end
-  def to_date(_, _), do: {:error, :invalid_date}
+  def to_datetime(_, _), do: {:error, :invalid_date}
 
   @spec to_naive_datetime(Types.date | Types.datetime | Types.microsecond_datetime) :: NaiveDateTime.t
   def to_naive_datetime({{y,m,d},{h,mm,s,us}}) when is_datetime(y,m,d,h,mm,s) do

--- a/test/timex_test.exs
+++ b/test/timex_test.exs
@@ -628,6 +628,16 @@ defmodule TimexTests do
     assert {:error, :invalid_date} == Timex.end_of_day(nil)
   end
 
+  test "to_datetime with invalid dates" do
+    # invalid date tuple
+    assert {:error, :invalid_date} == Timex.to_datetime({2015, 1}, {0,0,0})
+    assert {:error, :invalid_date} == Timex.to_datetime({2015, 1, 1, 1}, {0,0,0})
+
+    # just plain wrong
+    assert {:error, :invalid_date} == Timex.to_datetime("some day", {0,0,0})
+    assert {:error, :invalid_date} == Timex.to_datetime("some day", "some time")
+  end
+
   test "start and end for all types" do
     datetime = Timex.now()
 


### PR DESCRIPTION
### Summary of changes

I noticed that the [Inch CI docs test page](https://inch-ci.org/github/bitwalker/timex) was reporting that `Timex.Protocol.Tuple.to_date/2` was missing documentation.

After hunting it down in `erlang.ex` it looks like it was a copy-paste mistake and was intended to be a fail-through guard case of `to_datetime/2`.

I added a test which I believe covers this guard case.

### Checklist

- [x] New functions have typespecs, changed functions were updated
- [x] Same for documentation, including moduledocs
- [x] Tests were added or updated to cover changes
- [x] Commits were squashed into a single coherent commit
