### PR TITLE
fix `Timex.week_of_month/3` to support leap weeks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,13 +6,14 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ## Unreleased
 
 - TBD
+- fix end-of-year edge cases for `Timex.week_of_month/3`
 
 ## 3.6.1
 
 ### Potentially Breaking
 
 - Require Elixir v1.6+
- 
+
 ### Added
 
 - Setup property based test framework and add sample tests (#480)

--- a/lib/timex.ex
+++ b/lib/timex.ex
@@ -1300,7 +1300,18 @@ defmodule Timex do
   """
   @spec week_of_month(Types.year(), Types.month(), Types.day()) :: Types.week_of_month()
   def week_of_month(year, month, day) when is_date(year, month, day) do
-    {_, week_index_of_given_date} = iso_week(year, month, day)
+    # We have to handle a special case when iso_week for a date
+    # returns the first week of a following year.
+    # For example: `iso_week(2019, 12, 30)` is `{2020, 1}`, which results in
+    # this function returning -46 for this date.
+    # More details here: https://en.wikipedia.org/wiki/ISO_week_date
+
+    week_index_of_given_date =
+      case iso_week(year, month, day) do
+        {^year, week_index} -> week_index
+        {_next_year, 1} -> 53
+      end
+
     {_, week_index_of_first_day_of_given_month} = iso_week(year, month, 1)
     week_index_of_given_date - week_index_of_first_day_of_given_month + 1
   end

--- a/test/timex_test.exs
+++ b/test/timex_test.exs
@@ -796,4 +796,10 @@ defmodule TimexTests do
           "#{modifier_fn} for #{type_fn}:\n#{inspect(expected_result)} should equal #{inspect(result)}"
     end
   end
+
+  test "week_of_month/3 works correctly for end-of-year dates" do
+    datetime = Timex.to_datetime({2019, 12, 30})
+
+    assert Timex.week_of_month(datetime) == 6
+  end
 end


### PR DESCRIPTION
### Summary of changes

We have to handle a special case when iso_week for a date
returns the first week of a following year.
For example: `iso_week(2019, 12, 30)` is `{2020, 1}`, which results in
this function returning -46 for this date. Other examples are:
2024-12-31, 2029-12-31, 2030-12-31.

More details here: https://en.wikipedia.org/wiki/ISO_week_date

### Checklist

- [x] New functions have typespecs, changed functions were updated
- [x] Same for documentation, including moduledocs
- [x] Tests were added or updated to cover changes
- [x] Commits were squashed into a single coherent commit
- [x] Notes added to CHANGELOG file which describe changes at a high-level
