### PR TITLE
Fix Timex.Duration.diff/3 documentation of available units

### DIFF
--- a/lib/time/duration.ex
+++ b/lib/time/duration.ex
@@ -603,7 +603,7 @@ defmodule Timex.Duration do
 
   Valid measurement units for this function are:
 
-      :microseconds, :milliseconds, :seconds, :minutes, :hours, or :weeks
+      :microseconds, :milliseconds, :seconds, :minutes, :hours, :days, or :weeks
 
   ## Examples
 


### PR DESCRIPTION
### Summary of changes

While I was reading the docs for Timex.Duration.diff/3, I noticed that `:days` as an available unit was missing, and hoped it was a mistake. Upon further checking, it seems it was; so I have added it to the documentation.

### Checklist

- [x] New functions have typespecs, changed functions were updated
- [x] Same for documentation, including moduledocs
- [x] Tests were added or updated to cover changes
- [x] Commits were squashed into a single coherent commit
