### PR TITLE
Add Interval.contains?/2 to test if one interval contains another

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ version bump, as the old behavior did not match the docs, and was incorrect to b
 breaking changes only affect you if you relied on the incorrect behavior, if you were expecting the
 documented behavior, then these are _not_ breaking changes.
 
+### Added
+
+- Interval.contains?/2 to test if one interval contains another
+
 ### Fixed
 
 - Interval overlap was being improperly calculated

--- a/lib/interval/interval.ex
+++ b/lib/interval/interval.ex
@@ -281,6 +281,31 @@ defmodule Timex.Interval do
   end
 
   @doc """
+  Returns true if the first interval includes every point in time the second includes.
+
+  ## Examples
+
+  iex> #{__MODULE__}.contains?(#{__MODULE__}.new(from: ~D[2018-01-01], until: ~D[2018-01-31]), #{
+    __MODULE__
+  }.new(from: ~D[2018-01-01], until: ~D[2018-01-30]))
+  true
+
+  iex> #{__MODULE__}.contains?(#{__MODULE__}.new(from: ~D[2018-01-01], until: ~D[2018-01-30]), #{
+    __MODULE__
+  }.new(from: ~D[2018-01-01], until: ~D[2018-01-31]))
+  false
+
+  iex> #{__MODULE__}.contains?(#{__MODULE__}.new(from: ~D[2018-01-01], until: ~D[2018-01-10]), #{
+    __MODULE__
+  }.new(from: ~D[2018-01-05], until: ~D[2018-01-15]))
+  false
+  """
+  @spec contains?(__MODULE__.t(), __MODULE__.t()) :: boolean()
+  def contains?(%__MODULE__{} = a, %__MODULE__{} = b) do
+    Timex.compare(min(a), min(b)) <= 0 && Timex.compare(max(a), max(b)) >= 0
+  end
+
+  @doc """
   Returns true if the first interval shares any point(s) in time with the second.
 
   ## Examples

--- a/test/interval_test.exs
+++ b/test/interval_test.exs
@@ -182,4 +182,62 @@ defmodule IntervalTests do
       refute Interval.overlaps?(b, a)
     end
   end
+
+  describe "contains?/2" do
+    test "non-overlapping" do
+      earlier = Interval.new(from: ~D[2018-01-01], until: ~D[2018-01-04])
+      later = Interval.new(from: ~D[2018-01-05], until: ~D[2018-01-10])
+
+      refute Interval.contains?(earlier, later)
+    end
+
+    test "first subset of second" do
+      superset = Interval.new(from: ~D[2018-01-01], until: ~D[2018-01-31])
+      subset_a = Interval.new(from: ~D[2018-01-01], until: ~D[2018-01-30])
+      subset_b = Interval.new(from: ~D[2018-01-02], until: ~D[2018-01-15])
+
+      refute Interval.contains?(subset_a, superset)
+      refute Interval.contains?(subset_b, superset)
+    end
+
+    test "first superset of second" do
+      superset = Interval.new(from: ~D[2018-01-01], until: ~D[2018-01-31])
+      subset_a = Interval.new(from: ~D[2018-01-01], until: ~D[2018-01-30])
+      subset_b = Interval.new(from: ~D[2018-01-02], until: ~D[2018-01-15])
+
+      assert Interval.contains?(superset, subset_a)
+      assert Interval.contains?(superset, subset_b)
+    end
+
+    test "first partially ahead of second" do
+      first = Interval.new(from: ~D[2018-01-01], until: ~D[2018-01-10])
+      second = Interval.new(from: ~D[2018-01-05], until: ~D[2018-01-15])
+
+      refute Interval.contains?(first, second)
+    end
+
+    test "first partially behind second" do
+      first = Interval.new(from: ~D[2018-01-05], until: ~D[2018-01-15])
+      second = Interval.new(from: ~D[2018-01-01], until: ~D[2018-01-10])
+
+      refute Interval.contains?(first, second)
+    end
+
+    test "contains itself" do
+      from = ~D[2018-01-01]
+      until = ~D[2018-01-15]
+
+      interval_a = Interval.new(from: from, until: until, left_open: true, right_open: false)
+      assert Interval.contains?(interval_a, interval_a)
+
+      interval_b = Interval.new(from: from, until: until, left_open: true, right_open: true)
+      assert Interval.contains?(interval_b, interval_b)
+
+      interval_c = Interval.new(from: from, until: until, left_open: false, right_open: true)
+      assert Interval.contains?(interval_c, interval_c)
+
+      interval_d = Interval.new(from: from, until: until, left_open: false, right_open: false)
+      assert Interval.contains?(interval_d, interval_d)
+    end
+  end
 end


### PR DESCRIPTION
### Summary of changes

Add `Interval.contains?/2` to test if one interval contains another.

This is useful when, for example, deciding if a proposed appointment time slot fits inside a window of availability.

```elixir
Timex.Interval.contains?(availability_window, proposed_appointment)
```

### Checklist

- [x] New functions have typespecs, changed functions were updated
- [x] Same for documentation, including moduledocs
- [x] Tests were added or updated to cover changes
- [x] Commits were squashed into a single coherent commit

I also formatted the new code & tests with `mix format`.
