### PR TITLE
Fix Timex.Parse.DateTime.Tokenizer.tokenize specs

### DIFF
--- a/lib/parse/datetime/tokenizer.ex
+++ b/lib/parse/datetime/tokenizer.ex
@@ -4,7 +4,7 @@ defmodule Timex.Parse.DateTime.Tokenizer do
   """
   alias Timex.Parse.DateTime.Tokenizers.Directive
 
-  @callback tokenize(format_string :: String.t) :: [Directive.t] | {:error, term}
+  @callback tokenize(format_string :: String.t) :: {:ok, [Directive.t]} | {:error, term}
   @callback apply(DateTime.t, token :: atom, value :: term) :: DateTime.t | {:error, term} | :unrecognized
 
   defmacro __using__(_) do

--- a/lib/parse/datetime/tokenizers/default.ex
+++ b/lib/parse/datetime/tokenizers/default.ex
@@ -10,7 +10,7 @@ defmodule Timex.Parse.DateTime.Tokenizers.Default do
   @doc """
   Tokenizes the given format string and returns an error or a list of directives.
   """
-  @spec tokenize(String.t) :: [Directive.t] | {:error, term}
+  @spec tokenize(String.t) :: {:ok, [Directive.t]} | {:error, term}
   def tokenize(<<>>), do: {:error, "Format string cannot be empty."}
   def tokenize(str) do
     token_parser = default_format_parser()

--- a/lib/parse/datetime/tokenizers/strftime.ex
+++ b/lib/parse/datetime/tokenizers/strftime.ex
@@ -10,7 +10,7 @@ defmodule Timex.Parse.DateTime.Tokenizers.Strftime do
   @doc """
   Tokenizes the given format string and returns an error or a list of directives.
   """
-  @spec tokenize(String.t) :: [Directive.t] | {:error, term}
+  @spec tokenize(String.t) :: {:ok, [Directive.t]} | {:error, term}
   def tokenize(<<>>), do: {:error, "Format string cannot be empty."}
   def tokenize(str) do
     case Combine.parse(str, strftime_format_parser()) do


### PR DESCRIPTION
### Summary of changes

Fixed Timex.Parse.DateTime.Tokenizer.tokenize callback definition and specs in all modules that implements its behaviour. It was causing dialyzer to fail in my project.

### Checklist

- [ ] New functions have typespecs, changed functions were updated
- [ ] Same for documentation, including moduledocs
- [ ] Tests were added or updated to cover changes
- [ ] Commits were squashed into a single coherent commit
