### PR TITLE
Do not discard previously parsed date when applying %r directive

### DIFF
--- a/lib/parse/datetime/parser.ex
+++ b/lib/parse/datetime/parser.ex
@@ -222,8 +222,13 @@ defmodule Timex.Parse.DateTime.Parser do
     case token do
       # Formats
       clock when clock in [:kitchen, :strftime_iso_kitchen] ->
-        {{y,m,d},_} = :calendar.universal_time()
-        date = %{date | :year => y, :month => m, :day => d}
+        date = cond do
+          date == Timex.DateTime.Helpers.empty() ->
+            {{y,m,d},_} = :calendar.universal_time()
+            %{date | :year => y, :month => m, :day => d}
+          true ->
+            date
+        end
         case apply_directives(value, date, tokenizer) do
           {:error, _} = err -> err
           {:ok, date} when clock == :kitchen ->

--- a/test/parse_strftime_test.exs
+++ b/test/parse_strftime_test.exs
@@ -47,6 +47,25 @@ defmodule DateFormatTest.ParseStrftime do
     assert elem(ms3.microsecond, 0) == 100 * 1_000
   end
 
+  test "issue #446 - strftime_iso_kitchen should not discard dates" do
+    input_datetime_str = "July 23, 2018 05:34:04 PM PDT"
+    expected_datetime = %DateTime{
+      calendar: Calendar.ISO,
+      day: 23,
+      hour: 17,
+      microsecond: {0, 0},
+      minute: 34,
+      month: 7,
+      second: 4,
+      std_offset: 3600,
+      time_zone: "PST8PDT",
+      utc_offset: -28800,
+      year: 2018,
+      zone_abbr: "PDT"
+    }
+    assert Timex.parse!(input_datetime_str, "%B %d, %Y %r %Z", :strftime) == expected_datetime
+  end
+
   defp parse(date, fmt) do
     Timex.parse(date, fmt, :strftime)
   end


### PR DESCRIPTION
### Summary of changes

This fixes issue #446, where parsing using `:strftime` with `%r` overwrites previously parsed date information with the current date. So, when parsing the date `July 21, 2017 05:15:45 PM PST` with `%B %d, %Y %r %Z`, the time is correct but the date is set to today.

This fix does introduce a *different* edge case, where if you only include part of the date, the non-included fields will not be set. So `July 21, 05:15:45 PM` will return a date without a year. That seems like more reasonable behavior than setting the date to today, however.

### Checklist

- [x] New functions have typespecs, changed functions were updated
- [x] Same for documentation, including moduledocs
- [x] Tests were added or updated to cover changes
- [x] Commits were squashed into a single coherent commit
