### PR TITLE
#398 - Add support for millisecond formatting.

### DIFF
--- a/lib/format/datetime/formatter.ex
+++ b/lib/format/datetime/formatter.ex
@@ -598,6 +598,26 @@ defmodule Timex.Format.DateTime.Formatter do
   def format_token(_locale, :us, _date, _modifiers, flags, width) do
     pad_numeric(0, flags, width)
   end
+  def format_token(_locale, :ms, %{microsecond: {us, _precision}}, _modifiers, flags, width) do
+    min =
+      case Keyword.get(width, :min) do
+        nil -> 3
+        n when n < 3 -> 3
+        n -> n
+      end
+    max =
+      case Keyword.get(width, :max) do
+        nil -> min
+        n when n < min -> min
+        n -> n
+      end
+    us
+    |> div(1000)
+    |> pad_numeric(flags, width_spec(min..max))
+  end
+  def format_token(_locale, :ms, _date, _modifiers, flags, width) do
+    pad_numeric(0, flags, width)
+  end
   def format_token(locale, :am, %{hour: hour}, _modifiers, _flags, _width) do
     day_periods = Translator.get_day_periods(locale)
     {_, am_pm} = Timex.Time.to_12hour_clock(hour)

--- a/test/format_strftime_test.exs
+++ b/test/format_strftime_test.exs
@@ -259,6 +259,18 @@ defmodule DateFormatTest.FormatStrftime do
     assert { :ok, "AM  0" } = format(date_midnight, "%p %k")
   end
 
+  test "format %L" do
+    dt = Timex.to_datetime({{2018, 6, 6}, {0, 26, 15}})
+    dt = %{dt | :microsecond => {012_345,6}}
+
+    assert { :ok, "12" }  = format(dt, "%-L")
+    assert { :ok, "012" } = format(dt, "%L")
+    assert { :ok, "012" }  = format(dt, "%0L")
+    assert { :ok, " 12" } = format(dt, "%_L")
+    # the width is forced
+    assert { :ok, "012" } = format(dt, "%04L")
+  end
+
   test "format %p" do
     date_midnight = Timex.to_datetime({{2013,8,18}, {0,3,4}})
 
@@ -342,6 +354,7 @@ defmodule DateFormatTest.FormatStrftime do
     assert format(dt, "%d") == {:ok, "03"}
     assert format(dt, "%e") == {:ok, " 3"}
     assert format(dt, "%f") == {:ok, "012000"}
+    assert format(dt, "%L") == {:ok, "012"}
     assert format(dt, "%u") == {:ok, "1"}
     assert format(dt, "%w") == {:ok, "1"}
     assert format(dt_sunday, "%u") == {:ok, "7"}


### PR DESCRIPTION
This is my rudimentary attempt at fixing #398.

I'm not sure the min/max width computation is really needed, as the width is forced to 3 by definition, but mimicking microseconds, I put it there.