### PR TITLE
Fix #360 Update shift and diff by month

### DIFF
--- a/lib/comparable/comparable.ex
+++ b/lib/comparable/comparable.ex
@@ -38,6 +38,17 @@ defprotocol Timex.Comparable do
     - {:error, reason}: when there was a problem comparing,
       perhaps due to a value being passed which is not a valid date/datetime
 
+  ## Examples
+
+      iex> use Timex
+      iex> date1 = ~D[2014-03-04]
+      iex> date2 = ~D[2015-03-04]
+      iex> Timex.compare(date1, date2, :years)
+      -1
+      iex> Timex.compare(date2, date1, :years)
+      1
+      iex> Timex.compare(date1, date1)
+      0
   """
   @spec compare(comparable, comparable, granularity) :: compare_result
   def compare(a, b, granularity \\ :microseconds)
@@ -62,6 +73,27 @@ defprotocol Timex.Comparable do
   and the result will be an integer value of those units or a Duration struct.
   The diff value will be negative if `a` comes before `b`, and positive if `a` comes
   after `b`. This behaviour mirrors `compare/3`.
+
+  When using granularity of :months, the number of days in the month varies. This
+  behavior mirrors `Timex.shift/2`.
+
+  ## Examples
+
+      iex> use Timex
+      iex> date1 = ~D[2015-01-28]
+      iex> date2 = ~D[2015-02-28]
+      iex> Timex.diff(date1, date2, :months)
+      -1
+      iex> Timex.diff(date2, date1, :months)
+      1
+
+      iex> use Timex
+      iex> date1 = ~D[2015-01-31]
+      iex> date2 = ~D[2015-02-28]
+      iex> Timex.diff(date1, date2, :months)
+      -1
+      iex> Timex.diff(date2, date1, :months)
+      0
   """
   @spec diff(comparable, comparable, granularity) :: diff_result
   def diff(a, b, granularity \\ :microseconds)

--- a/lib/comparable/diff.ex
+++ b/lib/comparable/diff.ex
@@ -100,40 +100,21 @@ defmodule Timex.Comparable.Diff do
   defp diff_months(a, b) do
     {start_date, _} = :calendar.gregorian_seconds_to_datetime(div(a, 1_000*1_000))
     {end_date, _} = :calendar.gregorian_seconds_to_datetime(div(b, 1_000*1_000))
-    if a > b do
-      do_diff_months(end_date, start_date)
-    else
-      do_diff_months(start_date, end_date) * -1
+    do_diff_months(start_date, end_date)
+  end
+
+  defp do_diff_months({y, m, _}, {y, m, _}), do: 0
+  defp do_diff_months({y1, m1, d1}, {y2, m2, d2}) do
+    months = (y1 - y2) * 12 + m1 - m2
+    days_in_month2 = Timex.days_in_month(y2, m2)
+
+    cond do
+      months < 0 && d2 < d1 && (days_in_month2 >= d1 || days_in_month2 != d2) ->
+        months + 1
+      months > 0 && d2 > d1 ->
+        months - 1
+      true ->
+        months
     end
-  end
-  defp do_diff_months({y,m,_}, {y,m,_}), do: 0
-  defp do_diff_months({y1, m1, d1}, {y2, m2, d2}) when y1 <= y2 and m1 < m2 do
-    year_diff = y2 - y1
-    month_diff = if d2 >= d1, do: m2 - m1, else: (m2-1)-m1
-    (year_diff*12)+month_diff
-  end
-  defp do_diff_months({y1,m1,d1}, {y2,m2,d2}) when y1 < y2 and m1 > m2 do
-    year_diff = y2 - (y1+1)
-    month_diff =
-      cond do
-        d2 == d1 ->
-          12 - (m1-m2)
-        d2 > d1 ->
-          12 - ((m1-1)-m2)
-        d2 < d1 ->
-          12 - (m1-m2)
-      end
-    (year_diff*12)+month_diff
-  end
-  defp do_diff_months({y1,m,d1}, {y2,m,d2}) when y1 < y2 do
-    year_diff = y2 - (y1+1)
-    month_diff =
-      cond do
-        d2 > d1 ->
-          11
-        :else ->
-          12
-      end
-    (year_diff*12)+month_diff
   end
 end

--- a/lib/datetime/datetime.ex
+++ b/lib/datetime/datetime.ex
@@ -325,26 +325,20 @@ defimpl Timex.Protocol, for: DateTime do
       end
 
     # If the shift fails, it's because it's a high day number, and the month
-    # shifted to does not have that many days. We will handle this by shifting
-    # the leftover days into the next month
+    # shifted to does not have that many days. This will be handled by always
+    # shifting to the last day of the month shifted to.
     if :calendar.valid_date({shifted.year,shifted.month,shifted.day}) do
-      resolve_timezone_info(shifted)
+      shifted
     else
       last_day = :calendar.last_day_of_the_month(shifted.year, shifted.month)
-      shifted_year = shifted.year
-      shifted_month = shifted.month
-      shifted_day = shifted.day
-      shifted =
-        cond do
-          shifted_day <= last_day ->
-            shifted
-          shifted_day > last_day && shifted_month < 12 ->
-            %{shifted | :day => shifted_day - last_day, :month => shifted_month + 1}
-          shifted_day > last_day && shifted_month == 12 ->
-            %{shifted | :day => shifted_day - last_day, :month => 1, :year => shifted_year+1}
-        end
-      resolve_timezone_info(shifted)
+      cond do
+        shifted.day <= last_day ->
+          shifted
+        :else ->
+          %{shifted | :day => last_day}
+      end
     end
+    |> resolve_timezone_info
   end
   defp shift_by(%DateTime{microsecond: {current_usecs, _}} = datetime, value, :microseconds) do
     usecs_from_zero = :calendar.datetime_to_gregorian_seconds({

--- a/lib/timex.ex
+++ b/lib/timex.ex
@@ -1479,6 +1479,10 @@ defmodule Timex do
   with the exception of shifting DateTimes, which may result in an AmbiguousDateTime
   if the shift moves to an ambiguous time period for the zone of that DateTime.
 
+  Shifting by months will always return a date in the expected month. Because months
+  have different number of days, shifting to a month with fewer days may may not be
+  the same day of the month as the original date.
+
   If an error occurs, an error tuple will be returned.
 
   ## Examples
@@ -1507,6 +1511,21 @@ defmodule Timex do
       ...> Timex.shift(date, years: -1)
       ~D[2015-02-28]
 
+  ### Shifting by months
+
+      iex> date = ~D[2016-01-15]
+      ...> Timex.shift(date, months: 1)
+      ~D[2016-02-15]
+
+      iex> date = ~D[2016-01-31]
+      ...> Timex.shift(date, months: 1)
+      ~D[2016-02-29]
+
+      iex> date = ~D[2016-01-31]
+      ...> Timex.shift(date, months: 2)
+      ~D[2016-03-31]
+      ...> Timex.shift(date, months: 1) |> Timex.shift(months: 1)
+      ~D[2016-03-29]
   """
   @type shift_options :: [
     microseconds: integer,

--- a/test/shift_test.exs
+++ b/test/shift_test.exs
@@ -84,4 +84,10 @@ defmodule ShiftTests do
     expected = ~D[2000-12-01]
     assert expected === date
   end
+
+  test "shift datetime by a month from the end of January" do
+    date = ~D[2000-01-31] |> Timex.to_datetime |> Timex.shift(months: 1)
+    expected = ~D[2000-02-29] |> Timex.to_datetime
+    assert expected === date
+  end
 end

--- a/test/timex_test.exs
+++ b/test/timex_test.exs
@@ -365,6 +365,39 @@ defmodule TimexTests do
     assert Timex.diff(~T[09:00:00], ~T[12:30:23]) == -((3*60+30)*60+23)*1_000*1_000
   end
 
+  test "month diff is asymetrical for months of different lengths" do
+    assert Timex.diff(~D[2017-02-28], ~D[2017-01-27], :months) === 1
+    assert Timex.diff(~D[2017-02-28], ~D[2017-01-28], :months) === 1
+    assert Timex.diff(~D[2017-02-28], ~D[2017-01-29], :months) === 0
+    assert Timex.diff(~D[2017-02-28], ~D[2017-01-30], :months) === 0
+    assert Timex.diff(~D[2017-02-28], ~D[2017-01-31], :months) === 0
+
+    assert Timex.diff(~D[2017-01-27], ~D[2017-02-28], :months) === -1
+    assert Timex.diff(~D[2017-01-28], ~D[2017-02-28], :months) === -1
+    assert Timex.diff(~D[2017-01-29], ~D[2017-02-28], :months) === -1
+    assert Timex.diff(~D[2017-01-30], ~D[2017-02-28], :months) === -1
+    assert Timex.diff(~D[2017-01-31], ~D[2017-02-28], :months) === -1
+
+    assert Timex.diff(~D[2017-01-27], ~D[2017-02-27], :months) === -1
+    assert Timex.diff(~D[2017-01-28], ~D[2017-02-27], :months) === 0
+    assert Timex.diff(~D[2017-01-29], ~D[2017-02-27], :months) === 0
+    assert Timex.diff(~D[2017-01-30], ~D[2017-02-27], :months) === 0
+    assert Timex.diff(~D[2017-01-31], ~D[2017-02-27], :months) === 0
+  end
+
+  test "month diff matches month shift for native dates" do
+    date = ~D[2017-01-27]
+    Enum.each(0..34, fn(x) ->
+      date1 = Timex.shift(date, days: x)
+
+      date2 = Timex.shift(date1, months: 1)
+      assert Timex.diff(date1, date2, :months) === -1
+
+      date2 = Timex.shift(date1, months: -1)
+      assert Timex.diff(date1, date2, :months) === 1
+    end)
+  end
+
   test "timestamp diff same datetime" do
       dt = Timex.to_datetime({1984, 5, 10})
       assert Timex.diff(dt, dt, :duration) === Duration.zero

--- a/test/timex_test.exs
+++ b/test/timex_test.exs
@@ -398,6 +398,19 @@ defmodule TimexTests do
     end)
   end
 
+  test "month diff matches month shift for datetimes" do
+    date = ~D[2017-01-27] |> Timex.to_datetime
+    Enum.each(0..34, fn(x) ->
+      date1 = Timex.shift(date, days: x)
+
+      date2 = Timex.shift(date1, months: 1)
+      assert Timex.diff(date1, date2, :months) === -1
+
+      date2 = Timex.shift(date1, months: -1)
+      assert Timex.diff(date1, date2, :months) === 1
+    end)
+  end
+
   test "timestamp diff same datetime" do
       dt = Timex.to_datetime({1984, 5, 10})
       assert Timex.diff(dt, dt, :duration) === Duration.zero


### PR DESCRIPTION
### Summary of changes

This PR addresses the issue raised in https://github.com/bitwalker/timex/issues/360 and the ensuing discussion.

It accomplishes the goal of making the month `shift` consistent between `datetime.ex` and `nativetime.ex` and also makes `shift` and `diff` by month mirrors of each other.

It also is consistent with the behavior of other date libraries I have used, like ruby's Date class, where shifting January 31 ahead three months is April 30.

`shift` examples:
```
iex(1)> Timex.shift ~D[2017-01-31], months: 1
~D[2017-02-28]
iex(2)> Timex.shift ~D[2017-01-31], months: 2
~D[2017-03-31]
iex(3)> Timex.shift ~D[2017-01-31], months: 3
~D[2017-04-30]
```
same thing in Ruby
```
irb(main):001:0> Date.new(2017, 1, 31) >> 1
=> #<Date: 2017-02-28 ((2457813j,0s,0n),+0s,2299161j)>
irb(main):002:0> Date.new(2017, 1, 31) >> 2
=> #<Date: 2017-03-31 ((2457844j,0s,0n),+0s,2299161j)>
irb(main):003:0> Date.new(2017, 1, 31) >> 3
=> #<Date: 2017-04-30 ((2457874j,0s,0n),+0s,2299161j)>
```

It does cause `diff` to be sometimes different depending on the order of the arguments, but that is consistent with the `shift` behavior, and consistent with what I would expect.
```
iex(1)> Timex.diff ~D[2017-01-31], ~D[2017-02-28], :months
-1
iex(2)> Timex.diff ~D[2017-02-28], ~D[2017-01-31], :months
0
iex(3)> Timex.diff ~D[2017-02-28], ~D[2017-01-28], :months
1
```

I realize that is a change is in contrast to the breaking change made in version 2.0.0 as noted by:  https://github.com/bitwalker/timex/blob/master/CHANGELOG.md#L263
```
BREAKING diff/3 now returns the same value no matter which order the arguments are given. Use compare/3 to get the ordering
```
I wouldn't suggest a breaking change unless I felt strongly that the new behavior is better than the prior behavior.

I didn't see the specific behavior of monthly `shift` or `diff` in the documentation, so I didn't submit any changes to it.  I can write it up if you think this is a good change and that it is of interest.

### Checklist

- [x] New functions have typespecs, changed functions were updated - no new functions
- [x] Same for documentation, including moduledocs - none for now, let me know if you want some
- [x] Tests were added or updated to cover changes
- [ ] Commits were squashed into a single coherent commit - I left it as two commits, one for `diff` and one for `shift`
