### PR TITLE
Update Romanian translations to reflect correct plurals

### DIFF
--- a/priv/translations/ro/LC_MESSAGES/relative_time.po
+++ b/priv/translations/ro/LC_MESSAGES/relative_time.po
@@ -9,7 +9,7 @@
 msgid ""
 msgstr ""
 "Language: ro\n"
-"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"Plural-Forms: nplurals=3; plural=n==1 ? 0 : (n==0 || (n%100 > 0 && n%100 < 20)) ? 1 : 2\n"
 "Project-Id-Version: \n"
 "POT-Creation-Date: \n"
 "PO-Revision-Date: \n"
@@ -73,84 +73,98 @@ msgid "%{count} day ago"
 msgid_plural "%{count} days ago"
 msgstr[0] "%{count} zi in urma"
 msgstr[1] "%{count} zile in urma"
+msgstr[2] "%{count} de zile in urma"
 
 #: lib/l10n/translator.ex:278
 msgid "%{count} hour ago"
 msgid_plural "%{count} hours ago"
 msgstr[0] "%{count} ora in urma"
 msgstr[1] "%{count} ore in urma"
+msgstr[2] "%{count} de ore in urma"
 
 #: lib/l10n/translator.ex:281
 msgid "%{count} minute ago"
 msgid_plural "%{count} minutes ago"
 msgstr[0] "%{count} minut in urma"
 msgstr[1] "%{count} minute in urma"
+msgstr[2] "%{count} de minute in urma"
 
 #: lib/l10n/translator.ex:241
 msgid "%{count} month ago"
 msgid_plural "%{count} months ago"
 msgstr[0] "%{count} luna in urma"
 msgstr[1] "%{count} luni in urma"
+msgstr[2] "%{count} de luni in urma"
 
 #: lib/l10n/translator.ex:284
 msgid "%{count} second ago"
 msgid_plural "%{count} seconds ago"
 msgstr[0] "%{count} secunda in urma"
 msgstr[1] "%{count} secunde in urma"
+msgstr[2] "%{count} de secunde in urma"
 
 #: lib/l10n/translator.ex:247
 msgid "%{count} week ago"
 msgid_plural "%{count} weeks ago"
 msgstr[0] "%{count} saptamana in urma"
 msgstr[1] "%{count} saptamani in urma"
+msgstr[2] "%{count} de saptamani in urma"
 
 #: lib/l10n/translator.ex:235
 msgid "%{count} year ago"
 msgid_plural "%{count} years ago"
 msgstr[0] "%{count} an in urma"
 msgstr[1] "%{count} ani in urma"
+msgstr[2] "%{count} de ani in urma"
 
 #: lib/l10n/translator.ex:252
 msgid "in %{count} day"
 msgid_plural "in %{count} days"
 msgstr[0] "in %{count} zi"
 msgstr[1] "in %{count} zile"
+msgstr[2] "in %{count} de zile"
 
 #: lib/l10n/translator.ex:277
 msgid "in %{count} hour"
 msgid_plural "in %{count} hours"
 msgstr[0] "in %{count} ora"
 msgstr[1] "in %{count} ore"
+msgstr[2] "in %{count} de ore"
 
 #: lib/l10n/translator.ex:280
 msgid "in %{count} minute"
 msgid_plural "in %{count} minutes"
 msgstr[0] "in %{count} minut"
 msgstr[1] "in %{count} minute"
+msgstr[2] "in %{count} de minute"
 
 #: lib/l10n/translator.ex:240
 msgid "in %{count} month"
 msgid_plural "in %{count} months"
 msgstr[0] "in %{count} luna"
 msgstr[1] "in %{count} luni"
+msgstr[2] "in %{count} de luni"
 
 #: lib/l10n/translator.ex:283
 msgid "in %{count} second"
 msgid_plural "in %{count} seconds"
 msgstr[0] "in %{count} secunda"
 msgstr[1] "in %{count} secunde"
+msgstr[2] "in %{count} de secunde"
 
 #: lib/l10n/translator.ex:246
 msgid "in %{count} week"
 msgid_plural "in %{count} weeks"
 msgstr[0] "in %{count} saptamana"
 msgstr[1] "in %{count} saptamani"
+msgstr[2] "in %{count} de saptamani"
 
 #: lib/l10n/translator.ex:234
 msgid "in %{count} year"
 msgid_plural "in %{count} years"
 msgstr[0] "in %{count} an"
 msgstr[1] "in %{count} ani"
+msgstr[2] "in %{count} de ani"
 
 #: lib/l10n/translator.ex:267
 msgid "last friday"

--- a/priv/translations/ro/LC_MESSAGES/units.po
+++ b/priv/translations/ro/LC_MESSAGES/units.po
@@ -9,7 +9,7 @@
 msgid ""
 msgstr ""
 "Language: ro\n"
-"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"Plural-Forms: nplurals=3; plural=n==1 ? 0 : (n==0 || (n%100 > 0 && n%100 < 20)) ? 1 : 2\n"
 "Project-Id-Version: \n"
 "POT-Creation-Date: \n"
 "PO-Revision-Date: \n"
@@ -25,57 +25,67 @@ msgid "%{count} day"
 msgid_plural "%{count} days"
 msgstr[0] "%{count} zi"
 msgstr[1] "%{count} zile"
+msgstr[2] "%{count} de zile"
 
 #: lib/l10n/translator.ex:177
 msgid "%{count} hour"
 msgid_plural "%{count} hours"
 msgstr[0] "%{count} ora"
 msgstr[1] "%{count} ore"
+msgstr[2] "%{count} de ore"
 
 #: lib/l10n/translator.ex:173
 msgid "%{count} microsecond"
 msgid_plural "%{count} microseconds"
 msgstr[0] "%{count} microsecunda"
 msgstr[1] "%{count} microsecunde"
+msgstr[2] "%{count} de microsecunde"
 
 #: lib/l10n/translator.ex:174
 msgid "%{count} millisecond"
 msgid_plural "%{count} milliseconds"
 msgstr[0] "%{count} millisecunda"
 msgstr[1] "%{count} millisecunde"
+msgstr[2] "%{count} de millisecunde"
 
 #: lib/l10n/translator.ex:176
 msgid "%{count} minute"
 msgid_plural "%{count} minutes"
 msgstr[0] "%{count} minut"
 msgstr[1] "%{count} minute"
+msgstr[2] "%{count} de minute"
 
 #: lib/l10n/translator.ex:180
 msgid "%{count} month"
 msgid_plural "%{count} months"
 msgstr[0] "%{count} luna"
 msgstr[1] "%{count} luni"
+msgstr[2] "%{count} de luni"
 
 #: lib/l10n/translator.ex:172
 msgid "%{count} nanosecond"
 msgid_plural "%{count} nanoseconds"
 msgstr[0] "%{count} nanosecunda"
 msgstr[1] "%{count} nanosecunde"
+msgstr[2] "%{count} de nanosecunde"
 
 #: lib/l10n/translator.ex:175
 msgid "%{count} second"
 msgid_plural "%{count} seconds"
 msgstr[0] "%{count} secunda"
 msgstr[1] "%{count} secunde"
+msgstr[2] "%{count} de secunde"
 
 #: lib/l10n/translator.ex:179
 msgid "%{count} week"
 msgid_plural "%{count} weeks"
 msgstr[0] "%{count} saptamana"
 msgstr[1] "%{count} saptamani"
+msgstr[2] "%{count} de saptamani"
 
 #: lib/l10n/translator.ex:181
 msgid "%{count} year"
 msgid_plural "%{count} years"
 msgstr[0] "%{count} an"
 msgstr[1] "%{count} ani"
+msgstr[2] "%{count} ani"


### PR DESCRIPTION
### Summary of changes

Fixes #404.

Updates the RO translation files (which contain plurals) to accurately represent a third case. This case is for any number ending in 00, or 20-99, as shown at https://www.gnu.org/software/gettext/manual/html_node/Plural-forms.html#Plural-forms.

### Checklist

- [x] Plural translations have been updated
- [x] Commits were squashed into a single coherent commit
