### PR TITLE
Fixes #402

### DIFF
--- a/lib/format/datetime/formatter.ex
+++ b/lib/format/datetime/formatter.ex
@@ -651,8 +651,12 @@ defmodule Timex.Format.DateTime.Formatter do
       {:error, _} = err -> err
       "" -> ""
       offset ->
-        [qualifier, <<hour::binary-size(2), min::binary-size(2)>>] = String.split(offset, "", [trim: true, parts: 2])
-        <<qualifier::binary, hour::binary, ?:, min::binary>>
+        case String.split(offset, "", [trim: true, parts: 2]) do
+          [qualifier, <<hour::binary-size(2), min::binary-size(2)>>] ->
+            <<qualifier::binary, hour::binary, ?:, min::binary>>
+          [qualifier, <<hour::binary-size(2), "-", min::binary-size(2)>>] ->
+            <<qualifier::binary, hour::binary, ?:, min::binary>>
+        end
     end
   end
   def format_token(locale, :zoffs_sec, %{std_offset: std, utc_offset: utc} = date, modifiers, flags, width) do

--- a/test/format_test.exs
+++ b/test/format_test.exs
@@ -32,4 +32,15 @@ defmodule DateFormatTest.GeneralFormatting do
     assert "" = Timex.format!(t, "%f", :strftime)
     assert "000" = Timex.format!(t, "%03f", :strftime)
   end
+
+  test "issue #402 - formatting a Time sometimes crashes for timezones" do
+    assert Timex.to_datetime({{2016,2,8}, {12,0,0}})
+    |> Timex.Timezone.convert("Canada/Newfoundland")
+    |> Timex.format!("{ISO:Extended}") == "2016-02-08T08:30:00-03:30"
+
+    assert Timex.to_datetime({{2016,2,8}, {12,0,0}})
+    |> Timex.Timezone.convert("Pacific/Marquesas")
+    |> Timex.format!("{ISO:Extended}") == "2016-02-08T02:30:00-09:30"
+
+  end
 end


### PR DESCRIPTION
* Fix bug where some offsets were expressed with a dash
  between hours and minutes, and the format/2 function would
  crash while formatting the offset

### Summary of changes

I'll review the commits, so I mostly want to understand the "why" rather than the "what"

### Checklist

- [ ] New functions have typespecs, changed functions were updated
- [ ] Same for documentation, including moduledocs
- [ ] Tests were added or updated to cover changes
- [ ] Commits were squashed into a single coherent commit
