### PR TITLE
Fix problems with shift implementation and add tests

### DIFF
--- a/lib/datetime/naivedatetime.ex
+++ b/lib/datetime/naivedatetime.ex
@@ -199,18 +199,9 @@ defimpl Timex.Protocol, for: NaiveDateTime do
   end
   defp apply_shifts(datetime, []),
     do: datetime
-  defp apply_shifts(%NaiveDateTime{microsecond: {ms, precision}} = datetime, [{:duration, %Duration{} = duration} | rest]) do
-    total_microseconds = Duration.to_microseconds(duration)
-    seconds = div(total_microseconds + ms, 1_000*1_000)
-    rem_microseconds = rem(total_microseconds, 1_000*1_000)
-    shifted = shift_by(datetime, seconds, :seconds)
-    shifted = case precision do
-      0 ->
-        %{shifted | :microsecond => Timex.DateTime.Helpers.construct_microseconds(rem_microseconds)}
-      _ ->
-        {new_ms, _} = Timex.DateTime.Helpers.construct_microseconds(ms + rem_microseconds)
-        %{shifted | :microsecond => {new_ms, precision}}
-    end
+  defp apply_shifts(datetime, [{:duration, %Duration{} = duration} | rest]) do
+    duration_microseconds = Duration.to_microseconds(duration)
+    shifted = shift_by(datetime, duration_microseconds, :microseconds)
     apply_shifts(shifted, rest)
   end
   defp apply_shifts(datetime, [{unit, 0} | rest]) when is_atom(unit),
@@ -269,68 +260,38 @@ defimpl Timex.Protocol, for: NaiveDateTime do
         shifted
     end
   end
-  defp shift_by(%NaiveDateTime{microsecond: {current_usecs, _}} = datetime, value, :microseconds) do
-    usecs_from_zero = :calendar.datetime_to_gregorian_seconds({
-      {datetime.year,datetime.month,datetime.day},
-      {datetime.hour,datetime.minute,datetime.second}
-    }) * (1_000*1_000) + current_usecs + value
+  defp shift_by(datetime, value, :weeks),
+    do: shift_by(datetime, (value * 60 * 60 * 24 * 7 * 1_000_000), :microseconds)
+  defp shift_by(datetime, value, :days),
+    do: shift_by(datetime, (value * 60 * 60 * 24 * 1_000_000), :microseconds)
+  defp shift_by(datetime, value, :hours),
+    do: shift_by(datetime, (value * 60 * 60 * 1_000_000), :microseconds)
+  defp shift_by(datetime, value, :minutes),
+    do: shift_by(datetime, (value * 60 * 1_000_000), :microseconds)
+  defp shift_by(datetime, value, :seconds),
+    do: shift_by(datetime, (value * 1_000_000), :microseconds)
+  defp shift_by(datetime, value, :milliseconds),
+    do: shift_by(datetime, (value * 1_000), :microseconds)
+  defp shift_by(%NaiveDateTime{microsecond: {current_microseconds, current_precision}} = datetime, value, :microseconds) do
+    microseconds_from_zero = :calendar.datetime_to_gregorian_seconds({
+      {datetime.year, datetime.month, datetime.day},
+      {datetime.hour, datetime.minute, datetime.second}
+    }) * 1_000_000 + current_microseconds + value
 
-    secs_from_zero = div(usecs_from_zero, 1_000*1_000)
-    rem_microseconds = rem(usecs_from_zero, 1_000*1_000)
+    if microseconds_from_zero < 0 do
+      {:error, :shift_to_invalid_date}
+    else
+      seconds_from_zero = div(microseconds_from_zero, 1_000_000)
+      rem_microseconds = rem(microseconds_from_zero, 1_000_000)
 
-    shifted = :calendar.gregorian_seconds_to_datetime(secs_from_zero)
-    shifted = Timex.to_naive_datetime(shifted)
-    %{shifted | :microsecond => Timex.DateTime.Helpers.construct_microseconds(rem_microseconds)}
-  end
-  defp shift_by(%NaiveDateTime{microsecond: {current_usecs, _}} = datetime, value, :milliseconds) do
-    usecs_from_zero = :calendar.datetime_to_gregorian_seconds({
-      {datetime.year,datetime.month,datetime.day},
-      {datetime.hour,datetime.minute,datetime.second}
-    }) * (1_000*1_000) + current_usecs + (value*1_000)
-
-    secs_from_zero = div(usecs_from_zero, 1_000*1_000)
-    rem_microseconds = rem(usecs_from_zero, 1_000*1_000)
-
-    shifted = :calendar.gregorian_seconds_to_datetime(secs_from_zero)
-    shifted = Timex.to_naive_datetime(shifted)
-    %{shifted | :microsecond => Timex.DateTime.Helpers.construct_microseconds(rem_microseconds)}
-  end
-  defp shift_by(%NaiveDateTime{microsecond: {us, _}} = datetime, value, units) do
-    secs_from_zero = :calendar.datetime_to_gregorian_seconds({
-      {datetime.year,datetime.month,datetime.day},
-      {datetime.hour,datetime.minute,datetime.second}
-    })
-    shift_by = case units do
-      :microseconds -> div(value + us, 1_000*1_000)
-      :milliseconds -> div((value*1_000 + us), 1_000*1_000)
-      :seconds      -> value
-      :minutes      -> value * 60
-      :hours        -> value * 60 * 60
-      :days         -> value * 60 * 60 * 24
-      :weeks        -> value * 60 * 60 * 24 * 7
-      _ ->
-        {:error, {:unknown_shift_unit, units}}
-    end
-    case shift_by do
-      {:error, _} = err -> err
-      0 when units in [:microseconds] ->
-        %{datetime | :microsecond => Timex.DateTime.Helpers.construct_microseconds(value+us)}
-      0 when units in [:milliseconds] ->
-        %{datetime | :microsecond => Timex.DateTime.Helpers.construct_microseconds((value*1_000)+us)}
-      0 ->
-        datetime
-      _ ->
-        new_secs_from_zero = secs_from_zero + shift_by
-        cond do
-          new_secs_from_zero <= 0 ->
-            {:error, :shift_to_invalid_date}
-          :else ->
-            shifted = :calendar.gregorian_seconds_to_datetime(new_secs_from_zero)
-            shifted = Timex.to_naive_datetime(shifted)
-            %{shifted | :microsecond => Timex.DateTime.Helpers.construct_microseconds(us)}
-        end
+      shifted = seconds_from_zero
+      |> :calendar.gregorian_seconds_to_datetime
+      |> Timex.to_naive_datetime
+      |> Map.put(:microsecond, {rem_microseconds, current_precision})
     end
   end
+  defp shift_by(_datetime, _value, units),
+    do: {:error, {:unknown_shift_unit, units}}
 
   defp to_seconds(%NaiveDateTime{year: y, month: m, day: d, hour: h, minute: mm, second: s}, :zero) do
     :calendar.datetime_to_gregorian_seconds({{y,m,d},{h,mm,s}})

--- a/test/shift_test.exs
+++ b/test/shift_test.exs
@@ -2,7 +2,7 @@ defmodule ShiftTests do
   use ExUnit.Case, async: true
   use Timex
 
-  test "shift to invalid date" do
+  test "shift by months in a nonexistent day" do
     date = Timex.shift(~N[2015-06-29T12:00:00], months: -4)
     assert ~N[2015-02-28T12:00:00] = date
   end
@@ -83,5 +83,70 @@ defmodule ShiftTests do
     date = Timex.shift(~D[2000-11-01], months: 1)
     expected = ~D[2000-12-01]
     assert expected === date
+  end
+
+  test "shift by weeks" do
+    date = Timex.shift(~N[2017-10-24 12:00:00.100000], weeks: 1)
+    expected = ~N[2017-10-31 12:00:00.100000]
+    assert expected === date
+  end
+
+  test "shift by days" do
+    date = Timex.shift(~N[2017-10-24 12:00:00.100000], days: 1)
+    expected = ~N[2017-10-25 12:00:00.100000]
+    assert expected === date
+  end
+
+  test "shift by hours" do
+    date = Timex.shift(~N[2017-10-24 12:00:00.100000], hours: 1)
+    expected = ~N[2017-10-24 13:00:00.100000]
+    assert expected === date
+  end
+
+  test "shift by minutes" do
+    date = Timex.shift(~N[2017-10-24 12:00:00.100000], minutes: 1)
+    expected = ~N[2017-10-24 12:01:00.100000]
+    assert expected === date
+  end
+
+  test "shift by seconds" do
+    date = Timex.shift(~N[2017-10-24 12:00:00.100000], seconds: 1)
+    expected = ~N[2017-10-24 12:00:01.100000]
+    assert expected === date
+  end
+
+  test "shift by milliseconds" do
+    date = Timex.shift(~N[2017-10-24 12:00:00.100000], milliseconds: 1)
+    expected = ~N[2017-10-24 12:00:00.101000]
+    assert expected === date
+  end
+
+  test "shift by microseconds" do
+    date = Timex.shift(~N[2017-10-24 12:00:00.100000], microseconds: 1)
+    expected = ~N[2017-10-24 12:00:00.100001]
+    assert expected === date
+  end
+
+  test "shift by duration" do
+    date = Timex.shift(~N[2017-10-24 12:00:00.100000],
+      duration: Timex.Duration.from_microseconds(100))
+    expected = ~N[2017-10-24 12:00:00.100100]
+    assert expected === date
+  end
+
+  test "shift to zero" do
+    result = Timex.shift(~N[0000-01-01 00:00:01], seconds: -1)
+    expected = ~N[0000-01-01 00:00:00]
+    assert expected === result
+  end
+
+  test "shift to an invalid datetime" do
+    result = Timex.shift(~N[0000-01-01 00:00:00], seconds: -1)
+    assert {:error, :shift_to_invalid_date} === result
+  end
+
+  test "shift by an invalid unit" do
+    date = Timex.shift(~N[2017-10-24 12:00:00.100000], dayz: 1)
+    assert {:error, {:unknown_shift_unit, :dayz}} === date
   end
 end


### PR DESCRIPTION
This was motivated by issue #352, but I found a few more problems.

- Fix microseconds precision being lost;
- Fix error when shifting to an invalid value by microseconds;
- Unify clauses to remove code duplication.

As @alvinlindstam mentioned, I'm also not sure how to handle precision when shifting by a value with higher precision.
