### PR TITLE
Fix Timex.Format.DateTime.Formatters.Default Docs

### DIFF
--- a/lib/format/datetime/formatters/default.ex
+++ b/lib/format/datetime/formatters/default.ex
@@ -7,10 +7,10 @@ defmodule Timex.Format.DateTime.Formatters.Default do
 
   ## Directive format
 
-  A directive is an optional _padding specifier_ followed by a _mnemonic_, both
-  enclosed in braces (`{` and `}`):
+  A directive is an optional _padding specifier_ followed by a _mnemonic_ enclosed
+  in braces (`{` and `}`):
 
-      {<padding><mnemonic>}
+      <padding>{<mnemonic>}
 
   Supported padding specifiers:
 


### PR DESCRIPTION
The padding for a directive is not enclosed within
the braces

### Summary of changes

I'll review the commits, so I mostly want to understand the "why" rather than the "what"

### Checklist

- [ ] New functions have typespecs, changed functions were updated
- [ ] Same for documentation, including moduledocs
- [ ] Tests were added or updated to cover changes
- [ ] Commits were squashed into a single coherent commit
- [ ] Notes added to CHANGELOG file which describe changes at a high-level
