### PR TITLE
#454: Fixed this and added some tests.

### DIFF
--- a/lib/format/datetime/formatter.ex
+++ b/lib/format/datetime/formatter.ex
@@ -598,8 +598,10 @@ defmodule Timex.Format.DateTime.Formatter do
   def format_token(_locale, :us, _date, _modifiers, flags, width) do
     pad_numeric(0, flags, width)
   end
-  def format_token(_locale, :ms, _date = %{microsecond: {us, _precision}}, _modifiers, flags, width), do: pad_numeric(Kernel.round(us / 1000), flags, width_spec(3..3))
-  def format_token(_locale, :ms, _date, _modifiers, flags, width), do: pad_numeric(0, flags, width)
+  def format_token(_locale, :ms, _date = %{microsecond: {us, _precision}}, _modifiers, flags, width),
+    do: pad_numeric(Kernel.round(us / 1000), flags, width_spec(3..3))
+  def format_token(_locale, :ms, _date, _modifiers, flags, width),
+    do: pad_numeric(0, flags, width)
   def format_token(locale, :am, %{hour: hour}, _modifiers, _flags, _width) do
     day_periods = Translator.get_day_periods(locale)
     {_, am_pm} = Timex.Time.to_12hour_clock(hour)

--- a/lib/format/datetime/formatter.ex
+++ b/lib/format/datetime/formatter.ex
@@ -598,6 +598,8 @@ defmodule Timex.Format.DateTime.Formatter do
   def format_token(_locale, :us, _date, _modifiers, flags, width) do
     pad_numeric(0, flags, width)
   end
+  def format_token(_locale, :ms, _date = %{microsecond: {us, _precision}}, _modifiers, flags, width), do: pad_numeric(Kernel.round(us / 1000), flags, width_spec(3..3))
+  def format_token(_locale, :ms, _date, _modifiers, flags, width), do: pad_numeric(0, flags, width)
   def format_token(locale, :am, %{hour: hour}, _modifiers, _flags, _width) do
     day_periods = Translator.get_day_periods(locale)
     {_, am_pm} = Timex.Time.to_12hour_clock(hour)

--- a/test/comparable_test.exs
+++ b/test/comparable_test.exs
@@ -34,4 +34,12 @@ defmodule ComparableTests do
     assert 0 = Comparable.compare(lmt_jwst, lmt_jwst)
     assert {:error, {:ambiguous_comparison, _}} = Comparable.compare(lmt_jwst, Timex.to_naive_datetime({2015, 1, 1}))
   end
+
+  test "compare naive_datetime" do
+    naive_dt = Timex.to_naive_datetime({1970,1,1})
+    assert -1 == Comparable.compare(naive_dt, :distant_future)
+    assert +1 == Comparable.compare(naive_dt, :distant_past)
+    assert 0 == Comparable.compare(naive_dt, :epoch)
+    assert +1 == Comparable.compare(naive_dt, :zero)
+  end
 end

--- a/test/format_strftime_test.exs
+++ b/test/format_strftime_test.exs
@@ -17,14 +17,14 @@ defmodule DateFormatTest.FormatStrftime do
     end)
   end
 
-  test "success!" do
+  test "success! (to hit line 115 in datetime/formatters/strftime.ex)" do
     date = Timex.to_datetime({2013,03,02})
 
     formatter = Timex.Format.DateTime.Formatters.Strftime
     assert "2013-03-02" == formatter.format!(date, "%Y-%m-%d")
   end
 
-  test "error tuple" do
+  test "error returned when invalid directive is given" do
     date = Timex.to_datetime({2013,03,02})
 
     formatter = Timex.Format.DateTime.Formatters.Strftime

--- a/test/format_strftime_test.exs
+++ b/test/format_strftime_test.exs
@@ -243,6 +243,54 @@ defmodule DateFormatTest.FormatStrftime do
     assert { :ok, " 4" } = format(date, "%l")
   end
 
+  test "format %f" do
+    with_us_5 = {{2018,8,8}, {9,24,0,12345}}
+    with_us_6 = {{2018,8,8}, {9,24,0,123456}}
+    without_us = {{2018,8,8}, {9,24,0}}
+    dt_with_5 = Timex.to_datetime(with_us_5)
+    dt_with_6 = Timex.to_datetime(with_us_6)
+    dt_without = Timex.to_datetime(without_us)
+    assert { :ok, "000000" } = format(dt_without, "%f")
+    assert { :ok, "012345" } = format(dt_with_5, "%f")
+    assert { :ok, "012345" } = format(dt_with_5, "%0f")
+    assert { :ok, "123456" } = format(dt_with_6, "%f")
+    assert { :ok, "0" } = format(dt_without, "%-f")
+    assert { :ok, "12345" } = format(dt_with_5, "%-f")
+    assert { :ok, " 12345" } = format(dt_with_5, "%_f")
+  end
+
+  test "format %L" do
+    with_us_5 = {{2018,8,8}, {9,24,0,12345}}
+    with_us_6 = {{2018,8,8}, {9,24,0,123456}}
+    without_us = {{2018,8,8}, {9,24,0}}
+    dt_with_5 = Timex.to_datetime(with_us_5)
+    dt_with_6 = Timex.to_datetime(with_us_6)
+    dt_without = Timex.to_datetime(without_us)
+    assert { :ok, "000" } = format(dt_without, "%L")
+    assert { :ok, "012" } = format(dt_with_5, "%L")
+    assert { :ok, "012" } = format(dt_with_5, "%0L")
+    assert { :ok, "123" } = format(dt_with_6, "%L")
+    assert { :ok, "0" } = format(dt_without, "%-L")
+    assert { :ok, "12" } = format(dt_with_5, "%-L")
+    assert { :ok, " 12" } = format(dt_with_5, "%_L")
+  end
+
+  test "format %L (rounding)" do
+    with_us_5 = {{2018,8,8}, {9,24,0,12945}}
+    with_us_6 = {{2018,8,8}, {9,24,0,129456}}
+    without_us = {{2018,8,8}, {9,24,0}}
+    dt_with_5 = Timex.to_datetime(with_us_5)
+    dt_with_6 = Timex.to_datetime(with_us_6)
+    dt_without = Timex.to_datetime(without_us)
+    assert { :ok, "000" } = format(dt_without, "%L")
+    assert { :ok, "013" } = format(dt_with_5, "%L")
+    assert { :ok, "013" } = format(dt_with_5, "%0L")
+    assert { :ok, "129" } = format(dt_with_6, "%L")
+    assert { :ok, "0" } = format(dt_without, "%-L")
+    assert { :ok, "13" } = format(dt_with_5, "%-L")
+    assert { :ok, " 13" } = format(dt_with_5, "%_L")
+  end
+
   test "various time combinations" do
     date = Timex.to_datetime({{2013,8,18}, {12,3,4}})
     date_midnight = Timex.to_datetime({{2013,8,18}, {0,3,4}})

--- a/test/format_strftime_test.exs
+++ b/test/format_strftime_test.exs
@@ -17,6 +17,20 @@ defmodule DateFormatTest.FormatStrftime do
     end)
   end
 
+  test "success!" do
+    date = Timex.to_datetime({2013,03,02})
+
+    formatter = Timex.Format.DateTime.Formatters.Strftime
+    assert "2013-03-02" == formatter.format!(date, "%Y-%m-%d")
+  end
+
+  test "error tuple" do
+    date = Timex.to_datetime({2013,03,02})
+
+    formatter = Timex.Format.DateTime.Formatters.Strftime
+    assert { :error, { :format, "Expected at least one parser to succeed at line 1, column 0." } } == formatter.format(date, "%.")
+  end
+
   test "format %Y" do
     assert { :ok, "2013" } = format(@aug182013, "%Y")
     assert { :ok, "0003" } = format(@aug180003, "%Y")


### PR DESCRIPTION
Fixed to 3 zeroes as that is t…he point of the %L, I would assume. If that assumption incorrect, feedback is welcome.

### Summary of changes

The directive `%L` causes a crash.

### Checklist

- [x] New functions have typespecs, changed functions were updated
- [x] Same for documentation, including moduledocs
- [X] Tests were added or updated to cover changes
- [X] Commits were squashed into a single coherent commit

The tests were mostly copied from #433 and adapted, and made some more. Not sure whether the division should be rounded, but I would assume so. It might not be the case, and if so that can be fixed by just doing `div(us, 1000)` similarly to what #433 did.