### PR TITLE
fix calculation of diff_months when diffing same months

### DIFF
--- a/lib/comparable/diff.ex
+++ b/lib/comparable/diff.ex
@@ -129,7 +129,7 @@ defmodule Timex.Comparable.Diff do
     year_diff = y2 - (y1+1)
     month_diff =
       cond do
-        d2 > d1 ->
+        d1 > d2 ->
           11
         :else ->
           12

--- a/test/diff_test.exs
+++ b/test/diff_test.exs
@@ -1,0 +1,22 @@
+defmodule DiffTests do
+  use ExUnit.Case, async: true
+  use Timex
+
+  test "diff with same month and end day greater than start day" do
+    difference = Timex.diff(~D[2018-01-02], ~D[2017-01-01], :months)
+    expected = 12
+    assert expected === difference
+  end
+
+  test "diff with same month and end day equal to start day" do
+    difference = Timex.diff(~D[2018-01-01], ~D[2017-01-01], :months)
+    expected = 12
+    assert expected === difference
+  end
+
+  test "diff with same month and end day smaller than start day" do
+    difference = Timex.diff(~D[2018-01-01], ~D[2017-01-02], :months)
+    expected = 11
+    assert expected === difference
+  end
+end


### PR DESCRIPTION
### Steps to reproduce

`Timex.diff` is not working properly when diffing months.

### Description of issue

- `Timex.diff(~D[2018-01-02], ~D[2017-01-01] , :months)` is `11` but should be `12` months. Compare to https://www.wolframalpha.com/input/?i=months+from+2018-01-02+until+2017-01-01
