### PR TITLE
Interval.difference/2 removes one interval from another

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 
 - `Timex.set/2` now also accepts setting the `:date` from a `%Date{}` struct.
+- `Interval.difference/2` removes one interval from another
 
 ## 3.4.1
 

--- a/lib/interval/interval.ex
+++ b/lib/interval/interval.ex
@@ -331,6 +331,100 @@ defmodule Timex.Interval do
     end
   end
 
+  @doc """
+  Removes one interval from another, which may reduce, split, or
+  eliminate the original interval. Returns a (possibly empty) list
+  of intervals representing the remaining time.
+
+  ## Graphs
+
+  The following textual graphs show all the ways that the original interval and
+  the removal can relate to each other, and the action that `difference/2` will
+  take in each case.
+  The original interval is drawn with `O`s and the removal interval with `X`s.
+
+      # return original
+      OO
+          XX
+
+      # trim end
+      OOO
+        XXX
+
+      # trim end
+      OOOOO
+        XXX
+
+      # split
+      OOOOOOO
+        XXX
+
+      # eliminate
+      OO
+      XX
+
+      # eliminate
+      OO
+      XXXX
+
+      # trim beginning
+      OOOO
+      XX
+
+      # eliminate
+        OO
+      XXXXXX
+
+      # eliminate
+          OO
+      XXXXXX
+
+      # trim beginning
+        OOO
+      XXX
+
+      # return original
+           OO
+      XX
+
+  ## Examples
+
+      iex> #{__MODULE__}.difference(#{__MODULE__}.new(from: ~N[2018-01-01 02:00:00.000], until: ~N[2018-01-01 04:00:00.000]), #{__MODULE__}.new(from: ~N[2018-01-01 03:00:00.000], until: ~N[2018-01-01 05:00:00.000]))
+      [%#{__MODULE__}{from: ~N[2018-01-01 02:00:00.000], left_open: true, right_open: false, step: [days: 1], until: ~N[2018-01-01 03:00:00.000]}]
+
+      iex> #{__MODULE__}.difference(#{__MODULE__}.new(from: ~N[2018-01-01 01:00:00.000], until: ~N[2018-01-01 05:00:00.000]), #{__MODULE__}.new(from: ~N[2018-01-01 02:00:00.000], until: ~N[2018-01-01 03:00:00.000]))
+      [%#{__MODULE__}{from: ~N[2018-01-01 01:00:00.000], left_open: true, right_open: false, step: [days: 1], until: ~N[2018-01-01 02:00:00.000]}, %#{__MODULE__}{from: ~N[2018-01-01 03:00:00.000], left_open: true, right_open: false, step: [days: 1], until: ~N[2018-01-01 05:00:00.000]}]
+
+      iex> #{__MODULE__}.difference(#{__MODULE__}.new(from: ~N[2018-01-01 02:00:00.000], until: ~N[2018-01-01 04:00:00.000]), #{__MODULE__}.new(from: ~N[2018-01-01 01:00:00.000], until: ~N[2018-01-01 05:00:00.000]))
+      []
+  """
+  @spec difference(__MODULE__.t(), __MODULE__.t()) :: [__MODULE__.t()]
+  def difference(%__MODULE__{} = original, %__MODULE__{} = removal) do
+    cond do
+      contains?(removal, original) ->
+        # eliminate
+        []
+
+      !overlaps?(removal, original) ->
+        # return original
+        [original]
+
+      Timex.compare(min(removal), min(original)) <= 0 ->
+        # trim start
+        [Map.put(original, :from, Map.get(removal, :until))]
+
+      Timex.compare(max(original), max(removal)) <= 0 ->
+        # trim end
+        [Map.put(original, :until, Map.get(removal, :from))]
+
+      true ->
+        # split
+        part_before = Map.put(original, :until, Map.get(removal, :from))
+        part_after = Map.put(original, :from, Map.get(removal, :until))
+        [part_before, part_after]
+    end
+  end
+
   @doc false
   def min(interval)
 

--- a/test/interval_test.exs
+++ b/test/interval_test.exs
@@ -240,4 +240,182 @@ defmodule IntervalTests do
       assert Interval.contains?(interval_d, interval_d)
     end
   end
+
+  describe "difference/2 removes the part of one interval that overlaps with another" do
+    test "returns a list with the original interval when there is no overlap" do
+      midnight_to_noon =
+        Timex.Interval.new(
+          from: ~N[2018-01-01 00:00:00.000],
+          until: ~N[2018-01-01 12:00:00.000]
+        )
+
+      two_pm_to_four_pm =
+        Timex.Interval.new(
+          from: ~N[2018-01-01 14:00:00.000],
+          until: ~N[2018-01-01 16:00:00.000]
+        )
+
+      assert Interval.difference(midnight_to_noon, two_pm_to_four_pm) == [midnight_to_noon]
+
+      assert Interval.difference(two_pm_to_four_pm, midnight_to_noon) == [two_pm_to_four_pm]
+    end
+
+    test "returns an empty list when removal interval completely covers the original" do
+      two_to_four =
+        Timex.Interval.new(
+          from: ~N[2018-01-01 02:00:00.000],
+          until: ~N[2018-01-01 04:00:00.000]
+        )
+
+      one_to_five =
+        Timex.Interval.new(
+          from: ~N[2018-01-01 01:00:00.000],
+          until: ~N[2018-01-01 05:00:00.000]
+        )
+
+      assert Interval.difference(two_to_four, one_to_five) == []
+      assert Interval.difference(two_to_four, two_to_four) == []
+      assert Interval.difference(one_to_five, one_to_five) == []
+    end
+
+    test "trims the original interval when the removal interval overlaps one end" do
+      two_to_three =
+        Timex.Interval.new(
+          from: ~N[2018-01-01 02:00:00.000],
+          until: ~N[2018-01-01 03:00:00.000]
+        )
+
+      two_to_four =
+        Timex.Interval.new(
+          from: ~N[2018-01-01 02:00:00.000],
+          until: ~N[2018-01-01 04:00:00.000]
+        )
+
+      three_to_four =
+        Timex.Interval.new(
+          from: ~N[2018-01-01 03:00:00.000],
+          until: ~N[2018-01-01 04:00:00.000]
+        )
+
+      three_to_five =
+        Timex.Interval.new(
+          from: ~N[2018-01-01 03:00:00.000],
+          until: ~N[2018-01-01 05:00:00.000]
+        )
+
+      assert Interval.difference(two_to_four, two_to_three) ==
+               [
+                 Timex.Interval.new(
+                   from: ~N[2018-01-01 03:00:00.000],
+                   until: ~N[2018-01-01 04:00:00.000]
+                 )
+               ]
+
+      assert Interval.difference(two_to_four, three_to_four) ==
+               [
+                 Timex.Interval.new(
+                   from: ~N[2018-01-01 02:00:00.000],
+                   until: ~N[2018-01-01 03:00:00.000]
+                 )
+               ]
+
+      assert Interval.difference(two_to_four, three_to_five) ==
+               [
+                 Timex.Interval.new(
+                   from: ~N[2018-01-01 02:00:00.000],
+                   until: ~N[2018-01-01 03:00:00.000]
+                 )
+               ]
+
+      assert Interval.difference(three_to_five, two_to_four) ==
+               [
+                 Timex.Interval.new(
+                   from: ~N[2018-01-01 04:00:00.000],
+                   until: ~N[2018-01-01 05:00:00.000]
+                 )
+               ]
+    end
+
+    test "splits the original interval when the removal interval falls inside it" do
+      one_to_five =
+        Timex.Interval.new(
+          from: ~N[2018-01-01 01:00:00.000],
+          until: ~N[2018-01-01 05:00:00.000]
+        )
+
+      two_to_three =
+        Timex.Interval.new(
+          from: ~N[2018-01-01 02:00:00.000],
+          until: ~N[2018-01-01 03:00:00.000]
+        )
+
+      assert Interval.difference(one_to_five, two_to_three) ==
+               [
+                 Timex.Interval.new(
+                   from: ~N[2018-01-01 01:00:00.000],
+                   until: ~N[2018-01-01 02:00:00.000]
+                 ),
+                 Timex.Interval.new(
+                   from: ~N[2018-01-01 03:00:00.000],
+                   until: ~N[2018-01-01 05:00:00.000]
+                 )
+               ]
+    end
+
+    test "other than 'from' and 'until', preserves the original interval's attributes" do
+      one_to_fives =
+        for left_open <- [true, false],
+            right_open <- [true, false],
+            step <- [[seconds: 1], [minutes: 2]] do
+          Timex.Interval.new(
+            from: ~N[2018-01-01 01:00:00.000],
+            until: ~N[2018-01-01 05:00:00.000],
+            left_open: left_open,
+            right_open: right_open,
+            step: step
+          )
+        end
+
+      midnight_to_two =
+        Timex.Interval.new(
+          from: ~N[2018-01-01 00:00:00.000],
+          until: ~N[2018-01-01 02:00:00.000]
+        )
+
+      two_to_three =
+        Timex.Interval.new(
+          from: ~N[2018-01-01 02:00:00.000],
+          until: ~N[2018-01-01 03:00:00.000]
+        )
+
+      four_to_six =
+        Timex.Interval.new(
+          from: ~N[2018-01-01 04:00:00.000],
+          until: ~N[2018-01-01 06:00:00.000]
+        )
+
+      Enum.each(one_to_fives, fn one_to_five ->
+        assert [split_1, split_2] = Interval.difference(one_to_five, two_to_three)
+
+        assert split_1.left_open == one_to_five.left_open
+        assert split_1.right_open == one_to_five.right_open
+        assert split_1.step == one_to_five.step
+
+        assert split_2.left_open == one_to_five.left_open
+        assert split_2.right_open == one_to_five.right_open
+        assert split_2.step == one_to_five.step
+
+        assert [left_trimmed] = Interval.difference(one_to_five, midnight_to_two)
+
+        assert left_trimmed.left_open == one_to_five.left_open
+        assert left_trimmed.right_open == one_to_five.right_open
+        assert left_trimmed.step == one_to_five.step
+
+        assert [right_trimmed] = Interval.difference(one_to_five, four_to_six)
+        assert right_trimmed.right_open == one_to_five.right_open
+        assert right_trimmed.left_open == one_to_five.left_open
+        assert right_trimmed.step == one_to_five.step
+      end)
+    end
+  end
 end


### PR DESCRIPTION
### Summary of changes

Add `Interval.difference/2` to remove one interval from another. This is one of the functions discussed in https://github.com/bitwalker/timex/issues/460

### Checklist

- [x] New functions have typespecs, changed functions were updated
- [x] Same for documentation, including moduledocs
- [x] Tests were added or updated to cover changes
- [x] Commits were squashed into a single coherent commit
