### PR TITLE
Fixed italian weekday translation for 'Thu'

### DIFF
--- a/priv/translations/it/LC_MESSAGES/weekdays.po
+++ b/priv/translations/it/LC_MESSAGES/weekdays.po
@@ -53,7 +53,7 @@ msgstr "Domenica"
 
 #: lib/l10n/translator.ex:191
 msgid "Thu"
-msgstr "Giu"
+msgstr "Gio"
 
 #: lib/l10n/translator.ex:199
 msgid "Thursday"


### PR DESCRIPTION
### Summary of changes

Currently we translate the short weekday 'Thu' ('Thursday') to 'Giu' in italian. The right translation should be 'Gio' ('Giovedì').

### Checklist

- [x] No new functions
- [x] No new documentation
- [x] No test for translations
- [x] Single commit
