### PR TITLE
Maintain 1.4 compat until 4.0 is ready

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,6 @@ erl_crash.dump
 bench/snapshots
 priv/tmp_downloads
 cover/
+
+# ignore asdf config
+.tool-versions

--- a/lib/calendar/julian.ex
+++ b/lib/calendar/julian.ex
@@ -76,11 +76,11 @@ defmodule Timex.Calendar.Julian do
       :mon -> mod(cardinal + 6, 7) + 1
     end
   end
-  def day_of_week(_, _, _, weekstart) when weekstart not in [:sun, :mon] do
-    {:error, {:bad_weekstart_value, expected: [:sun, :mon], got: weekstart}}
-  end
-  def day_of_week(_,_,_, _) do
-    {:error, :invalid_date}
+  def day_of_week(_, _, _, weekstart) do
+    case weekstart in [:sun, :mon] do
+      true -> {:error, :invalid_date}
+      false -> {:error, {:bad_weekstart_value, expected: [:sun, :mon], got: weekstart}}
+    end
   end
 
   defp mod(a, b), do: rem(rem(a, b) + b, b)

--- a/lib/comparable/diff.ex
+++ b/lib/comparable/diff.ex
@@ -59,8 +59,7 @@ defmodule Timex.Comparable.Diff do
   defp do_diff(a, b, :years) do
     diff_years(a, b)
   end
-  defp do_diff(_, _, granularity) when granularity not in @units,
-    do: {:error, {:invalid_granularity, granularity}}
+  defp do_diff(_, _, granularity), do: {:error, {:invalid_granularity, granularity}}
 
   defp diff_years(a, b) do
     {start_date, _} = :calendar.gregorian_seconds_to_datetime(div(a, 1_000*1_000))


### PR DESCRIPTION
### Summary of changes

Revert use of 'not in' within guards until elixir 1.4 support is dropped.

### Checklist

- [x] New functions have typespecs, changed functions were updated
- [x] Same for documentation, including moduledocs
- [x] Tests were added or updated to cover changes
- [x] Commits were squashed into a single coherent commit
