### PR TITLE
Support time units in singular

### DIFF
--- a/lib/comparable/comparable.ex
+++ b/lib/comparable/comparable.ex
@@ -4,8 +4,8 @@ defprotocol Timex.Comparable do
   """
   alias Timex.Types
 
-  @type granularity :: :years | :months | :weeks | :calendar_weeks | :days |
-                       :hours | :minutes | :seconds | :milliseconds | :microseconds |
+  @type granularity :: :year | :years | :month | :months | :week | :weeks | :calendar_week | :calendar_weeks | :day | :days |
+                       :hour | :hours | :minute | :minutes | :second | :seconds | :millisecond | :milliseconds | :microsecond | :microseconds |
                        :duration
   @type constants :: :epoch | :zero | :distant_past | :distant_future
   @type comparable :: Date.t | DateTime.t | NaiveDateTime.t | Types.date | Types.datetime
@@ -17,20 +17,30 @@ defprotocol Timex.Comparable do
 
   You can optionally specify a comparison granularity, any of the following:
 
+  - :year
   - :years
+  - :month
   - :months
+  - :week
   - :weeks
-  - :calendar_weeks (weeks of the calendar as opposed to actual weeks in terms of days)
+  - :calendar_week (weeks of the calendar as opposed to actual weeks in terms of days)
+  - :calendar_weeks
+  - :day
   - :days
+  - :hour
   - :hours
+  - :minute
   - :minutes
+  - :second
   - :seconds
+  - :millisecond
   - :milliseconds
-  - :microseconds (default)
+  - :microsecond (default)
+  - :microseconds
   - :duration
 
   and the dates will be compared with the cooresponding accuracy.
-  The default granularity is :microseconds.
+  The default granularity is `:microsecond`.
 
     - 0:  when equal
     - -1: when the first date/time comes before the second
@@ -43,31 +53,41 @@ defprotocol Timex.Comparable do
       iex> use Timex
       iex> date1 = ~D[2014-03-04]
       iex> date2 = ~D[2015-03-04]
-      iex> Timex.compare(date1, date2, :years)
+      iex> Timex.compare(date1, date2, :year)
       -1
-      iex> Timex.compare(date2, date1, :years)
+      iex> Timex.compare(date2, date1, :year)
       1
       iex> Timex.compare(date1, date1)
       0
   """
   @spec compare(comparable, comparable, granularity) :: compare_result
-  def compare(a, b, granularity \\ :microseconds)
+  def compare(a, b, granularity \\ :microsecond)
 
   @doc """
   Get the difference between two date or datetime types.
 
   You can optionally specify a diff granularity, any of the following:
 
+  - :year
   - :years
+  - :month
   - :months
-  - :calendar_weeks (weeks of the calendar as opposed to actual weeks in terms of days)
+  - :week
   - :weeks
+  - :calendar_week (weeks of the calendar as opposed to actual weeks in terms of days)
+  - :calendar_weeks
+  - :day
   - :days
+  - :hour
   - :hours
+  - :minute
   - :minutes
+  - :second
   - :seconds
+  - :millisecond
   - :milliseconds
-  - :microseconds (default)
+  - :microsecond (default)
+  - :microseconds
   - :duration
 
   and the result will be an integer value of those units or a Duration struct.
@@ -82,19 +102,19 @@ defprotocol Timex.Comparable do
       iex> use Timex
       iex> date1 = ~D[2015-01-28]
       iex> date2 = ~D[2015-02-28]
-      iex> Timex.diff(date1, date2, :months)
+      iex> Timex.diff(date1, date2, :month)
       -1
-      iex> Timex.diff(date2, date1, :months)
+      iex> Timex.diff(date2, date1, :month)
       1
 
       iex> use Timex
       iex> date1 = ~D[2015-01-31]
       iex> date2 = ~D[2015-02-28]
-      iex> Timex.diff(date1, date2, :months)
+      iex> Timex.diff(date1, date2, :month)
       -1
-      iex> Timex.diff(date2, date1, :months)
+      iex> Timex.diff(date2, date1, :month)
       0
   """
   @spec diff(comparable, comparable, granularity) :: diff_result
-  def diff(a, b, granularity \\ :microseconds)
+  def diff(a, b, granularity \\ :microsecond)
 end

--- a/lib/comparable/diff.ex
+++ b/lib/comparable/diff.ex
@@ -19,14 +19,22 @@ defmodule Timex.Comparable.Diff do
   end
 
   defp do_diff(a, b, :duration), do: Duration.from_seconds(do_diff(a,b,:seconds))
-  defp do_diff(a, b, :microseconds), do: a - b
-  defp do_diff(a, b, :milliseconds), do: div(a - b, 1_000)
-  defp do_diff(a, b, :seconds),      do: div(a - b, 1_000*1_000)
-  defp do_diff(a, b, :minutes),      do: div(a - b, 1_000*1_000*60)
-  defp do_diff(a, b, :hours),        do: div(a - b, 1_000*1_000*60*60)
-  defp do_diff(a, b, :days),         do: div(a - b, 1_000*1_000*60*60*24)
-  defp do_diff(a, b, :weeks),        do: div(a - b, 1_000*1_000*60*60*24*7)
-  defp do_diff(a, b, :calendar_weeks) do
+  defp do_diff(a, b, :microseconds), do: do_diff(a, b, :microsecond)
+  defp do_diff(a, b, :microsecond),  do: a - b
+  defp do_diff(a, b, :milliseconds), do: do_diff(a, b, :millisecond)
+  defp do_diff(a, b, :millisecond),  do: div(a - b, 1_000)
+  defp do_diff(a, b, :seconds),      do: do_diff(a, b, :second)
+  defp do_diff(a, b, :second),       do: div(a - b, 1_000*1_000)
+  defp do_diff(a, b, :minutes),      do:  do_diff(a, b, :minute)
+  defp do_diff(a, b, :minute),       do: div(a - b, 1_000*1_000*60)
+  defp do_diff(a, b, :hours),        do: do_diff(a, b, :hour)
+  defp do_diff(a, b, :hour),         do: div(a - b, 1_000*1_000*60*60)
+  defp do_diff(a, b, :days),         do: do_diff(a, b, :day)
+  defp do_diff(a, b, :day),          do: div(a - b, 1_000*1_000*60*60*24)
+  defp do_diff(a, b, :weeks),        do: do_diff(a, b, :week)
+  defp do_diff(a, b, :week),         do: div(a - b, 1_000*1_000*60*60*24*7)
+  defp do_diff(a, b, :calendar_weeks), do: do_diff(a, b, :calendar_week)
+  defp do_diff(a, b, :calendar_week) do
     adate      = :calendar.gregorian_seconds_to_datetime(div(a, 1_000*1_000))
     bdate      = :calendar.gregorian_seconds_to_datetime(div(b, 1_000*1_000))
     days = cond do
@@ -49,10 +57,12 @@ defmodule Timex.Comparable.Diff do
       :else -> div(days, 7)
     end
   end
-  defp do_diff(a, b, :months) do
+  defp do_diff(a, b, :months), do: do_diff(a, b, :month)
+  defp do_diff(a, b, :month) do
     diff_months(a, b)
   end
-  defp do_diff(a, b, :years) do
+  defp do_diff(a, b, :years), do: do_diff(a, b, :year)
+  defp do_diff(a, b, :year) do
     diff_years(a, b)
   end
   defp do_diff(_, _, granularity), do: {:error, {:invalid_granularity, granularity}}

--- a/lib/timex.ex
+++ b/lib/timex.ex
@@ -166,9 +166,8 @@ defmodule Timex do
 
   Converts the given Unix time to DateTime.
 
-  The integer can be given in different units(:seconds, :milliseconds, :microseconds, :nanoseconds
-  and also units described in `System.convert_time_unit/3`) and it will be converted to
-  microseconds internally. Defaults to `:second`.
+  The integer can be given in different units according to `System.convert_time_unit/3`
+  and it will be converted to microseconds internally. Defaults to `:second`.
 
   Unix times are always in UTC and therefore the DateTime will be returned in UTC.
   """
@@ -948,28 +947,38 @@ defmodule Timex do
 
   You can optionally specify a comparison granularity, any of the following:
 
+  - :year
   - :years
+  - :month
   - :months
+  - :week
   - :weeks
-  - :calendar_weeks (weeks of the calendar as opposed to actual weeks in terms of days)
+  - :calendar_week (weeks of the calendar as opposed to actual weeks in terms of days)
+  - :calendar_weeks
+  - :day
   - :days
+  - :hour
   - :hours
+  - :minute
   - :minutes
+  - :second
   - :seconds
+  - :millisecond
   - :milliseconds
-  - :microseconds (default)
+  - :microsecond (default)
+  - :microseconds
   - :duration
 
   and the dates will be compared with the cooresponding accuracy.
-  The default granularity is :microseconds.
+  The default granularity is `:microsecond`.
 
   ## Examples
 
       iex> date1 = ~D[2014-03-04]
       iex> date2 = ~D[2015-03-04]
-      iex> Timex.compare(date1, date2, :years)
+      iex> Timex.compare(date1, date2, :year)
       -1
-      iex> Timex.compare(date2, date1, :years)
+      iex> Timex.compare(date2, date1, :year)
       1
       iex> Timex.compare(date1, date1)
       0
@@ -998,16 +1007,26 @@ defmodule Timex do
 
   You must specify one of the following units:
 
+  - :year
   - :years
+  - :month
   - :months
-  - :calendar_weeks (weeks of the calendar as opposed to actual weeks in terms of days)
+  - :week
   - :weeks
+  - :calendar_week (weeks of the calendar as opposed to actual weeks in terms of days)
+  - :calendar_weeks
+  - :day
   - :days
+  - :hour
   - :hours
+  - :minute
   - :minutes
+  - :second
   - :seconds
+  - :millisecond
   - :milliseconds
-  - :microseconds (default)
+  - :microsecond (default)
+  - :microseconds
   - :duration
 
   and the result will be an integer value of those units or a Duration.
@@ -1016,7 +1035,7 @@ defmodule Timex do
   @spec diff(Comparable.comparable(), Comparable.comparable(), Comparable.granularity()) ::
           Duration.t() | integer | {:error, term}
   def diff(%Time{}, %Time{}, granularity)
-      when granularity in [:days, :weeks, :calendar_weeks, :months, :years] do
+      when granularity in [:day, :days, :week, :weeks, :calendar_week, :calendar_weeks, :month, :months, :year, :years] do
     0
   end
 
@@ -1026,11 +1045,11 @@ defmodule Timex do
 
     case granularity do
       :duration -> Duration.from_seconds(div(a - b, 1_000 * 1_000))
-      :microseconds -> a - b
-      :milliseconds -> div(a - b, 1_000)
-      :seconds -> div(a - b, 1_000 * 1_000)
-      :minutes -> div(a - b, 1_000 * 1_000 * 60)
-      :hours -> div(a - b, 1_000 * 1_000 * 60 * 60)
+      µs when µs in [:microseconds, :microsecond] -> a - b
+      ms when ms in [:milliseconds, :millisecond] -> div(a - b, 1_000)
+      s when s in [:seconds, :second] -> div(a - b, 1_000 * 1_000)
+      min when min in [:minutes, :minute] -> div(a - b, 1_000 * 1_000 * 60)
+      h when h in [:hours, :hour] -> div(a - b, 1_000 * 1_000 * 60 * 60)
       _ -> {:error, {:invalid_granularity, granularity}}
     end
   end

--- a/lib/timex.ex
+++ b/lib/timex.ex
@@ -1045,7 +1045,7 @@ defmodule Timex do
 
     case granularity do
       :duration -> Duration.from_seconds(div(a - b, 1_000 * 1_000))
-      µs when µs in [:microseconds, :microsecond] -> a - b
+      us when us in [:microseconds, :microsecond] -> a - b
       ms when ms in [:milliseconds, :millisecond] -> div(a - b, 1_000)
       s when s in [:seconds, :second] -> div(a - b, 1_000 * 1_000)
       min when min in [:minutes, :minute] -> div(a - b, 1_000 * 1_000 * 60)

--- a/lib/timex/types.ex
+++ b/lib/timex/types.ex
@@ -28,8 +28,7 @@ defmodule Timex.Types do
   # Complex types
   @type weekday_name :: :monday | :tuesday | :wednesday | :thursday | :friday | :saturday | :sunday
   @type shift_units :: :milliseconds | :seconds | :minutes | :hours | :days | :weeks | :years
-  @type time_units :: :microseconds | :milliseconds | :seconds | :minutes | :hours | :days | :weeks | :years
-  @type second_time_units :: :second | :millisecond | :microsecond | :nanosecond | :seconds | :milliseconds | :microseconds | :nanoseconds
+  @type time_units :: :microsecond | :microseconds | :millisecond | :milliseconds | :second | :seconds | :minute | :minutes | :hour | :hours | :day | :days | :week | :weeks | :year | :years
   @type time :: { hour, minute, second }
   @type microsecond_time :: { hour, minute, second, microsecond | microseconds}
   @type date :: { year, month, day }

--- a/test/comparable_test.exs
+++ b/test/comparable_test.exs
@@ -42,4 +42,18 @@ defmodule ComparableTests do
     assert 0 == Comparable.compare(naive_dt, :epoch)
     assert +1 == Comparable.compare(naive_dt, :zero)
   end
+
+  test "supports singular timeunits" do
+    epoch = Timex.epoch()
+    date1 = Timex.to_datetime({1971,1,1})
+    date2 = Timex.to_datetime({1973,1,1})
+
+    assert Timex.compare(date1, date2, :seconds) == Timex.compare(date1, date2, :second)
+    assert Timex.compare(date1, date2, :minutes) == Timex.compare(date1, date2, :minute)
+    assert Timex.compare(date1, date2, :hours)   == Timex.compare(date1, date2, :hour)
+    assert Timex.compare(date1, date2, :days)    == Timex.compare(date1, date2, :day)
+    assert Timex.compare(date1, date2, :weeks)   == Timex.compare(date1, date2, :week)
+    assert Timex.compare(date1, date2, :months)  == Timex.compare(date1, date2, :month)
+    assert Timex.compare(date1, date2, :years)   == Timex.compare(date1, date2, :year)
+  end
 end

--- a/test/diff_test.exs
+++ b/test/diff_test.exs
@@ -19,4 +19,18 @@ defmodule DiffTests do
     expected = 11
     assert expected === difference
   end
+
+  test "supports singular timeunits" do
+    epoch = Timex.epoch()
+    date1 = Timex.to_datetime({1971,1,1})
+    date2 = Timex.to_datetime({1973,1,1})
+
+    assert Timex.diff(date1, date2, :seconds) == Timex.diff(date1, date2, :second)
+    assert Timex.diff(date1, date2, :minutes) == Timex.diff(date1, date2, :minute)
+    assert Timex.diff(date1, date2, :hours)   == Timex.diff(date1, date2, :hour)
+    assert Timex.diff(date1, date2, :days)    == Timex.diff(date1, date2, :day)
+    assert Timex.diff(date1, date2, :weeks)   == Timex.diff(date1, date2, :week)
+    assert Timex.diff(date1, date2, :months)  == Timex.diff(date1, date2, :month)
+    assert Timex.diff(date1, date2, :years)   == Timex.diff(date1, date2, :year)
+  end
 end


### PR DESCRIPTION
### Summary of changes

Elixir 1.8 emits warnings for using plural time units (ie for `:seconds`), see: #503 
When working with Elixir 1.8 and Timex it's a bit confusing when to use what form of time units.

This PR adds support for singular time units for `Timex.diff` and `Timex.compare`. I am not sure about `shift` - should I change it to also accept singular?

### Checklist

- [x] New functions have typespecs, changed functions were updated
- [x] Same for documentation, including moduledocs
- [x] Tests were added or updated to cover changes
- [x] Commits were squashed into a single coherent commit
