### PR TITLE
inclusive_start/inclusive_end options for Timex.between?

### DIFF
--- a/test/timex_test.exs
+++ b/test/timex_test.exs
@@ -289,6 +289,44 @@ defmodule TimexTests do
     assert {:error, :invalid_date} == Timex.between?({{2013, 1, 1}, {1, 1, 2}}, {{2013, 1, 1}, {1, 1, 2}}, {}, options)
   end
 
+  test "between? inclusive_start" do
+    date1 = Timex.to_datetime({{2013,1,1},{0, 0, 0}})
+    date2 = Timex.to_datetime({{2013,1,5},{0, 0, 0}})
+    date3 = Timex.to_datetime({{2013,1,9},{0, 0, 0}})
+
+    options = [inclusive: :start]
+
+    assert true == Timex.between?(date2, date1, date3, options)
+    assert true == Timex.between?(date1, date1, date3, options)
+    assert false == Timex.between?(date3, date1, date3, options)
+
+    assert false == Timex.between?(date1, date2, date3, options)
+    assert false == Timex.between?(date3, date1, date2, options)
+
+    assert {:error, :invalid_date} == Timex.between?({}, {{2013, 1, 1}, {1, 1, 2}}, {{2013, 1, 1}, {1, 1, 2}}, options)
+    assert {:error, :invalid_date} == Timex.between?({{2013, 1, 1}, {1, 1, 2}}, {}, {{2013, 1, 1}, {1, 1, 2}}, options)
+    assert {:error, :invalid_date} == Timex.between?({{2013, 1, 1}, {1, 1, 2}}, {{2013, 1, 1}, {1, 1, 2}}, {}, options)
+  end
+
+  test "between? inclusive_end" do
+    date1 = Timex.to_datetime({{2013,1,1},{0, 0, 0}})
+    date2 = Timex.to_datetime({{2013,1,5},{0, 0, 0}})
+    date3 = Timex.to_datetime({{2013,1,9},{0, 0, 0}})
+
+    options = [inclusive: :end]
+
+    assert true == Timex.between?(date2, date1, date3, options)
+    assert false == Timex.between?(date1, date1, date3, options)
+    assert true == Timex.between?(date3, date1, date3, options)
+
+    assert false == Timex.between?(date1, date2, date3, options)
+    assert false == Timex.between?(date3, date1, date2, options)
+
+    assert {:error, :invalid_date} == Timex.between?({}, {{2013, 1, 1}, {1, 1, 2}}, {{2013, 1, 1}, {1, 1, 2}}, options)
+    assert {:error, :invalid_date} == Timex.between?({{2013, 1, 1}, {1, 1, 2}}, {}, {{2013, 1, 1}, {1, 1, 2}}, options)
+    assert {:error, :invalid_date} == Timex.between?({{2013, 1, 1}, {1, 1, 2}}, {{2013, 1, 1}, {1, 1, 2}}, {}, options)
+  end
+
   test "equal" do
     assert Timex.equal?(Timex.today, Timex.today)
     refute Timex.equal?(Timex.today, Timex.epoch)


### PR DESCRIPTION
* Timex.between? the :inclusive option can now take `:start`, `:end` in addition to `true`
### Summary of changes

I have a use case to ask if a given time is between two other times, with one bound being inclusive, and the other being exclusive. I imagine this is useful for anyone iterating over adjacent intervals of time.

### Checklist

- [x] New functions have typespecs, changed functions were updated
- [x] Same for documentation, including moduledocs
- [x] Tests were added or updated to cover changes
- [x] Commits were squashed into a single coherent commit
