### PR TITLE
add link to changelog

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -33,7 +33,10 @@ defmodule Timex.Mixfile do
     [ files: ["lib", "priv", "mix.exs", "README.md", "LICENSE.md"],
       maintainers: ["Paul Schoenfelder"],
       licenses: ["MIT"],
-      links: %{ "GitHub": "https://github.com/bitwalker/timex" } ]
+      links: %{ 
+        "Changelog": "https://github.com/bitwalker/timex/blob/master/CHANGELOG.md", 
+        "GitHub": "https://github.com/bitwalker/timex"
+    }]
   end
 
   def deps do


### PR DESCRIPTION
link will be picked up by hex and added to https://hex.pm/packages/timex next time a version is published

for example see https://hex.pm/packages/quantum

### Summary of changes

new "Changelog" link on https://hex.pm/packages/timex to https://github.com/bitwalker/timex/blob/master/CHANGELOG.md

### Checklist

- [x] New functions have typespecs, changed functions were updated
- [x] Same for documentation, including moduledocs
- [x] Tests were added or updated to cover changes
- [x] Commits were squashed into a single coherent commit
