### PR TITLE
Add Time.t to the calendar_types and valid_datetime

### DIFF
--- a/lib/timex/types.ex
+++ b/lib/timex/types.ex
@@ -35,7 +35,7 @@ defmodule Timex.Types do
   @type datetime :: { date, time }
   @type microsecond_datetime :: { date, microsecond_time }
   @type iso_triplet :: { year, weeknum, weekday }
-  @type calendar_types :: Date.t | DateTime.t | NaiveDateTime.t
-  @type valid_datetime :: Date.t | DateTime.t | NaiveDateTime.t | datetime | date | microsecond_datetime
+  @type calendar_types :: Date.t | DateTime.t | NaiveDateTime.t | Time.t
+  @type valid_datetime :: Date.t | DateTime.t | NaiveDateTime.t | Time.t | datetime | date | microsecond_datetime
   @type weekstart :: weekday | binary | atom
 end


### PR DESCRIPTION
### Summary of changes
In regards to https://github.com/bitwalker/timex/issues/414
Timex.format!(~T[12:00:00], "{h12}:{m} {AM}") will produce the expected result of "12:00 PM"
However dialyzer flags it as an error because Time.t is not one of the allowed arguments.

### Checklist

- [ x ] New functions have typespecs, changed functions were updated
- [ x ] Same for documentation, including moduledocs
- [ x ] Tests were added or updated to cover changes
- [ x ] Commits were squashed into a single coherent commit
