### PR TITLE
Implement beginning_of_iso_week

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
 
-- TBD
+- Added `Timex.beginning_of_iso_week/2` which returns the beginning of a week (1-53) of a given year
 
 ## 3.6.1
 

--- a/lib/date/date.ex
+++ b/lib/date/date.ex
@@ -76,6 +76,29 @@ defimpl Timex.Protocol, for: Date do
     end
   end
 
+  @spec beginning_of_iso_week(Date.t, Types.weeknum) :: Date.t() | {:error, term}
+  def beginning_of_iso_week(%Date{year: year} = _date, weeknum) do
+    beginning_of_target_iso_week =
+      year
+      |> Timex.beginning_of_year()
+      |> Timex.weekday()
+      |> case do
+        weekday when weekday <= 4 ->
+          %Date{year: year, month: 1, day: 1} |> Timex.beginning_of_week()
+
+        _weekday ->
+          %Date{year: year, month: 1, day: 1}
+          |> Timex.beginning_of_week()
+          |> Timex.shift(weeks: 1)
+      end
+      |> Timex.shift(weeks: weeknum - 1)
+
+    case Timex.iso_week(beginning_of_target_iso_week) do
+      {^year, _week} -> beginning_of_target_iso_week
+      {_following_year, _week} -> {:error, :invalid_weeknum}
+    end
+  end
+
   @spec beginning_of_year(Date.t) :: Date.t
   def beginning_of_year(%Date{} = date),
     do: %{date | :month => 1, :day => 1}

--- a/lib/protocol.ex
+++ b/lib/protocol.ex
@@ -113,6 +113,13 @@ defprotocol Timex.Protocol do
   def end_of_week(datetime, weekstart)
 
   @doc """
+  Get a new version of the date/time value representing the beginning of it's
+  ISO week, providing a year and the week number.
+  """
+  @spec beginning_of_iso_week(Types.year(), Types.weeknum()) :: Types.valid_datetime | {:error, term}
+  def beginning_of_iso_week(year, weeknum)
+
+  @doc """
   Get a new version of the date/time value representing the beginning of it's year
   """
   @spec beginning_of_year(Types.year | Types.valid_datetime) :: Types.valid_datetime | {:error, term}
@@ -246,6 +253,9 @@ defimpl Timex.Protocol, for: Any do
 
   def end_of_week(%{__struct__: _} = d, weekstart), do: Timex.end_of_week(Map.from_struct(d), weekstart)
   def end_of_week(_datetime, _weekstart), do: {:error, :invalid_date}
+
+  def beginning_of_iso_week(%{__struct__: _} = d, weeknum), do: Timex.beginning_of_iso_week(Map.from_struct(d), weeknum)
+  def beginning_of_iso_week(_datetime, _weeknum), do: {:error, :invalid_date}
 
   def beginning_of_year(%{__struct__: _} = d), do: Timex.beginning_of_year(Map.from_struct(d))
   def beginning_of_year(_datetime), do: {:error, :invalid_date}

--- a/lib/timex.ex
+++ b/lib/timex.ex
@@ -1563,6 +1563,27 @@ defmodule Timex do
   defdelegate end_of_week(datetime, weekstart \\ 1), to: Timex.Protocol
 
   @doc """
+  Returns the date of the first Monday of a given week according to ISO 8601
+
+  ## Examples
+
+      iex> Timex.beginning_of_iso_week(2013, 1)
+      ~D[2012-12-31]
+
+      iex> Timex.beginning_of_iso_week(2017, 1)
+      ~D[2017-01-02]
+
+  """
+  @spec end_of_year(Types.year() | Types.valid_datetime()) ::
+          Types.valid_datetime() | {:error, term}
+  def beginning_of_iso_week(year, weeknum) when is_year(year) and is_week_of_year(weeknum),
+    do: Timex.Protocol.beginning_of_iso_week(%Date{year: year, month: 12, day: 31}, weeknum)
+
+  def beginning_of_iso_week(datetime, weeknum) when is_week_of_year(weeknum), do: Timex.Protocol.beginning_of_iso_week(datetime, weeknum)
+
+  def beginning_of_iso_week(_, _), do: {:error, :invalid_year_or_weeknum}
+
+  @doc """
   Returns a DateTime representing the beginning of the day
 
   ## Examples

--- a/test/timex_test.exs
+++ b/test/timex_test.exs
@@ -746,6 +746,25 @@ defmodule TimexTests do
     assert {:error, :invalid_date} = Timex.beginning_of_week(nil, nil)
   end
 
+  test "beginning_of_iso_week" do
+    assert Timex.beginning_of_iso_week(2019, 1) === ~D[2018-12-31]
+    assert Timex.beginning_of_iso_week(2017, 1) === ~D[2017-01-02]
+    assert Timex.beginning_of_iso_week(2016, 1) === ~D[2016-01-04]
+    assert Timex.beginning_of_iso_week(2013, 1) === ~D[2012-12-31]
+    assert Timex.beginning_of_iso_week(2020, 53) === ~D[2020-12-28]
+
+    # Invalid beginning of iso week - out of range
+    assert {:error, _} = Timex.beginning_of_iso_week(2020, 54)
+    assert {:error, _} = Timex.beginning_of_iso_week(2019, 53)
+
+    # Invalid beginning of iso week string
+    assert {:error, _} = Timex.beginning_of_iso_week("Made up year", 1)
+    assert {:error, _} = Timex.beginning_of_iso_week(2019, "Made up week number")
+
+    # Invalid beginning of iso week - invalid date
+    assert {:error, :invalid_year_or_weeknum} = Timex.beginning_of_iso_week(nil, nil)
+  end
+
   test "beginning_of_day" do
     date = Timex.to_datetime({{2015,1,1},{13,14,15}})
     assert Timex.beginning_of_day(date) == Timex.to_datetime({{2015,1,1},{0,0,0}})


### PR DESCRIPTION
### Summary of changes

I wanted to find out what is the first day of a given week of the year. I couldn't find this functionality in Timex at the moment (although I may be missing something obvious!) and when I tried to implement it on top of it, I found a couple of edge cases and thought it might something of value to others.

Let me know if this is of use and any feedback to make it better! Thanks!

Thanks to @Vereis for helping out.

### Checklist

- [x] New functions have typespecs, changed functions were updated
- [x] Same for documentation, including moduledocs
- [x] Tests were added or updated to cover changes
- [x] Commits were squashed into a single coherent commit
- [x] Notes added to CHANGELOG file which describe changes at a high-level
