### PR TITLE
Parse weekday

### DIFF
--- a/lib/parse/datetime/parser.ex
+++ b/lib/parse/datetime/parser.ex
@@ -305,6 +305,10 @@ defmodule Timex.Parse.DateTime.Parser do
       week_num when week_num in [:week_mon, :week_sun] ->
         reset = %{date | :month => 1, :day => 1}
         reset |> Timex.shift(weeks: value)
+
+      :weekday ->
+        date |> Timex.shift(days: value - 1)
+
       # Hours
       hour when hour in [:hour24, :hour12] ->
         %{date | :hour => value}

--- a/test/parse_default_test.exs
+++ b/test/parse_default_test.exs
@@ -85,6 +85,18 @@ defmodule DateFormatTest.ParseDefault do
     assert ~N[2007-11-19 00:00:00] = Timex.parse!("2007-W47", "{ISOweek}")
   end
 
+  test "parse ISO week with day" do
+    assert ~N[2018-06-25 00:00:00] = Timex.parse!("2018-W26-1", "{ISOweek-day}")
+    assert ~N[2018-06-26 00:00:00] = Timex.parse!("2018-W26-2", "{ISOweek-day}")
+    assert ~N[2018-07-01 00:00:00] = Timex.parse!("2018-W26-7", "{ISOweek-day}")
+
+    assert {:error, "Expected `ordinal weekday` at line 1, column 10."} =
+             Timex.parse("2018-W26-0", "{ISOweek-day}")
+
+    assert {:error, "Expected `ordinal weekday` at line 1, column 10."} =
+             Timex.parse("2018-W26-8", "{ISOweek-day}")
+  end
+
   test "parse ISO year4/year2" do
     date = Timex.to_naive_datetime({2007,1,1})
     year = date.year


### PR DESCRIPTION
Added parsing of weekday token that is used in 
{ISOweek-day} default Tokenizer

### Summary of changes

The `:weekday` Token was missing while parsing an `{ISOweek-day}`:
```
iex(10)> Timex.parse!("2007-W09-1", "{ISOweek-day}")
** (Timex.Parse.ParseError) Unrecognized token: weekday
    (timex) lib/parse/datetime/parser.ex:97: Timex.Parse.DateTime.Parser.parse!/3
```

### Checklist

- [x] New functions have typespecs, changed functions were updated
- [x] Same for documentation, including moduledocs
- [x] Tests were added or updated to cover changes
- [x] Commits were squashed into a single coherent commit
