### PR TITLE
Fix iso week year formatting (#496)

### DIFF
--- a/lib/format/datetime/formatter.ex
+++ b/lib/format/datetime/formatter.ex
@@ -425,14 +425,14 @@ defmodule Timex.Format.DateTime.Formatter do
   def format_token(locale, :iso_week, date, modifiers, _flags, _width) do
     # 2015-W04
     flags = [padding: :zeroes]
-    year = format_token(locale, :year4, date, modifiers, flags, width_spec(4..4))
+    year = format_token(locale, :iso_year4, date, modifiers, flags, width_spec(4..4))
     week = format_token(locale, :iso_weeknum, date, modifiers, flags, width_spec(2..2))
     "#{year}-W#{week}"
   end
   def format_token(locale, :iso_weekday, date, modifiers, _flags, _width) do
     # 2015-W04-1
     flags = [padding: :zeroes]
-    year = format_token(locale, :year4, date, modifiers, flags, width_spec(4..4))
+    year = format_token(locale, :iso_year4, date, modifiers, flags, width_spec(4..4))
     week = format_token(locale, :iso_weeknum, date, modifiers, flags, width_spec(2..2))
     day  = format_token(locale, :wday_mon, date, modifiers, flags, width_spec(1, 1))
     "#{year}-W#{week}-#{day}"


### PR DESCRIPTION
### Summary of changes

Replaced in the default formatter for ISOWeek the year formatting. 
The new function now call `:iso_year4` formatting function.