### PR TITLE
Fix Negative Shifts Across Month Boundaries

### DIFF
--- a/lib/datetime/datetime.ex
+++ b/lib/datetime/datetime.ex
@@ -382,10 +382,10 @@ defimpl Timex.Protocol, for: DateTime do
         %DateTime{datetime | day: day + value}
       (month - 1) >= 1 ->
         ldom = :calendar.last_day_of_the_month(year, month - 1)
-        shift_by(%DateTime{datetime | month: month - 1, day: ldom}, value + day + 1, :days)
+        shift_by(%DateTime{datetime | month: month - 1, day: ldom}, value + day, :days)
       :else ->
         ldom = :calendar.last_day_of_the_month(year - 1, 12)
-        shift_by(%DateTime{datetime | year: year - 1, month: 12, day: ldom}, value + day + 1, :days)
+        shift_by(%DateTime{datetime | year: year - 1, month: 12, day: ldom}, value + day, :days)
     end
   end
 

--- a/test/shift_test.exs
+++ b/test/shift_test.exs
@@ -97,6 +97,16 @@ defmodule ShiftTests do
     assert expected === date
   end
 
+  test "shift by days into the previous month" do
+    date = Timex.shift(~N[2017-12-01 12:00:00.100000], days: -1)
+    expected = ~N[2017-11-30 12:00:00.100000]
+    assert expected === date
+
+    date = Timex.shift(~N[2017-12-05 12:00:00.100000], days: -8)
+    expected = ~N[2017-11-27 12:00:00.100000]
+    assert expected === date
+  end
+
   test "shift by hours" do
     date = Timex.shift(~N[2017-10-24 12:00:00.100000], hours: 1)
     expected = ~N[2017-10-24 13:00:00.100000]


### PR DESCRIPTION
There was an off by one error in the implementation of logical shifts
for days.  It effectively caused a shift by `days: -1` on day 1 of a month to
resolve back to the current date.

### Checklist

- [x] New functions have typespecs, changed functions were updated
- [x] Same for documentation, including moduledocs
- [x] Tests were added or updated to cover changes
- [x] Commits were squashed into a single coherent commit
