### PR TITLE
Fix typo in Interval.with_step/2 typespec

### DIFF
--- a/lib/interval/interval.ex
+++ b/lib/interval/interval.ex
@@ -249,7 +249,7 @@ defmodule Timex.Interval do
       ["2014-09-22", "2014-09-25"]
 
   """
-  @spec with_step(t, valid_interval_step) :: t | {:error, :invalid_step}
+  @spec with_step(t, valid_interval_steps) :: t | {:error, :invalid_step}
   def with_step(%__MODULE__{} = interval, step) do
     if invalid_step?(step) do
       {:error, :invalid_step}


### PR DESCRIPTION
The type of the second parameter of `Timex.Interval.with_step/2` was declared as atom, but the code expects a list of atoms causing Dialyzer to warn.

The correct type was already declared, so this PR sets the type to the correct one.

Closes #566 