### PR TITLE
Add parsing support for languages in the included locales

### DIFF
--- a/lib/parse/datetime/parsers.ex
+++ b/lib/parse/datetime/parsers.ex
@@ -45,14 +45,18 @@ defmodule Timex.Parse.DateTime.Parsers do
     |> label(expected_digits)
   end
   def month_full(_) do
-    one_of(word_of(~r/[[:alpha:]]/u), Helpers.months)
-    |> map(&Helpers.to_month_num/1)
+    locale = Timex.Translator.current_locale()
+
+    one_of(word_of(~r/[[:alpha:]]/u), Helpers.months(locale))
+    |> map(fn m -> Helpers.to_month_num(m, locale) end)
     |> label("full month name")
   end
   def month_short(_) do
-    abbrs = Helpers.months |> Enum.map(fn m -> String.slice(m, 0, 3) end)
-    one_of(word_of(~r/[[:alpha:]]/), abbrs)
-    |> map(&Helpers.to_month_num/1)
+    locale = Timex.Translator.current_locale()
+    abbrs = Helpers.months(locale) |> Enum.map(fn m -> Helpers.abbreviate_month(m, locale) end)
+
+    one_of(word_of(~r/[[:alpha:]\.]/u), abbrs)
+    |> map(fn m -> Helpers.to_month_num(m, locale) end)
     |> label("month abbreviation")
   end
 
@@ -82,15 +86,19 @@ defmodule Timex.Parse.DateTime.Parsers do
     |> label("ordinal weekday")
   end
   def weekday_short(_) do
+    locale = Timex.Translator.current_locale()
+
     word_of(~r/[[:alpha:]]/u)
-    |> satisfy(&Helpers.is_weekday/1)
-    |> map(fn name -> Helpers.to_weekday(name) end)
+    |> satisfy(fn w -> Helpers.is_weekday(w, locale) end)
+    |> map(fn name -> Helpers.to_weekday(name, locale) end)
     |> label("weekday abbreviation")
   end
   def weekday_full(_) do
+    locale = Timex.Translator.current_locale()
+
     word_of(~r/[[:alpha:]]/u)
-    |> satisfy(&Helpers.is_weekday/1)
-    |> map(fn name -> Helpers.to_weekday(name) end)
+    |> satisfy(fn w -> Helpers.is_weekday(w, locale) end)
+    |> map(fn name -> Helpers.to_weekday(name, locale) end)
     |> label("weekday name")
   end
 
@@ -107,18 +115,24 @@ defmodule Timex.Parse.DateTime.Parsers do
     |> label("hour between 1 and 12")
   end
   def ampm_lower(_) do
-    one_of(word(), ["am", "pm"])
-    |> map(&Helpers.to_ampm/1)
+    locale = Timex.Translator.current_locale()
+
+    one_of(word(), Helpers.periods_lower(locale))
+    |> map(fn ampm -> Helpers.to_ampm(ampm, locale) end)
     |> label("am/pm")
   end
   def ampm_upper(_) do
-    one_of(word(), ["AM", "PM"])
-    |> map(&Helpers.to_ampm/1)
+    locale = Timex.Translator.current_locale()
+
+    one_of(word(), Helpers.periods_upper(locale))
+    |> map(fn ampm -> Helpers.to_ampm(ampm, locale) end)
     |> label("AM/PM")
   end
   def ampm(_) do
-    one_of(word(), ["am", "AM", "pm", "PM"])
-    |> map(&Helpers.to_ampm/1)
+    locale = Timex.Translator.current_locale()
+
+    one_of(word(), Helpers.periods(locale))
+    |> map(fn ampm -> Helpers.to_ampm(ampm, locale) end)
     |> label("am/pm or AM/PM")
   end
   def minute(opts \\ []) do

--- a/test/nonenglish_parser_test.exs
+++ b/test/nonenglish_parser_test.exs
@@ -4,8 +4,6 @@ defmodule Timex.NonEnglishParser.Test do
 
   use Combine
   import Timex.Parse.DateTime.Parsers
-  alias Timex.Parse.DateTime.Helpers
-
   require Timex.Translator
   alias Timex.Translator
 
@@ -52,8 +50,10 @@ defmodule Timex.NonEnglishParser.Test do
   end
 
   test "parsers: am/pm lower" do
-    assert [[am: "pm"]] = Combine.parse("pm", ampm_lower([]))
-    assert [[am: "am"]] = Combine.parse("am", ampm_lower([]))
-    assert {:error, _} = Combine.parse("fm", ampm_lower([]))
+    Translator.with_locale("ru") do
+      assert [[am: "pm"]] = Combine.parse("пп", ampm_lower([]))
+      assert [[am: "am"]] = Combine.parse("дп", ampm_lower([]))
+      assert {:error, _} = Combine.parse("fm", ampm_lower([]))
+    end
   end
 end

--- a/test/nonenglish_parser_test.exs
+++ b/test/nonenglish_parser_test.exs
@@ -1,0 +1,59 @@
+defmodule Timex.NonEnglishParser.Test do
+  use ExUnit.Case, async: true
+  doctest Timex.Parse.DateTime.Parser
+
+  use Combine
+  import Timex.Parse.DateTime.Parsers
+  alias Timex.Parse.DateTime.Helpers
+
+  require Timex.Translator
+  alias Timex.Translator
+
+  test "helpers: to_month_num" do
+    Translator.with_locale("fr") do
+      assert [[month: 1]] = Combine.parse("janvier", month_full([]))
+      assert [[month: 1]] = Combine.parse("janv.", month_short([]))
+      assert [[month: 2]] = Combine.parse("février", month_full([]))
+      assert [[month: 2]] = Combine.parse("févr.", month_short([]))
+      assert [[month: 3]] = Combine.parse("mars", month_full([]))
+      assert [[month: 3]] = Combine.parse("mars", month_short([]))
+      assert [[month: 4]] = Combine.parse("avril", month_full([]))
+      assert [[month: 4]] = Combine.parse("avr.", month_short([]))
+      assert [[month: 5]] = Combine.parse("mai", month_full([]))
+      assert [[month: 6]] = Combine.parse("juin", month_short([]))
+      assert [[month: 6]] = Combine.parse("juin", month_short([]))
+      assert [[month: 7]] = Combine.parse("juillet", month_full([]))
+      assert [[month: 7]] = Combine.parse("juil.", month_short([]))
+      assert [[month: 8]] = Combine.parse("août", month_full([]))
+      assert [[month: 8]] = Combine.parse("août", month_short([]))
+      assert [[month: 9]] = Combine.parse("septembre", month_full([]))
+      assert [[month: 9]] = Combine.parse("sept.", month_short([]))
+      assert [[month: 10]] = Combine.parse("octobre", month_full([]))
+      assert [[month: 10]] = Combine.parse("oct.", month_short([]))
+      assert [[month: 11]] = Combine.parse("novembre", month_full([]))
+      assert [[month: 11]] = Combine.parse("nov.", month_short([]))
+      assert [[month: 12]] = Combine.parse("décembre", month_full([]))
+      assert [[month: 12]] = Combine.parse("déc.", month_short([]))
+      assert {:error, "Expected `full month name` at line 1, column 10."} = Combine.parse("Something", month_full([]))
+    end
+  end
+
+  test "helpers: is_weekday" do
+    Translator.with_locale("fr") do
+      assert [1] = Combine.parse("lundi", weekday_full([]))
+      assert [2] = Combine.parse("mardi", weekday_full([]))
+      assert [3] = Combine.parse("mercredi", weekday_full([]))
+      assert [4] = Combine.parse("jeudi", weekday_full([]))
+      assert [5] = Combine.parse("vendredi", weekday_full([]))
+      assert [6] = Combine.parse("samedi", weekday_full([]))
+      assert [7] = Combine.parse("dimanche", weekday_full([]))
+      assert {:error, _} = Combine.parse("Whatday", weekday_full([]))
+    end
+  end
+
+  test "parsers: am/pm lower" do
+    assert [[am: "pm"]] = Combine.parse("pm", ampm_lower([]))
+    assert [[am: "am"]] = Combine.parse("am", ampm_lower([]))
+    assert {:error, _} = Combine.parse("fm", ampm_lower([]))
+  end
+end

--- a/test/parser_test.exs
+++ b/test/parser_test.exs
@@ -4,6 +4,7 @@ defmodule Timex.Parser.Test do
 
   use Combine
   import Timex.Parse.DateTime.Parsers
+  alias Timex.Parse.DateTime.Helpers
 
   test "helpers: to_month_num" do
     assert [[month: 1]] = Combine.parse("January", month_full([]))

--- a/test/parser_test.exs
+++ b/test/parser_test.exs
@@ -4,7 +4,6 @@ defmodule Timex.Parser.Test do
 
   use Combine
   import Timex.Parse.DateTime.Parsers
-  alias Timex.Parse.DateTime.Helpers
 
   test "helpers: to_month_num" do
     assert [[month: 1]] = Combine.parse("January", month_full([]))
@@ -31,7 +30,6 @@ defmodule Timex.Parser.Test do
     assert [[month: 12]] = Combine.parse("December", month_full([]))
     assert [[month: 12]] = Combine.parse("Dec", month_short([]))
     assert {:error, "Expected `full month name` at line 1, column 10."} = Combine.parse("Something", month_full([]))
-
   end
 
   test "helpers: is_weekday" do


### PR DESCRIPTION
* I'd like to be able to use this library to parse
  dates that are in non-english languages. I could
  see how to translate dates, but not parse them
  from strings.
* This PR enables the following use case

  ```elixir
    require Timex.Translator
    alias Timex.Translator

    Translator.with_locale("fr") do
      Timex.parse("décembre", "{Mfull}")
    end
    # {:ok, ~N[0000-12-01 00:00:00]}
  ```

Not sure if this is a reasonable strategy, but
there are several obvious implications of this:

Questions:
  * For users with a non-english default locale, this
    will break things
    * Is the global gettext locale the right place to do this?
    * If not, we could explicitly pass the locale in to the parse
      function, which might be less surprising for folks

### Summary of changes

I'll review the commits, so I mostly want to understand the "why" rather than the "what"

### Checklist

- [ ] New functions have typespecs, changed functions were updated
- [ ] Same for documentation, including moduledocs
- [ ] Tests were added or updated to cover changes
- [ ] Commits were squashed into a single coherent commit
