### PR TITLE
Make beginning_of_month return the first of the month in the correct timezone

### DIFF
--- a/lib/datetime/datetime.ex
+++ b/lib/datetime/datetime.ex
@@ -125,8 +125,8 @@ defimpl Timex.Protocol, for: DateTime do
   end
 
   @spec beginning_of_month(DateTime.t) :: DateTime.t
-  def beginning_of_month(%DateTime{microsecond: {_, _precision}} = datetime),
-    do: %{datetime | :day => 1, :hour => 0, :minute => 0, :second => 0, :microsecond => {0, 0}}
+  def beginning_of_month(%DateTime{year: year, month: month, time_zone: tz}),
+    do: Timex.DateTime.Helpers.construct({{year, month, 1}, {0, 0, 0, 0}}, tz)
 
   @spec end_of_month(DateTime.t) :: DateTime.t
   def end_of_month(%DateTime{year: year, month: month, time_zone: tz} = date),

--- a/test/timex_test.exs
+++ b/test/timex_test.exs
@@ -441,6 +441,7 @@ defmodule TimexTests do
   test "beginning_of_month" do
     assert Timex.beginning_of_month({2016,2,15}) == {2016, 2, 1}
     assert Timex.beginning_of_month(Timex.to_datetime({{2014,2,15},{14,14,14}})) == Timex.to_datetime({{2014,2,1},{0,0,0}})
+    assert Timex.beginning_of_month(Timex.to_datetime({{2018,11,15},{14,14,14}}, "America/New_York")) == Timex.to_datetime({{2018,11,1},{0,0,0}}, "America/New_York")
 
     assert {:error, :invalid_date} = Timex.beginning_of_month("Made up date")
     assert {:error, :invalid_date} = Timex.beginning_of_month(nil)


### PR DESCRIPTION
### Summary of changes

Takes the time_offset of the beginning of the month into account when computing `beginning_of_month`. Fixes an issue whereby `beginning_of_month` called with e.g. `13:45 15 Nov 2018 EST` would return `00:00 1 Nov 2018 EST` where it should be `00:00 1 Nov 2018 EDT` since the Eastern timezone was still in daylight savings on 1 Nov. 

Note that other `{beginning,end}_of_{day,week,month}` functions already do the right thing - the implementation of this method was the outlier. 

### Checklist

- [x] New functions have typespecs, changed functions were updated
- [x] Same for documentation, including moduledocs
- [x] Tests were added or updated to cover changes
- [x] Commits were squashed into a single coherent commit
