### PR TITLE
Fix letter encoding on PT translation - Closes Issue #515 

### DIFF
--- a/priv/translations/pt/LC_MESSAGES/months.po
+++ b/priv/translations/pt/LC_MESSAGES/months.po
@@ -49,7 +49,7 @@ msgstr "Junho"
 
 #: lib/l10n/translator.ex:219
 msgid "March"
-msgstr "Março"
+msgstr "MarÃ§o"
 
 #: lib/l10n/translator.ex:221
 msgid "May"


### PR DESCRIPTION
### Summary of changes

This PR fixes the bug described on #515.

Seems that `ç` wasn't on UTF-8. I noticed that based this [commit](https://github.com/bitwalker/timex/commit/0b656661d3a288aea0f0d6fa39aed3aa3dd877b9).

It will require recompiling `Timex.Translator` since its external resources changed.

### Checklist

- [x] New functions have typespecs, changed functions were updated
- [x] Same for documentation, including moduledocs
- [x] Tests were added or updated to cover changes
- [x] Commits were squashed into a single coherent commit
