### PR TITLE
Fix incorrect month key for swedish translation

### DIFF
--- a/priv/translations/sv/LC_MESSAGES/months.po
+++ b/priv/translations/sv/LC_MESSAGES/months.po
@@ -39,7 +39,7 @@ msgid "June"
 msgstr "juni"
 
 #: lib/l10n/translator.ex:219
-msgid "Mars"
+msgid "March"
 msgstr "mars"
 
 #: lib/l10n/translator.ex:221


### PR DESCRIPTION
Sometime in the past the translation key for March was accidentally translated into swedish in the swedish month translation file.

This restores it to the correct key so translations of March into swedish works again.
