### PR TITLE
Add missing pt br relative time translation

### DIFF
--- a/priv/translations/pt_BR/LC_MESSAGES/relative_time.po
+++ b/priv/translations/pt_BR/LC_MESSAGES/relative_time.po
@@ -238,4 +238,4 @@ msgstr "esta quarta-feira"
 
 #: lib/l10n/translator.ex:286
 msgid "now"
-msgstr ""
+msgstr "agora"


### PR DESCRIPTION
### Summary of changes

Msgid "now" is empty in the relative time translation file, returning english version
I'm having to do the translation inside my application instead of using the translation of the timex

```elixir
# before 
Timex.Translator.translate("pt_BR", "relative_time", "now")
=> "now"

# now
Timex.Translator.translate("pt_BR", "relative_time", "now")
"agora"

```

### Checklist

- [ ] New functions have typespecs, changed functions were updated
- [ ] Same for documentation, including moduledocs
- [ ] Tests were added or updated to cover changes
- [x] Commits were squashed into a single coherent commit
