### PR TITLE
Remove deprecations on Elixir 1.8 - Closes Issue #503

### DIFF
--- a/lib/timex.ex
+++ b/lib/timex.ex
@@ -166,14 +166,35 @@ defmodule Timex do
 
   Converts the given Unix time to DateTime.
 
-  The integer can be given in different units according to `System.convert_time_unit/3`
-  and it will be converted to microseconds internally. Defaults to `:seconds`.
+  The integer can be given in different units(:seconds, :milliseconds, :microseconds, :nanoseconds
+  and also units described in `System.convert_time_unit/3`) and it will be converted to
+  microseconds internally. Defaults to `:second`.
 
   Unix times are always in UTC and therefore the DateTime will be returned in UTC.
   """
-  @spec from_unix(secs :: non_neg_integer, :native | System.time_unit()) ::
+  @spec from_unix(secs :: non_neg_integer, :native | Types.second_time_units()) ::
           DateTime.t() | no_return
-  def from_unix(secs, unit \\ :seconds), do: DateTime.from_unix!(secs, unit)
+  def from_unix(secs, unit \\ :second)
+
+  def from_unix(secs, :seconds) do
+    from_unix(secs, :second)
+  end
+
+  def from_unix(secs, :milliseconds) do
+    from_unix(secs, :millisecond)
+  end
+
+  def from_unix(secs, :microseconds) do
+    from_unix(secs, :microsecond)
+  end
+
+  def from_unix(secs, :nanoseconds) do
+    from_unix(secs, :nanosecond)
+  end
+
+  def from_unix(secs, unit) do
+    DateTime.from_unix!(secs, unit)
+  end
 
   @doc """
   Formats a date/time value using the given format string (and optional formatter).

--- a/lib/timex/types.ex
+++ b/lib/timex/types.ex
@@ -29,6 +29,7 @@ defmodule Timex.Types do
   @type weekday_name :: :monday | :tuesday | :wednesday | :thursday | :friday | :saturday | :sunday
   @type shift_units :: :milliseconds | :seconds | :minutes | :hours | :days | :weeks | :years
   @type time_units :: :microseconds | :milliseconds | :seconds | :minutes | :hours | :days | :weeks | :years
+  @type second_time_units :: :second | :millisecond | :microsecond | :nanosecond | :seconds | :milliseconds | :microseconds | :nanoseconds
   @type time :: { hour, minute, second }
   @type microsecond_time :: { hour, minute, second, microsecond | microseconds}
   @type date :: { year, month, day }

--- a/test/timex_test.exs
+++ b/test/timex_test.exs
@@ -104,6 +104,37 @@ defmodule TimexTests do
     end
   end
 
+  describe "from_unix" do
+    test "defaults to unit :second" do
+      assert Timex.from_unix(1_549_021_655) == Timex.to_datetime({{2019, 2, 1}, {11, 47, 35}})
+    end
+
+    test "has seconds as unit" do
+      assert Timex.from_unix(1_549_021_655, :seconds) ==
+               Timex.to_datetime({{2019, 2, 1}, {11, 47, 35}})
+    end
+
+    test "has milliseconds as unit" do
+      assert Timex.from_unix(1_549_021_655_901, :milliseconds) ==
+               Timex.to_datetime({{2019, 2, 1}, {11, 47, 35, 901_000}})
+    end
+
+    test "has microseconds as unit" do
+      assert Timex.from_unix(1_549_021_655_900_123, :microseconds) ==
+               Timex.to_datetime({{2019, 2, 1}, {11, 47, 35, 900_123}})
+    end
+
+    test "has nanoseconds as unit" do
+      assert Timex.from_unix(1_549_021_655_900_123_456, :nanoseconds) ==
+               Timex.to_datetime({{2019, 2, 1}, {11, 47, 35, 900_123}})
+    end
+
+    test "has System.convert_time_unit/3 units" do
+      assert Timex.from_unix(1_549_021_655_900_123, :microsecond) ==
+               Timex.to_datetime({{2019, 2, 1}, {11, 47, 35, 900_123}})
+    end
+  end
+
   test "days_in_month" do
     localdate = {{2013,2,17},{11,59,10}}
     assert Timex.days_in_month(Timex.to_datetime(localdate)) === 28

--- a/test/zoneinfo_parser_test.exs
+++ b/test/zoneinfo_parser_test.exs
@@ -7,24 +7,24 @@ defmodule ZoneInfoParserTest do
 
   test "parse_tzfile with TZIF v1" do
     # TZIF Version 1
-    chicago = System.cwd |> Path.join("test/include/tzif/America/Chicago")
+    chicago = File.cwd! |> Path.join("test/include/tzif/America/Chicago")
     assert {:ok, "CDT"} = chicago |> File.read! |> Local.parse_tzfile(@seconds1)
     assert {:ok, "CST"} = chicago |> File.read! |> Local.parse_tzfile(@seconds2)
 
     # TZIF Version 1
-    new_york = System.cwd |> Path.join("test/include/tzif/America/New_York")
+    new_york = File.cwd! |> Path.join("test/include/tzif/America/New_York")
     assert {:ok, "EDT"} = new_york |> File.read! |> Local.parse_tzfile(@seconds1)
     assert {:ok, "EST"} = new_york |> File.read! |> Local.parse_tzfile(@seconds2)
   end
 
   test "parse_tzfile with TZIF v2" do
     # TZIF Version 2
-    chicago = System.cwd |> Path.join("test/include/tzif2/America/Chicago")
+    chicago = File.cwd! |> Path.join("test/include/tzif2/America/Chicago")
     assert {:ok, "CDT"} = chicago |> File.read! |> Local.parse_tzfile(@seconds1)
     assert {:ok, "CST"} = chicago |> File.read! |> Local.parse_tzfile(@seconds2)
 
     # TZIF Version 2
-    new_york = System.cwd |> Path.join("test/include/tzif2/America/New_York")
+    new_york = File.cwd! |> Path.join("test/include/tzif2/America/New_York")
     assert {:ok, "EDT"} = new_york |> File.read! |> Local.parse_tzfile(@seconds1)
     assert {:ok, "EST"} = new_york |> File.read! |> Local.parse_tzfile(@seconds2)
   end


### PR DESCRIPTION
### Summary of changes

Elixir 1.8 deprecates [System.cwd](https://hexdocs.pm/elixir/1.8.1/System.html#cwd/0) and changes the type [time_unit](https://hexdocs.pm/elixir/System.html#t:time_unit/0).

This PR aims to fix those warnings while keeping the old function behavior functional. It should close Issue #503 .

Feel free to reject the PR for any reason(no hard feelings) just let me know why so I can learn from it.
I'm gonna be away from from computer on the next 2 weeks so I won't be able to do any updates during this time.

Thank you for maintaining this library it's awesome! 👍 💐 
### Checklist

- [x] New functions have typespecs, changed functions were updated
- [x] Same for documentation, including moduledocs
- [x] Tests were added or updated to cover changes
- [x] Commits were squashed into a single coherent commit
