### PR TITLE
Fix dialyzer warning when comparing Timex.DateTime

### DIFF
--- a/lib/comparable/comparable.ex
+++ b/lib/comparable/comparable.ex
@@ -8,7 +8,7 @@ defprotocol Timex.Comparable do
                        :hours | :minutes | :seconds | :milliseconds | :microseconds |
                        :duration
   @type constants :: :epoch | :zero | :distant_past | :distant_future
-  @type comparable :: Date.t | DateTime.t | NaiveDateTime.t | Types.date | Types.datetime
+  @type comparable :: Timex.DateTime.t | Date.t | DateTime.t | NaiveDateTime.t | Types.date | Types.datetime
   @type compare_result :: -1 | 0 | 1 | {:error, term}
   @type diff_result :: Timex.Duration.t | integer | {:error, term}
 

--- a/test/comparable_test.exs
+++ b/test/comparable_test.exs
@@ -22,6 +22,12 @@ defmodule ComparableTests do
     assert {:error, :invalid_date} = Comparable.diff({0,0,0}, {2015,1,1})
   end
 
+  test "compare Timex.DateTime" do
+    assert 0 == Comparable.compare(Timex.DateTime.from_seconds(0), Timex.DateTime.from_seconds(0))
+    assert 1 == Comparable.compare(Timex.DateTime.from_seconds(1), Timex.DateTime.from_seconds(0))
+    assert -1 == Comparable.compare(Timex.DateTime.from_seconds(0), Timex.DateTime.from_seconds(1))
+  end
+
   test "compare ambiguous_datetime" do
     lmt_jwst = Timex.to_datetime({{1895,12,31},{23,55,0}}, "Asia/Taipei")
     assert 0 = Comparable.compare(lmt_jwst, lmt_jwst)


### PR DESCRIPTION
### Summary of changes

When running `mix dialyze` on this project, one of the warnings is
```
lib/comparable/date.ex:12: The call 'Elixir.Timex.DateTime':compare({'error','badarg'} | #{'__struct__':='Elixir.Timex.DateTime', 'calendar':=_, 'day':=_, 'hour':=_, 'millisecond':=
_, 'minute':=_, 'month':=_, 'second':=_, 'timezone':=_, 'year':=_},any(),granularity@1::any()) will never return since it differs in the 1st argument from the success typing argumen
ts: ('distant_future' | 'distant_past' | 'epoch' | 'zero' | {{{non_neg_integer(),1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 | 11 | 12,1..255},{byte(),byte(),byte()} | {byte(),byte(),byt
e(),non_neg_integer()}} | {non_neg_integer(),1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 | 11 | 12,1..255},{byte(),byte(),byte()} | {byte(),byte(),byte(),non_neg_integer()} | #{'__struct
__':='Elixir.Timex.TimezoneInfo', 'abbreviation':=_, 'from':=_, 'full_name':=_, 'offset_std':=_, 'offset_utc':=_, 'until':=_}} | {non_neg_integer(),1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9
 | 10 | 11 | 12,1..255} | #{'__struct__':='Elixir.Date' | 'Elixir.DateTime', 'calendar':=atom(), 'day':=integer(), 'month':=integer(), 'year':=integer(), 'hour'=>integer(), 'microse
cond'=>{char(),0 | 1 | 2 | 3 | 4 | 5 | 6}, 'minute'=>integer(), 'second'=>integer(), 'std_offset'=>integer(), 'time_zone'=>binary(), 'utc_offset'=>integer(), 'zone_abbr'=>binary()},
'distant_future' | 'distant_past' | 'epoch' | 'zero' | {{{non_neg_integer(),1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 | 11 | 12,1..255},{byte(),byte(),byte()} | {byte(),byte(),byte(),n
on_neg_integer()}} | {non_neg_integer(),1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 | 11 | 12,1..255},{byte(),byte(),byte()} | {byte(),byte(),byte(),non_neg_integer()} | #{'__struct__':=
'Elixir.Timex.TimezoneInfo', 'abbreviation':=_, 'from':=_, 'full_name':=_, 'offset_std':=_, 'offset_utc':=_, 'until':=_}} | {non_neg_integer(),1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10
 | 11 | 12,1..255} | #{'__struct__':='Elixir.Date' | 'Elixir.DateTime', 'calendar':=atom(), 'day':=integer(), 'month':=integer(), 'year':=integer(), 'hour'=>integer(), 'microsecond'
=>{char(),0 | 1 | 2 | 3 | 4 | 5 | 6}, 'minute'=>integer(), 'second'=>integer(), 'std_offset'=>integer(), 'time_zone'=>binary(), 'utc_offset'=>integer(), 'zone_abbr'=>binary()},'cale
ndar_weeks' | 'days' | 'hours' | 'minutes' | 'months' | 'seconds' | 'timestamp' | 'weeks' | 'years')
```

I also ran into this in my own project when trying to compare two Timex.DateTime structs.

I believe the problem is that the `comparable` type includes `DateTime.t` which refers to the Elixir builtin `DateTime`, but `compare/1` also works fine with `Timex.DateTime` as the added test verifies. In other modules, we `alias Timex.DateTime`, but not in `Comparable`. I'm not sure if the builtin Elixir `DateTime` is intentionally supported, but I'm leaving it there for backward compatibility. 

This PR lowers the number of `mix dialyze` warnings from 142 to 129.

### Checklist

- [x] New functions have typespecs, changed functions were updated
- [x] Same for documentation, including moduledocs
- [x] Tests were added or updated to cover changes
- [x] Commits were squashed into a single coherent commit
