### PR TITLE
Disable CI running on osx

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,6 @@
 language: elixir
 sudo: false
 os:
-  - windows
-  - macos
   - linux
 elixir:
   - '1.6'
@@ -17,7 +15,6 @@ otp_release:
   - '22.2'
 matrix:
   exclude:
-    - os: windows
     - elixir: '1.6'
       otp_release: '22.2'
     - elixir: '1.7'


### PR DESCRIPTION
### Summary of changes

fix #590 

For some reason, `macos` in a Travis config is mistakenly treated as `ubuntu` before, but not anymore since about a month ago. This led to allowing our CI running on OSX system.

However, OSX with Erlang is not supported by Travis, so the CI was broken.  

refs:

- https://github.com/travis-ci/travis-build/pull/1130#issuecomment-429654578
- https://github.com/travis-ci/travis-ci/issues/2315

To fix it, I suggest disabling CI running on MacOS now. It's safe because we didn't have it before.

### Checklist

- [ ] New functions have typespecs, changed functions were updated
- [ ] Same for documentation, including moduledocs
- [ ] Tests were added or updated to cover changes
- [x] Commits were squashed into a single coherent commit
- [ ] Notes added to CHANGELOG file which describe changes at a high-level
