### PR TITLE
Update docs to reflect the actual behavior of days of week formatters.

### DIFF
--- a/lib/format/datetime/formatters/default.ex
+++ b/lib/format/datetime/formatters/default.ex
@@ -39,8 +39,8 @@ defmodule Timex.Format.DateTime.Formatters.Default do
 
   * `{D}`       - day number (1..31)
   * `{Dord}`    - ordinal day of the year (1..366)
-  * `{WDmon}`   - weekday, Monday first (1..7, no padding)
-  * `{WDsun}`   - weekday, Sunday first (1..7, no padding)
+  * `{WDmon}`   - weekday, Monday first (0..6, no padding)
+  * `{WDsun}`   - weekday, Sunday first (0..6, no padding)
   * `{WDshort}` - abbreviated weekday name (Mon..Sun, no padding)
   * `{WDfull}`  - full weekday name (Monday..Sunday, no padding)
 


### PR DESCRIPTION
I was surprised to see that this library was returning 1-based days of the week. When I started writing tests I saw that they were zero based, as I would have thought:
```
iex(noreaga-local@127.0.0.1)25> Timex.format!(~N[2019-04-14 05:00:00], "{WDsun}")
"0"
iex(noreaga-local@127.0.0.1)26> Timex.format!(~N[2019-04-15 05:00:00], "{WDsun}")
"1"
iex(noreaga-local@127.0.0.1)27> Timex.format!(~N[2019-04-16 05:00:00], "{WDsun}")
"2"
iex(noreaga-local@127.0.0.1)28> Timex.format!(~N[2019-04-17 05:00:00], "{WDsun}")
"3"
iex(noreaga-local@127.0.0.1)29> Timex.format!(~N[2019-04-18 05:00:00], "{WDsun}")
"4"
iex(noreaga-local@127.0.0.1)30> Timex.format!(~N[2019-04-19 05:00:00], "{WDsun}")
"5"
iex(noreaga-local@127.0.0.1)31> Timex.format!(~N[2019-04-20 05:00:00], "{WDsun}")
"6"
iex(noreaga-local@127.0.0.1)32> Timex.format!(~N[2019-04-21 05:00:00], "{WDsun}")
"0"
iex(noreaga-local@127.0.0.1)33> Timex.format!(~N[2019-04-22 05:00:00], "{WDsun}")
"1"
```

### Summary of changes

I'll review the commits, so I mostly want to understand the "why" rather than the "what"

### Checklist

- [ ] New functions have typespecs, changed functions were updated
- [ ] Same for documentation, including moduledocs
- [ ] Tests were added or updated to cover changes
- [ ] Commits were squashed into a single coherent commit
