### PR TITLE
Fix wrong type spec

### DIFF
--- a/lib/timex.ex
+++ b/lib/timex.ex
@@ -965,9 +965,8 @@ defmodule Timex do
   @doc """
   See docs for `diff/3`
   """
-  @spec diff(Time, Time) :: Types.timestamp() | {:error, term}
-  @spec diff(Comparable.comparable(), Comparable.comparable()) ::
-          Types.timestamp() | {:error, term}
+  @spec diff(Time, Time) :: Duration.t() | integer | {:error, term}
+  @spec diff(Comparable.comparable(), Comparable.comparable()) :: Duration.t() | integer | {:error, term}
   def diff(%Time{} = a, %Time{} = b), do: diff(a, b, :microseconds)
   defdelegate diff(a, b), to: Timex.Comparable
 


### PR DESCRIPTION
### Summary of changes

The diff/2 function had a wrong typespec, I got warnings inside of this code:

```
defp check_token_expiry(%{"expiry" => expiry}) do
  case Timex.diff(Timex.now(), Timex.from_unix(expiry, :second)) do
    # In contrast to the documentation, "Timex.diff" returns an integer.
    time when time <= 0 ->
      :ok
 
    _ ->
      {:error, :claim_token_expired}
  end
end
```

### Checklist

- [ ] New functions have typespecs, changed functions were updated
- [ ] Same for documentation, including moduledocs
- [ ] Tests were added or updated to cover changes
- [x] Commits were squashed into a single coherent commit
