### PR TITLE
WIP beginning_of_seconds and end_of_seconds

### DIFF
--- a/lib/timex.ex
+++ b/lib/timex.ex
@@ -1362,6 +1362,65 @@ defmodule Timex do
 
   def end_of_quarter(_, _), do: {:error, :invalid_year_or_month}
 
+
+  @doc """
+  Given a Datetime, returns a datetime at the end of a period of N seconds.
+  For example, this could be used to round to the next hour.
+
+  iex> Timex.end_of_seconds(~N[2018-01-01 00:00:13], 15)
+  ~N[2018-01-01 00:00:15]
+
+  iex> Timex.end_of_seconds(~N[2018-01-01 01:47:00], 60 * 60)
+  ~N[2018-01-01 02:00:00]
+  """
+  @spec end_of_seconds(Types.valid_datetime(), integer()) :: Types.valid_datetime() | {:error, term}
+  def end_of_seconds(input_datetime, seconds) do
+    unix = input_datetime |> Timex.to_unix()
+
+    if rem(unix, seconds) == 0 do
+      input_datetime
+    else
+      rounded_down = div(unix, seconds) * seconds
+      rounded_up = rounded_down + seconds
+
+      output_datetime = rounded_up |> Timex.from_unix()
+
+      case input_datetime do
+        %DateTime{} -> output_datetime
+        %NaiveDateTime{} -> output_datetime |> DateTime.to_naive()
+      end
+    end
+  end
+
+  @doc """
+  Given a Datetime, returns a datetime at the end of a period of N seconds.
+  For example, this could be used to round to the next hour.
+
+  iex> Timex.beginning_of_seconds(~N[2018-01-01 00:00:20], 15)
+  ~N[2018-01-01 00:00:15]
+
+  iex> Timex.beginning_of_seconds(~N[2018-01-01 02:47:00], 60 * 60)
+  ~N[2018-01-01 02:00:00]
+  """
+  @spec beginning_of_seconds(Types.valid_datetime(), integer()) :: Types.valid_datetime() | {:error, term}
+  def beginning_of_seconds(input_datetime, seconds) do
+    unix = input_datetime |> Timex.to_unix()
+
+    if rem(unix, seconds) == 0 do
+      input_datetime
+    else
+      rounded_down = div(unix, seconds) * seconds
+
+      output_datetime = rounded_down |> Timex.from_unix()
+
+      # return the same type we were given
+      case input_datetime do
+        %DateTime{} -> output_datetime
+        %NaiveDateTime{} -> output_datetime |> DateTime.to_naive()
+      end
+    end
+  end
+
   @doc """
   Given a date or a number create a date at the beginning of that year
 

--- a/test/timex_test.exs
+++ b/test/timex_test.exs
@@ -542,6 +542,20 @@ defmodule TimexTests do
     assert {:error, :invalid_date} = Timex.end_of_quarter(nil)
   end
 
+  test "beginning_of_seconds" do
+    assert Timex.beginning_of_seconds(~N[2018-01-01 00:00:47], 15) == ~N[2018-01-01 00:00:45]
+    assert Timex.beginning_of_seconds(~N[2018-01-01 00:00:47], 30) == ~N[2018-01-01 00:00:30]
+    assert Timex.beginning_of_seconds(~N[2018-01-01 00:00:27], 30) == ~N[2018-01-01 00:00:00]
+    assert Timex.beginning_of_seconds(~N[2018-01-01 02:47:00], 60 * 60) == ~N[2018-01-01 02:00:00]
+  end
+
+  test "end_of_seconds" do
+    assert Timex.end_of_seconds(~N[2018-01-01 00:00:13], 15) == ~N[2018-01-01 00:00:15]
+    assert Timex.end_of_seconds(~N[2018-01-01 00:00:13], 30) == ~N[2018-01-01 00:00:30]
+    assert Timex.end_of_seconds(~N[2018-01-01 00:00:31], 30) == ~N[2018-01-01 00:01:00]
+    assert Timex.end_of_seconds(~N[2018-01-01 01:47:00], 60 * 60) == ~N[2018-01-01 02:00:00]
+  end
+
   test "beginning_of_week" do
     # Monday 30th November 2015
     date = Timex.to_datetime({{2015, 11, 30}, {13, 30, 30}})


### PR DESCRIPTION
These are two functions I found useful in my work, where I needed to "round" some datetimes to the nearest hour. They seems to fit in with functions like `end_of_month`, etc.

This is WIP, as it needs to be split up into protocol implementations. But I wanted to see if you like the idea before doing that.

### Summary of changes

I'll review the commits, so I mostly want to understand the "why" rather than the "what"

### Checklist

- [ ] New functions have typespecs, changed functions were updated
- [ ] Same for documentation, including moduledocs
- [ ] Tests were added or updated to cover changes
- [ ] Commits were squashed into a single coherent commit
