### PR TITLE
Validate granularity on diff even when values are equal

### DIFF
--- a/lib/comparable/diff.ex
+++ b/lib/comparable/diff.ex
@@ -11,7 +11,6 @@ defmodule Timex.Comparable.Diff do
 
   @spec diff(Types.microseconds, Types.microseconds, Comparable.granularity) :: integer
   @spec diff(Types.valid_datetime, Types.valid_datetime, Comparable.granularity) :: integer
-  def diff(a, a, granularity) when is_integer(a), do: zero(granularity)
   def diff(a, b, granularity) when is_integer(a) and is_integer(b) and is_atom(granularity) do
     do_diff(a, b, granularity)
   end
@@ -23,7 +22,6 @@ defmodule Timex.Comparable.Diff do
     end
   end
 
-  defp do_diff(a, a, type),      do: zero(type)
   defp do_diff(a, b, :duration), do: Duration.from_seconds(do_diff(a,b,:seconds))
   defp do_diff(a, b, :microseconds), do: a - b
   defp do_diff(a, b, :milliseconds), do: div(a - b, 1_000)
@@ -63,9 +61,6 @@ defmodule Timex.Comparable.Diff do
   end
   defp do_diff(_, _, granularity) when not granularity in @units,
     do: {:error, {:invalid_granularity, granularity}}
-
-  defp zero(:duration), do: Duration.zero
-  defp zero(_type), do: 0
 
   defp diff_years(a, a), do: 0
   defp diff_years(a, b) do

--- a/test/timex_test.exs
+++ b/test/timex_test.exs
@@ -363,6 +363,10 @@ defmodule TimexTests do
     assert Timex.diff(date2, date1, :months) === -25
 
     assert Timex.diff(~T[09:00:00], ~T[12:30:23]) == -((3*60+30)*60+23)*1_000*1_000
+
+    assert {:error, {:invalid_granularity, :dayz}} === Timex.diff(date1, date1, :dayz)
+    assert {:error, {:invalid_granularity, :dayz}} === Timex.diff(d1, d1, :dayz)
+    assert {:error, {:invalid_granularity, :dayz}} === Timex.diff(~T[12:00:00], ~T[12:00:00], :dayz)
   end
 
   test "timestamp diff same datetime" do


### PR DESCRIPTION
Issue #384
This fixes the granularity validity not being checked when applying diff on equal values.

This makes the behavior consistent. Currently diff only fails with an invalid value when comparing times:
```elixir
iex(1)> Timex.diff(~N[2012-12-12 12:00:00], ~N[2012-12-12 12:00:00], :invalid)
0
iex(2)> Timex.diff(~D[2012-12-12], ~D[2012-12-12], :invalid)                  
0
iex(3)> Timex.diff(~T[12:00:00], ~T[12:00:00], :invalid)            
{:error, {:invalid_granularity, :invalid}}
```