### PR TITLE
Remove unused diff_years method

### DIFF
--- a/lib/comparable/diff.ex
+++ b/lib/comparable/diff.ex
@@ -67,7 +67,6 @@ defmodule Timex.Comparable.Diff do
   defp zero(:duration), do: Duration.zero
   defp zero(_type), do: 0
 
-  defp diff_years(a, a), do: 0
   defp diff_years(a, b) do
     {start_date, _} = :calendar.gregorian_seconds_to_datetime(div(a, 1_000*1_000))
     {end_date, _} = :calendar.gregorian_seconds_to_datetime(div(b, 1_000*1_000))


### PR DESCRIPTION
### Summary of changes

I think this method is never hit `defp diff_years(a, a), do: 0` in the current implementation, so let's remove it.

### Checklist

- [x] New functions have typespecs, changed functions were updated
- [x] Same for documentation, including moduledocs
- [x] Tests were added or updated to cover changes
- [x] Commits were squashed into a single coherent commit
