### PR TITLE
Added missing type specs for Timex.set/2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,9 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
 
-TODO
+### Added
+
+- `Timex.set/2` now also accepts setting the `:date` from a `%Date{}` struct.
 
 ## 3.4.1
 

--- a/lib/datetime/datetime.ex
+++ b/lib/datetime/datetime.ex
@@ -188,13 +188,15 @@ defimpl Timex.Protocol, for: DateTime do
             else
               %{result | :year => y, :month => m, :day => d}
             end
+          {:date, %Date{} = d} ->
+            Timex.set(result, [date: {d.year, d.month, d.day}])
           {:time, {h, m, s}} ->
             if validate? do
               %{result | :hour => Timex.normalize(:hour, h), :minute => Timex.normalize(:minute, m), :second => Timex.normalize(:second, s)}
             else
               %{result | :hour => h, :minute => m, :second => s}
             end
-          {:time, t} ->
+          {:time, %Time{} = t} ->
             Timex.set(result, [time: {t.hour, t.minute, t.second}])
           {:day, d} ->
             if validate? do

--- a/lib/timex.ex
+++ b/lib/timex.ex
@@ -1681,7 +1681,8 @@ defmodule Timex do
   @type set_options :: [
           validate: boolean,
           datetime: Types.datetime(),
-          date: Types.date(),
+          date: Types.valid_date(),
+          time: Types.valid_time(),
           year: Types.year(),
           month: Types.month(),
           day: Types.day(),

--- a/lib/timex/types.ex
+++ b/lib/timex/types.ex
@@ -37,5 +37,7 @@ defmodule Timex.Types do
   @type iso_triplet :: { year, weeknum, weekday }
   @type calendar_types :: Date.t | DateTime.t | NaiveDateTime.t | Time.t
   @type valid_datetime :: Date.t | DateTime.t | NaiveDateTime.t | Time.t | datetime | date | microsecond_datetime
+  @type valid_date :: Date.t | date
+  @type valid_time :: Time.t | time
   @type weekstart :: weekday | binary | atom
 end

--- a/test/parse_default_test.exs
+++ b/test/parse_default_test.exs
@@ -397,30 +397,6 @@ defmodule DateFormatTest.ParseDefault do
     assert {:ok, ^date5} = parse("20070405T14Z", "{ISO:Basic}")
   end
 
-  test "parse time struct" do
-    to_change = Timex.to_datetime({{2017, 7, 21}, {1, 2, 3}})
-    changed = Timex.set(to_change, [time: ~T[09:52:33.000]])
-
-    assert 33 == changed.second
-    assert 52 == changed.minute
-    assert 9 == changed.hour
-    assert changed.year == to_change.year
-    assert changed.month == to_change.month
-    assert changed.day == to_change.day
-  end
-
-  test "set from time struct with more than one change requested" do
-    to_change = Timex.to_datetime({{2017, 7, 21}, {1, 2, 3}})
-    changed = Timex.set(to_change, [time: ~T[09:52:33.000], year: 1989])
-
-    assert 1989 == changed.year
-    assert 33 == changed.second
-    assert 52 == changed.minute
-    assert 9 == changed.hour
-    assert changed.month == to_change.month
-    assert changed.day == to_change.day
-  end
-
   test "roundtrip bug #252" do
     format = "{YYYY}-{0M}-{0D}T{0h24}:{0m}:{0s}{0ss}{Zname}"
     now = Timex.now()

--- a/test/set_test.exs
+++ b/test/set_test.exs
@@ -1,0 +1,43 @@
+defmodule SetTests do
+  use ExUnit.Case, async: true
+  use Timex
+
+  test "sets from time struct" do
+    original_date = Timex.to_datetime({{2017, 7, 21}, {1, 2, 3}})
+    new_date = Timex.set(original_date, [time: ~T[09:52:33.000]])
+
+    assert original_date.year == new_date.year
+    assert original_date.month == new_date.month
+    assert original_date.day == new_date.day
+
+    assert new_date.hour == 9
+    assert new_date.minute == 52
+    assert new_date.second == 33
+  end
+
+  test "sets from time struct with more than one change requested" do
+    original_date = Timex.to_datetime({{2017, 7, 21}, {1, 2, 3}})
+    new_date = Timex.set(original_date, [time: ~T[09:52:33.000], year: 1989])
+
+    assert new_date.year == 1989
+    assert original_date.month == new_date.month
+    assert original_date.day == new_date.day
+
+    assert new_date.hour == 9
+    assert new_date.minute == 52
+    assert new_date.second == 33
+  end
+
+  test "sets from date struct" do
+    original_date = Timex.to_datetime({{2017, 7, 21}, {12, 0, 0}})
+    new_date = Timex.set(original_date, [date: ~D[2018-09-02], hour: 16])
+
+    assert new_date.year == 2018
+    assert new_date.month == 9
+    assert new_date.day == 2
+
+    assert new_date.hour == 16
+    assert new_date.minute == 0
+    assert new_date.second == 0
+  end
+end


### PR DESCRIPTION
### Summary of changes

In https://github.com/bitwalker/timex/pull/376, the option was added to pass a `%Time{}` struct to Timex.set/2 via `:time`. However currently dialyzer complains because the type is still specified as {hour, minute, second}. This PR fixes that:)

### Checklist

- [x] New functions have typespecs, changed functions were updated
- [x] Same for documentation, including moduledocs
- [x] Tests were added or updated to cover changes
- [x] Commits were squashed into a single coherent commit
