### PR TITLE
Fix a couple of shift issues

### DIFF
--- a/lib/datetime/datetime.ex
+++ b/lib/datetime/datetime.ex
@@ -235,7 +235,7 @@ defimpl Timex.Protocol, for: DateTime do
       datetime
       |> Timezone.convert("Etc/UTC")
       |> logical_shift(logical_shifts)
-      us = to_gregorian_microseconds(datetime)
+    us = to_gregorian_microseconds(datetime)
     shift = calculate_shift(shifts)
     shifted_us = us + shift
     shifted_secs = div(shifted_us, 1_000*1_000)

--- a/lib/datetime/datetime.ex
+++ b/lib/datetime/datetime.ex
@@ -230,11 +230,12 @@ defimpl Timex.Protocol, for: DateTime do
   @spec shift(DateTime.t, list({atom(), term})) :: DateTime.t | {:error, term}
   def shift(%DateTime{time_zone: tz, microsecond: {_us, precision}} = datetime, shifts) when is_list(shifts) do
     {logical_shifts, shifts} = Keyword.split(shifts, [:years, :months, :weeks, :days])
+    incoming_tzinfo = Timex.timezone(tz, datetime)
     datetime =
       datetime
       |> Timezone.convert("Etc/UTC")
       |> logical_shift(logical_shifts)
-    us = to_gregorian_microseconds(datetime)
+      us = to_gregorian_microseconds(datetime)
     shift = calculate_shift(shifts)
     shifted_us = us + shift
     shifted_secs = div(shifted_us, 1_000*1_000)
@@ -242,6 +243,16 @@ defimpl Timex.Protocol, for: DateTime do
 
     # Convert back to DateTime in UTC
     shifted = raw_convert(shifted_secs, {rem_us, precision})
+    shifted_timezone = Timex.timezone(tz, shifted)
+
+    incoming_std = Map.get(incoming_tzinfo, :offset_std, 0)
+    shifted_std = Map.get(shifted_timezone, :offset_std, 0)
+
+    shifted = if incoming_std != shifted_std do
+      raw_convert(shifted_secs + incoming_std - shifted_std, {rem_us, precision})
+    else
+      shifted
+    end
 
     # Convert to original timezone
     case Timezone.convert(shifted, tz) do
@@ -382,10 +393,10 @@ defimpl Timex.Protocol, for: DateTime do
         %DateTime{datetime | day: day + value}
       (month - 1) >= 1 ->
         ldom = :calendar.last_day_of_the_month(year, month - 1)
-        shift_by(%DateTime{datetime | month: month - 1, day: ldom}, value + day + 1, :days)
+        shift_by(%DateTime{datetime | month: month - 1, day: ldom}, value + day, :days)
       :else ->
         ldom = :calendar.last_day_of_the_month(year - 1, 12)
-        shift_by(%DateTime{datetime | year: year - 1, month: 12, day: ldom}, value + day + 1, :days)
+        shift_by(%DateTime{datetime | year: year - 1, month: 12, day: ldom}, value + day, :days)
     end
   end
 

--- a/test/shift_test.exs
+++ b/test/shift_test.exs
@@ -155,4 +155,40 @@ defmodule ShiftTests do
     expected = ~D[2000-02-29] |> Timex.to_datetime
     assert expected === date
   end
+
+  test "shift November DTS datetime by a month in America/New_York timezone" do
+    date = ~D[2018-11-01] |> Timex.to_datetime("America/New_York") |> Timex.shift(months: 1)
+    expected = ~D[2018-12-01] |> Timex.to_datetime("America/New_York")
+    assert expected === date
+  end
+
+  test "shift March DTS datetime by a month in America/New_York timezone" do
+    date = ~D[2018-03-01] |> Timex.to_datetime("America/New_York") |> Timex.shift(months: 1)
+    expected = ~D[2018-04-01] |> Timex.to_datetime("America/New_York")
+    assert expected === date
+  end
+
+  test "shift back 4 days should yield first of month" do
+    date = ~D[2018-11-05] |> Timex.to_datetime |> Timex.shift(days: -4)
+    expected = ~D[2018-11-01] |> Timex.to_datetime
+    assert expected === date
+  end
+
+  test "shift back 5 days should yield last of previous month" do
+    date = ~D[2018-11-05] |> Timex.to_datetime |> Timex.shift(days: -5)
+    expected = ~D[2018-10-31] |> Timex.to_datetime
+    assert expected === date
+  end
+
+  test "shift back 4 days should yield first of year" do
+    date = ~D[2018-01-05] |> Timex.to_datetime |> Timex.shift(days: -4)
+    expected = ~D[2018-01-01] |> Timex.to_datetime
+    assert expected === date
+  end
+
+  test "shift back 5 days should yield last of previous year" do
+    date = ~D[2018-01-05] |> Timex.to_datetime |> Timex.shift(days: -5)
+    expected = ~D[2017-12-31] |> Timex.to_datetime
+    assert expected === date
+  end
 end


### PR DESCRIPTION
### Summary of changes

- If a shift crosses a daylight savings time shift be sure to include the offset_std difference in the time conversion. This change probably fixes the issue mentioned here: https://github.com/bitwalker/timex/blob/master/lib/datetime/datetime.ex#L249-L251

- Shifting backwards into the previous month had an off by one error.

I'll review the commits, so I mostly want to understand the "why" rather than the "what"

### Checklist

- [ ] New functions have typespecs, changed functions were updated
- [ ] Same for documentation, including moduledocs
- [ X] Tests were added or updated to cover changes
- [ ] Commits were squashed into a single coherent commit
