### PR TITLE
Fixes wrong interval bounds interpretation, fixes #482

### DIFF
--- a/test/interval_test.exs
+++ b/test/interval_test.exs
@@ -19,7 +19,7 @@ defmodule IntervalTests do
       assert %Interval{step: [days: 5]} = Interval.new(step: [days: 5])
       assert %Interval{step: [weeks: 5]} = Interval.new(step: [weeks: 5])
       assert %Interval{step: [months: 5]} = Interval.new(step: [months: 5])
-      assert %Interval{step: [years: 5]} =  Interval.new(step: [years: 5])
+      assert %Interval{step: [years: 5]} = Interval.new(step: [years: 5])
     end
 
     test "returns an error tuple when given an invalid step" do
@@ -46,62 +46,75 @@ defmodule IntervalTests do
   describe "with_step/2" do
     test "updates step to step with valid step unit" do
       interval = Interval.new()
-      assert %Interval{step: [microseconds: 5]} = Interval.with_step(interval, [microseconds: 5])
-      assert %Interval{step: [milliseconds: 5]} = Interval.with_step(interval, [milliseconds: 5])
-      assert %Interval{step: [seconds: 5]} = Interval.with_step(interval, [seconds: 5])
-      assert %Interval{step: [minutes: 5]} = Interval.with_step(interval, [minutes: 5])
-      assert %Interval{step: [hours: 5]} = Interval.with_step(interval, [hours: 5])
-      assert %Interval{step: [days: 5]} = Interval.with_step(interval, [days: 5])
-      assert %Interval{step: [weeks: 5]} = Interval.with_step(interval, [weeks: 5])
-      assert %Interval{step: [months: 5]} = Interval.with_step(interval, [months: 5])
-      assert %Interval{step: [years: 5]} =  Interval.with_step(interval, [years: 5])
+      assert %Interval{step: [microseconds: 5]} = Interval.with_step(interval, microseconds: 5)
+      assert %Interval{step: [milliseconds: 5]} = Interval.with_step(interval, milliseconds: 5)
+      assert %Interval{step: [seconds: 5]} = Interval.with_step(interval, seconds: 5)
+      assert %Interval{step: [minutes: 5]} = Interval.with_step(interval, minutes: 5)
+      assert %Interval{step: [hours: 5]} = Interval.with_step(interval, hours: 5)
+      assert %Interval{step: [days: 5]} = Interval.with_step(interval, days: 5)
+      assert %Interval{step: [weeks: 5]} = Interval.with_step(interval, weeks: 5)
+      assert %Interval{step: [months: 5]} = Interval.with_step(interval, months: 5)
+      assert %Interval{step: [years: 5]} = Interval.with_step(interval, years: 5)
     end
 
     test "returns error tuple when given invalid step unit" do
       interval = Interval.new()
-      assert {:error, :invalid_step} = Interval.with_step(interval, [invalid_step: 3])
+      assert {:error, :invalid_step} = Interval.with_step(interval, invalid_step: 3)
     end
   end
 
   test "can enumerate days in an interval" do
-    dates = Interval.new(from: ~D[2014-09-22], until: [days: 3])
-            |> Enum.map(&(Timex.format!(&1, "%Y-%m-%d", :strftime)))
+    dates =
+      Interval.new(from: ~D[2014-09-22], until: [days: 3])
+      |> Enum.map(&Timex.format!(&1, "%Y-%m-%d", :strftime))
+
     assert ["2014-09-22", "2014-09-23", "2014-09-24"] == dates
   end
 
-  test "right open interval includes until" do
-    dates = Interval.new(from: ~D[2014-09-22], until: [days: 3], right_open: true)
-            |> Enum.map(&(Timex.format!(&1, "%Y-%m-%d", :strftime)))
+  test "right closed interval includes until" do
+    dates =
+      Interval.new(from: ~D[2014-09-22], until: [days: 3], right_open: false)
+      |> Enum.map(&Timex.format!(&1, "%Y-%m-%d", :strftime))
+
     assert ["2014-09-22", "2014-09-23", "2014-09-24", "2014-09-25"] == dates
   end
 
-  test "left closed interval excludes from" do
-    dates = Interval.new(from: ~D[2014-09-22], until: [days: 3], left_open: false)
-            |> Enum.map(&(Timex.format!(&1, "%Y-%m-%d", :strftime)))
+  test "left open interval excludes from" do
+    dates =
+      Interval.new(from: ~D[2014-09-22], until: [days: 3], left_open: true)
+      |> Enum.map(&Timex.format!(&1, "%Y-%m-%d", :strftime))
+
     assert ["2014-09-23", "2014-09-24"] == dates
   end
 
   test "can enumerate by other units in an interval" do
-    steps = Interval.new(from: ~N[2014-09-22T15:00:00], until: [hours: 1])
-            |> Interval.with_step(minutes: 10)
-            |> Enum.map(&(Timex.format!(&1, "%H:%M", :strftime)))
+    steps =
+      Interval.new(from: ~N[2014-09-22T15:00:00], until: [hours: 1])
+      |> Interval.with_step(minutes: 10)
+      |> Enum.map(&Timex.format!(&1, "%H:%M", :strftime))
+
     assert ["15:00", "15:10", "15:20", "15:30", "15:40", "15:50"] == steps
   end
 
   test "raises FormatError when enumerating with an invalid step unit" do
     interval = %Interval{from: ~D[2017-04-02], until: ~D[2017-05-02], step: [invalid_step: 1]}
+
     assert_raise Interval.FormatError, "Invalid step unit for interval: :invalid_step", fn ->
       Enum.count(interval)
     end
   end
 
   test "can get duration of an interval" do
-    duration = Interval.new(from: ~D[2014-09-22], until: [months: 5])
-               |> Interval.duration(:months)
+    duration =
+      Interval.new(from: ~D[2014-09-22], until: [months: 5])
+      |> Interval.duration(:months)
+
     assert 5 == duration
 
-    duration = Interval.new(from: ~N[2014-09-22T15:30:00], until: [minutes: 20])
-               |> Interval.duration(:duration)
+    duration =
+      Interval.new(from: ~N[2014-09-22T15:30:00], until: [minutes: 20])
+      |> Interval.duration(:duration)
+
     assert Duration.from_minutes(20) == duration
   end
 
@@ -117,12 +130,12 @@ defmodule IntervalTests do
     end
 
     test "can exclude start date from membership" do
-      interval = Interval.new(from: ~D[2014-09-22], until: [days: 3], left_open: false)
+      interval = Interval.new(from: ~D[2014-09-22], until: [days: 3], left_open: true)
       refute ~D[2014-09-22] in interval
     end
 
     test "can include end date in membership" do
-      interval = Interval.new(from: ~D[2014-09-22], until: [days: 3], right_open: true)
+      interval = Interval.new(from: ~D[2014-09-22], until: [days: 3], right_open: false)
       assert ~D[2014-09-25] in interval
     end
 
@@ -134,7 +147,7 @@ defmodule IntervalTests do
 
     test "membership includes datetimes in interval" do
       interval = Interval.new(from: ~D[2014-09-22], until: ~D[2014-09-24])
-      assert ~N[2014-09-23 00:00:00] in interval
+      assert ~N[2014-09-22 00:00:00] in interval
     end
   end
 


### PR DESCRIPTION
Hi.
I said it already in the Issue #482, you misinterpreted the meaning of open/closed bounds of intervals.
Open intervals **do not include** the bounds, closed bounds **do include** the bounds.
So, your original implementation was correct.

### Summary of changes
Since your original implementation was correct, I have reverted your [commit](https://github.com/bitwalker/timex/commit/063e2dd1d5c0767e5e24ee3b8bc8bd2157aa7362) by hand, preserving the documentation changes you did in this commit (just adjusted the wrong statements about the bounds) and the updated implementation.
The 3 broken tests are already in the master branch and are not related to the changes I did.
When you see my diff, you would realize that I changed more lines that I needed. That's because of the formatter I always run. But most of the changes, the formatter has done, are really good ones.

Hope you can fix it as soon as possible. And it would be great if you consider this fix to be worth releasing a new version.

By the way, thank you for this great library! We use it in EVERY project we start. 

### Checklist

- [x ] New functions have typespecs, changed functions were updated
- [x ] Same for documentation, including moduledocs
- [x ] Tests were added or updated to cover changes
- [x ] Commits were squashed into a single coherent commit
