### PR TITLE
Fix microseconds formatting

### DIFF
--- a/lib/format/datetime/formatter.ex
+++ b/lib/format/datetime/formatter.ex
@@ -552,7 +552,10 @@ defmodule Timex.Format.DateTime.Formatter do
         n when n < min_width -> min_width
         n -> n
       end
-    padded = pad_numeric(us, [padding: :zeroes], width_spec(min_width..max_width))
+
+    us_str = "#{us}"
+    padded_us_str = String.duplicate(pad_char(:zeroes), 6 - byte_size(us_str)) <> us_str
+    padded = pad_numeric(padded_us_str, [padding: :zeroes], width_spec(min_width..max_width))
     ".#{padded}"
   end
   def format_token(_locale, :sec_fractional, _date, _modifiers, _flags, width) do
@@ -572,19 +575,18 @@ defmodule Timex.Format.DateTime.Formatter do
         pad_numeric(Timex.to_unix(date), flags, width)
     end
   end
-  def format_token(_locale, :us, %{microsecond: {us, precision}}, _modifiers, flags, width) do
+  def format_token(_locale, :us, %{microsecond: {us, _precision}}, _modifiers, flags, width) do
     min =
       case Keyword.get(width, :min) do
-        nil -> precision
-        n when n < 1 -> precision
+        nil -> 6
+        n when n < 0 -> 6
         n -> n
       end
     max =
       case Keyword.get(width, :max) do
-        nil -> precision
-        n when n < 1 -> precision
-        n when n < min -> min
-        n -> n
+        nil -> 6
+        n when n > 6 -> n
+        _ -> 6
       end
     pad_numeric(us, flags, width_spec(min..max))
   end

--- a/test/format_default_test.exs
+++ b/test/format_default_test.exs
@@ -444,8 +444,8 @@ defmodule DateFormatTest.FormatDefault do
 
   test "milliseconds as fractional seconds via {ss}" do
     date = Timex.to_datetime({{2015,11,9}, {8,37,48}})
-    date = %{date | :microsecond => {655_000,3}}
-    assert { :ok, "2015-11-09T08:37:48.655" } = format(date, "{YYYY}-{0M}-{0D}T{h24}:{m}:{s}{ss}")
+    date = %{date | :microsecond => {065_000,3}}
+    assert { :ok, "2015-11-09T08:37:48.065" } = format(date, "{YYYY}-{0M}-{0D}T{h24}:{m}:{s}{ss}")
   end
 
   test "issue #79 - invalid ISO 8601 string with fractional ms" do

--- a/test/format_strftime_test.exs
+++ b/test/format_strftime_test.exs
@@ -332,7 +332,7 @@ defmodule DateFormatTest.FormatStrftime do
 
   test "lau/calendar tests" do
     dt = Timex.to_datetime({{2014, 11, 3}, {1, 41, 2}})
-    dt = %{dt | :microsecond => {123_000,3}}
+    dt = %{dt | :microsecond => {012_000,3}}
     dt_sunday = Timex.to_datetime({{2014, 11, 2}, {1, 41, 2}})
     assert format(dt, "%a") == {:ok, "Mon"}
     assert format(dt, "%A") == {:ok, "Monday"}
@@ -341,7 +341,7 @@ defmodule DateFormatTest.FormatStrftime do
     assert format(dt, "%B") == {:ok, "November"}
     assert format(dt, "%d") == {:ok, "03"}
     assert format(dt, "%e") == {:ok, " 3"}
-    assert format(dt, "%f") == {:ok, "123"}
+    assert format(dt, "%f") == {:ok, "012000"}
     assert format(dt, "%u") == {:ok, "1"}
     assert format(dt, "%w") == {:ok, "1"}
     assert format(dt_sunday, "%u") == {:ok, "7"}

--- a/test/format_test.exs
+++ b/test/format_test.exs
@@ -22,14 +22,14 @@ defmodule DateFormatTest.GeneralFormatting do
   end
 
   test "fractional seconds padding obeys formatting rules" do
-    t = Timex.parse!("2017-06-28 20:21:22.000000", "%F %T.%f", :strftime)
-    assert {0, 6} = t.microsecond
-    assert "000000" = Timex.format!(t, "%f", :strftime)
-    assert "000" = Timex.format!(t, "%03f", :strftime)
+    t = Timex.parse!("2017-06-28 20:21:22.012345", "%F %T.%f", :strftime)
+    assert {12345, 6} = t.microsecond
+    assert "012345" = Timex.format!(t, "%f", :strftime)
+    assert "12345" = Timex.format!(t, "%03f", :strftime)
 
     t = Timex.to_datetime({2017, 6, 22})
     assert {0, 0} = t.microsecond
-    assert "" = Timex.format!(t, "%f", :strftime)
+    assert "000000" = Timex.format!(t, "%f", :strftime)
     assert "000" = Timex.format!(t, "%03f", :strftime)
   end
 end


### PR DESCRIPTION
This fix formatting fractional seconds with leading zeroes (issue #388) and change the format of microseconds when using `%f` to conform with what's documented:

>`%f` - microseconds in zero padded decimal form, i.e. 025000

Please see the changed tests. I'd like to hear some thoughts on whether the precision should be taken into account when formatting microseconds.

### Summary of changes

- Pad with zeroes before truncating when formating fractional seconds;
- Pad with zeroes and never truncate when formatting with %f.