### PR TITLE
Fix Incorrect ordinal day for DateTime (#527)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,14 +5,14 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
 
-- TBD
+- `Timex.day/1` works better for DateTime that could fall on diff Dates (#527)
 
 ## 3.6.1
 
 ### Potentially Breaking
 
 - Require Elixir v1.6+
- 
+
 ### Added
 
 - Setup property based test framework and add sample tests (#480)

--- a/lib/datetime/datetime.ex
+++ b/lib/datetime/datetime.ex
@@ -146,8 +146,10 @@ defimpl Timex.Protocol, for: DateTime do
 
   def weekday(%DateTime{:year => y, :month => m, :day => d}), do: :calendar.day_of_the_week({y, m, d})
 
-  def day(%DateTime{} = date) do
-    ref = beginning_of_year(date)
+  @spec day(DateTime.t) :: 1..366
+  def day(%DateTime{} = dt) do
+    ref = beginning_of_year(dt)
+    date = Timex.to_date(dt) # lock in Date to avoid DateTime ambiguity wrt TZ 
     1 + Timex.diff(date, ref, :days)
   end
 

--- a/test/timex_test.exs
+++ b/test/timex_test.exs
@@ -56,6 +56,13 @@ defmodule TimexTests do
     assert  {:error, :invalid_date} = Timex.day(nil)
   end
 
+  test "incorrect ordinal day (issue #527)" do
+    t1 = "2019-04-03T21:07:45Z" |> Timex.parse!("{ISO:Extended:Z}") |> Timex.to_datetime("Europe/Berlin")
+    t2 = "2019-04-03T22:07:45Z" |> Timex.parse!("{ISO:Extended:Z}") |> Timex.to_datetime("Europe/Berlin")
+    assert Timex.day(t1) === 93 
+    assert Timex.day(t2) === 94
+  end
+  
   test "week" do
     localdate = {{2013,3,17},{11,59,10}}
     assert Timex.iso_week(localdate) === {2013,11}


### PR DESCRIPTION
Underlying Timex.diff simplifies DateTime to just microseconds,
but it can be unclear on which date a DateTime falls without TZ.
In this fix, we lock the date part of DateTime
and then calc ordinal day from that Date rather than DateTime

CHANGELOG.md update too

added typespec, was missing

docs live in `protocol.ex`

### Summary of changes

I'll review the commits, so I mostly want to understand the "why" rather than the "what"

### Checklist

- [check] New functions have typespecs, changed functions were updated
- [n/a] Same for documentation, including moduledocs
- [check] Tests were added or updated to cover changes
- [check] Commits were squashed into a single coherent commit
- [check] Notes added to CHANGELOG file which describe changes at a high-level
