### PR TITLE
fix broken link in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -204,7 +204,7 @@ in order to craft an excellent pull request:
 4. Commit your changes in logical chunks. Keep your commit messages organized,
    with a short description in the first line and more detailed information on
    the following lines. Feel free to use Git's
-   [interactive rebase](https://help.github.com/articles/interactive-rebase)
+   [interactive rebase](https://help.github.com/en/articles/using-git-rebase-on-the-command-line)
    feature to tidy up your commits before making them public.
 
 5. Make sure all the tests are still passing.


### PR DESCRIPTION
### Summary of changes

The link under [interactive rebase] was giving a 404, I searched in help.github.com/articles and this link is the most suitable https://help.github.com/en/articles/using-git-rebase-on-the-command-line

### Checklist

- [x] New functions have typespecs, changed functions were updated
- [x] Same for documentation, including moduledocs
- [x] Tests were added or updated to cover changes
- [x] Commits were squashed into a single coherent commit
- [x] Notes added to CHANGELOG file which describe changes at a high-level
