### PR TITLE
Run CI against 1.10

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,10 +9,12 @@ elixir:
   - 1.7
   - 1.8
   - 1.9
+  - 1.10
 otp_release:
   - 19.3
   - 20.3
   - 21.0
+  - 22.0
 matrix:
   exclude:
     - os: windows


### PR DESCRIPTION
### Summary of changes

Added elixir 1.10 and otp 22 to travis.yml so CI runs against latest elixir version as well
### Checklist

- [ ] New functions have typespecs, changed functions were updated
- [ ] Same for documentation, including moduledocs
- [ ] Tests were added or updated to cover changes
- [ ] Commits were squashed into a single coherent commit
- [ ] Notes added to CHANGELOG file which describe changes at a high-level
