### PR TITLE
Fix a typo in valid_interval_step typespec

### DIFF
--- a/lib/interval/interval.ex
+++ b/lib/interval/interval.ex
@@ -45,7 +45,7 @@ defmodule Timex.Interval do
                                [days:         integer()] |
                                [weeks:        integer()] |
                                [months:       integer()] |
-                               [year:         integer()]
+                               [years:        integer()]
 
   @enforce_keys [:from, :until]
   defstruct from:       nil,


### PR DESCRIPTION
### Summary of changes

Fix a typo in valid_interval_step type in Timex.Interval.