### PR TITLE
WIP: Add an overload for the 'time' option of Timex.set/2 that accepts a Time struct

### DIFF
--- a/lib/datetime/datetime.ex
+++ b/lib/datetime/datetime.ex
@@ -194,6 +194,8 @@ defimpl Timex.Protocol, for: DateTime do
             else
               %{result | :hour => h, :minute => m, :second => s}
             end
+          {:time, t} ->
+            Timex.set(result, [time: {t.hour, t.minute, t.second}])
           {:day, d} ->
             if validate? do
               %{result | :day => Timex.normalize(:day, {result.year, result.month, d})}

--- a/test/parse_default_test.exs
+++ b/test/parse_default_test.exs
@@ -385,6 +385,30 @@ defmodule DateFormatTest.ParseDefault do
     assert {:ok, ^date5} = parse("20070405T14Z", "{ISO:Basic}")
   end
 
+  test "parse time struct" do
+    to_change = Timex.to_datetime({{2017, 7, 21}, {1, 2, 3}})
+    changed = Timex.set(to_change, [time: ~T[09:52:33.000]])
+
+    assert 33 == changed.second
+    assert 52 == changed.minute
+    assert 9 == changed.hour
+    assert changed.year == to_change.year
+    assert changed.month == to_change.month
+    assert changed.day == to_change.day
+  end
+
+  test "set from time struct with more than one change requested" do
+    to_change = Timex.to_datetime({{2017, 7, 21}, {1, 2, 3}})
+    changed = Timex.set(to_change, [time: ~T[09:52:33.000], year: 1989])
+
+    assert 1989 == changed.year
+    assert 33 == changed.second
+    assert 52 == changed.minute
+    assert 9 == changed.hour
+    assert changed.month == to_change.month
+    assert changed.day == to_change.day
+  end
+
   test "roundtrip bug #252" do
     format = "{YYYY}-{0M}-{0D}T{0h24}:{0m}:{0s}{0ss}{Zname}"
     now = Timex.now()


### PR DESCRIPTION
### Summary of changes

I wanted to be able to use the `Time` struct instead of the h/m/s tuple for `Timex.set` when modifying a `DateTime`:
```ex
iex> to_change = Timex.to_datetime({{2017, 7, 21}, {1, 2, 3}})
iex> changed = Timex.set(to_change, [time: ~T[09:52:33.000]])
#<DateTime(2017-07-21T09:52:33Z Etc/UTC)>
```

As discussed in #368, this is nice to have for consistency as it's something I had been missing from Timex when I first used it.

There should probably be an equivalent option for `date` but I wanted to get early feedback on this change first to make sure that I am doing things "the right way" before getting too deep into it.

Open questions:
 * Should the tests really have gone in the `parse_default_test` file? I didn't see a set of tests dedicated solely to `set/2` so was unsure where to put them.
 * How should I handle possibly obliterating the `validate` option when I call `Timex.set` after converting the struct into a tuple? (datetime.ex:198)

### Checklist

- [x] New functions have typespecs, changed functions were updated
- [x] Same for documentation, including moduledocs
- [x] Tests were added or updated to cover changes
- [x] Commits were squashed into a single coherent commit
