### PR TITLE
format code

### DIFF
--- a/.formatter.exs
+++ b/.formatter.exs
@@ -1,3 +1,4 @@
+# Used by "mix format"
 [
   inputs: ["{mix,.formatter}.exs", "{config,lib,test}/**/*.{ex,exs}"]
 ]

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,23 +5,34 @@ os:
   - macos
   - linux
 elixir:
-  - 1.6
-  - 1.7
-  - 1.8
-  - 1.9
+  - '1.6'
+  - '1.7'
+  - '1.8'
+  - '1.9'
+  - '1.10'
 otp_release:
-  - 19.3
-  - 20.3
-  - 21.0
+  - '19.3'
+  - '20.3'
+  - '21.0'
+  - '22.2'
 matrix:
   exclude:
     - os: windows
-    - elixir: 1.8
-      otp_release: 19.3
-    - elixir: 1.9
-      otp_release: 19.3
+    - elixir: '1.6'
+      otp_release: '22.2'
+    - elixir: '1.7'
+      otp_release: '22.2'
+    - elixir: '1.8'
+      otp_release: '19.3'
+    - elixir: '1.9'
+      otp_release: '19.3'
+    - elixir: '1.10'
+      otp_release: '19.3'
+    - elixir: '1.10'
+      otp_release: '20.3'
 script:
   - if [[ "$TRAVIS_OS_NAME" = 'windows' ]]; then ./bin/build_win32; else ./bin/build; fi
+  - if [[ "$TRAVIS_ELIXIR_VERSION" = 1.10* ]]; then mix format --check-formatted; fi
 notifications:
   recipients:
     - paulschoenfelder@fastmail.com

--- a/lib/parse/datetime/parser.ex
+++ b/lib/parse/datetime/parser.ex
@@ -407,7 +407,8 @@ defmodule Timex.Parse.DateTime.Parser do
             date
             |> Timex.to_naive_datetime()
             |> Timex.set(second: 0)
-            |> Timex.shift([minutes: 1])
+            |> Timex.shift(minutes: 1)
+
           value ->
             %{date | :second => value}
         end


### PR DESCRIPTION
### Summary of changes

The project is formatted with `mix format`,  for a better future developing experience.  

[related issue](https://github.com/bitwalker/timex/issues/579)

- [x] All the codes (`*.ex`, `*.exs`) are formatted with `mix format`;
- [x] Travis CI scripts are updated, with `mix format --check-formatted` added in scripts when running on Elixir 1.10.x, in order to check future integrations;
- [x] Travis CI `elixir` and `otp_release` configurations are updated to the latest stable version (22.2) in order to stick with the latest Elixir version and formatting rules. 

Specification fixes will follow in another pull request.

### Checklist

- [x] New functions have typespecs, changed functions were updated
- [x] Same for documentation, including moduledocs
- [x] Tests were added or updated to cover changes
- [x] Commits were squashed into a single coherent commit
- [x] Notes added to CHANGELOG file which describe changes at a high-level
