### PR TITLE
Fix infinite loop on Timex.Timezone.convert/2

### DIFF
--- a/lib/timezone/timezone.ex
+++ b/lib/timezone/timezone.ex
@@ -472,7 +472,10 @@ defmodule Timex.Timezone do
     end
   end
   def convert(date, tz) do
-    convert(Timex.to_datetime(date), tz)
+    case Timex.to_datetime(date) do
+      {:error, _} = err -> err
+      date -> convert(date, tz)
+    end
   end
 
   defp do_shift(%DateTime{:microsecond => us} = datetime, seconds) do

--- a/test/timezone_test.exs
+++ b/test/timezone_test.exs
@@ -93,6 +93,9 @@ defmodule TimezoneTests do
     assert %DateTime{hour: 7} = Timex.to_datetime({{2014,2,24},{12,0,0}}, gmt_plus_two) |> Timezone.convert(gmt_minus_three)
     # If it's noon in GMT-3, then it's 5'oclock in the evening in GMT+2
     assert %DateTime{hour: 17} = Timex.to_datetime({{2014,2,24},{12,0,0}}, gmt_minus_three) |> Timezone.convert(gmt_plus_two)
+
+    # Return {:error, term} if an invalid date is given
+    assert {:error, :invalid_date} = Timezone.convert(nil, cst)
   end
 
   test "converting across zone boundaries" do


### PR DESCRIPTION
### Summary of changes

This PR fixes an infinite loop on Timex.Timezone.convert/2.

I found the use of `Timex.Timezone.convert(nil, "Etc/UTC")` leads non-termination due to the lack of response handling for Timex.to_datetime/1 in the last clause of Timex.Timezone.convert/2.

### Checklist

- ~~[ ] New functions have typespecs, changed functions were updated~~
- ~~[ ] Same for documentation, including moduledocs~~
- [x] Tests were added or updated to cover changes
- [x] Commits were squashed into a single coherent commit
