### PR TITLE
Fix parse for ISOweek

### DIFF
--- a/lib/parse/datetime/parser.ex
+++ b/lib/parse/datetime/parser.ex
@@ -338,7 +338,7 @@ defmodule Timex.Parse.DateTime.Parser do
           hh == 12 and (String.downcase(value) == "am") ->
             %{date | :hour => 0}
           hh in (1..11) and String.downcase(value) == "pm" ->
-            %{date | :hour => hh + 12} 
+            %{date | :hour => hh + 12}
           true ->
             date
         end
@@ -553,7 +553,7 @@ defmodule Timex.Parse.DateTime.Parser do
         n when n < 5 -> # Week 1, seek backwards to beginning of week
           [days: -(7-(7-(n-1)))]
         n -> # Part of last year's week, seek forwards to beginning of week
-          [days: (7-(7-(n-1))) - 1]
+          [days: 7-(n-1)]
       end
     datetime = Timex.to_naive_datetime(datetime)
     do_shift_to_week_of_year(Timex.shift(%{datetime | month: 1, day: 1}, shift), value)

--- a/test/parse_default_test.exs
+++ b/test/parse_default_test.exs
@@ -80,9 +80,13 @@ defmodule DateFormatTest.ParseDefault do
   end
 
   test "parse ISO week" do
-    assert ~N[2016-11-28 00:00:00] = Timex.parse!("2016-W48", "{ISOweek}")
-    assert ~N[2009-12-28 00:00:00] = Timex.parse!("2009-W53", "{ISOweek}")
-    assert ~N[2007-11-19 00:00:00] = Timex.parse!("2007-W47", "{ISOweek}")
+    assert ~N[2007-11-19 00:00:00] = Timex.parse!("2007-W47", "{ISOweek}") # monday
+    assert ~N[2018-12-31 00:00:00] = Timex.parse!("2019-W01", "{ISOweek}") # monday
+    assert ~N[2009-12-28 00:00:00] = Timex.parse!("2009-W53", "{ISOweek}") # thursday
+    assert ~N[2024-12-30 00:00:00] = Timex.parse!("2025-W01", "{ISOweek}") # wednesday
+    assert ~N[2016-11-28 00:00:00] = Timex.parse!("2016-W48", "{ISOweek}") # friday
+    assert ~N[2022-01-03 00:00:00] = Timex.parse!("2022-W01", "{ISOweek}") # saturday
+    assert ~N[2023-01-02 00:00:00] = Timex.parse!("2023-W01", "{ISOweek}") # sunday
   end
 
   test "parse ISO week with day" do


### PR DESCRIPTION
[![Open Source Saturday](https://img.shields.io/badge/%E2%9D%A4%EF%B8%8F-open%20source%20saturday-F64060.svg)](https://www.meetup.com/it-IT/Open-Source-Saturday-Milano/)

fix #508