### PR TITLE
Improve Romanian translations

### DIFF
--- a/priv/translations/ro/LC_MESSAGES/months.po
+++ b/priv/translations/ro/LC_MESSAGES/months.po
@@ -12,16 +12,16 @@ msgstr ""
 "Project-Id-Version: \n"
 "POT-Creation-Date: \n"
 "PO-Revision-Date: \n"
-"Last-Translator: \n"
+"Last-Translator: Mihai Târnovan <mihai@steadyhq.com>\n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=iso-8859-1\n"
+"Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: Poedit 1.8.11\n"
 
 #: lib/l10n/translator.ex:220
 msgid "April"
-msgstr "Aprile"
+msgstr "Aprilie"
 
 #: lib/l10n/translator.ex:224
 msgid "August"
@@ -29,7 +29,7 @@ msgstr "August"
 
 #: lib/l10n/translator.ex:228
 msgid "December"
-msgstr "Decembre"
+msgstr "Decembrie"
 
 #: lib/l10n/translator.ex:218
 msgid "February"

--- a/priv/translations/ro/LC_MESSAGES/relative_time.po
+++ b/priv/translations/ro/LC_MESSAGES/relative_time.po
@@ -13,20 +13,20 @@ msgstr ""
 "Project-Id-Version: \n"
 "POT-Creation-Date: \n"
 "PO-Revision-Date: \n"
-"Last-Translator: \n"
+"Last-Translator: Mihai Târnovan <mihai@steadyhq.com>\n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=iso-8859-1\n"
+"Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: Poedit 1.8.11\n"
 
 #: lib/l10n/translator.ex:237
 msgid "last month"
-msgstr "ultima luna"
+msgstr "ultima lună"
 
 #: lib/l10n/translator.ex:243
 msgid "last week"
-msgstr "ultima saptamana"
+msgstr "ultima săptămână"
 
 #: lib/l10n/translator.ex:231
 msgid "last year"
@@ -34,15 +34,15 @@ msgstr "ultimul an"
 
 #: lib/l10n/translator.ex:239
 msgid "next month"
-msgstr "luna urmatoare"
+msgstr "luna următoare"
 
 #: lib/l10n/translator.ex:245
 msgid "next week"
-msgstr "saptamana urmatoare"
+msgstr "săptămâna următoare"
 
 #: lib/l10n/translator.ex:233
 msgid "next year"
-msgstr "anul urmator"
+msgstr "anul următor"
 
 #: lib/l10n/translator.ex:238
 msgid "this month"
@@ -50,7 +50,7 @@ msgstr "luna aceasta"
 
 #: lib/l10n/translator.ex:244
 msgid "this week"
-msgstr "saptamana aceasta"
+msgstr "săptămâna aceasta"
 
 #: lib/l10n/translator.ex:232
 msgid "this year"
@@ -58,11 +58,11 @@ msgstr "anul acesta"
 
 #: lib/l10n/translator.ex:250
 msgid "today"
-msgstr "astazi"
+msgstr "astăzi"
 
 #: lib/l10n/translator.ex:251
 msgid "tomorrow"
-msgstr "maine"
+msgstr "mâine"
 
 #: lib/l10n/translator.ex:249
 msgid "yesterday"
@@ -71,128 +71,128 @@ msgstr "ieri"
 #: lib/l10n/translator.ex:253
 msgid "%{count} day ago"
 msgid_plural "%{count} days ago"
-msgstr[0] "%{count} zi in urma"
-msgstr[1] "%{count} zile in urma"
-msgstr[2] "%{count} de zile in urma"
+msgstr[0] "acum o zi"
+msgstr[1] "acum %{count} zile"
+msgstr[2] "acum %{count} de zile"
 
 #: lib/l10n/translator.ex:278
 msgid "%{count} hour ago"
 msgid_plural "%{count} hours ago"
-msgstr[0] "%{count} ora in urma"
-msgstr[1] "%{count} ore in urma"
-msgstr[2] "%{count} de ore in urma"
+msgstr[0] "acum o oră"
+msgstr[1] "acum %{count} ore"
+msgstr[2] "acum %{count} de ore"
 
 #: lib/l10n/translator.ex:281
 msgid "%{count} minute ago"
 msgid_plural "%{count} minutes ago"
-msgstr[0] "%{count} minut in urma"
-msgstr[1] "%{count} minute in urma"
-msgstr[2] "%{count} de minute in urma"
+msgstr[0] "acum un minut"
+msgstr[1] "acum %{count} minute"
+msgstr[2] "acum %{count} de minute"
 
 #: lib/l10n/translator.ex:241
 msgid "%{count} month ago"
 msgid_plural "%{count} months ago"
-msgstr[0] "%{count} luna in urma"
-msgstr[1] "%{count} luni in urma"
-msgstr[2] "%{count} de luni in urma"
+msgstr[0] "acum o lună"
+msgstr[1] "acum %{count} luni"
+msgstr[2] "acum %{count} de luni"
 
 #: lib/l10n/translator.ex:284
 msgid "%{count} second ago"
 msgid_plural "%{count} seconds ago"
-msgstr[0] "%{count} secunda in urma"
-msgstr[1] "%{count} secunde in urma"
-msgstr[2] "%{count} de secunde in urma"
+msgstr[0] "acum o secundă"
+msgstr[1] "acum %{count} secunde"
+msgstr[2] "acum %{count} de secunde"
 
 #: lib/l10n/translator.ex:247
 msgid "%{count} week ago"
 msgid_plural "%{count} weeks ago"
-msgstr[0] "%{count} saptamana in urma"
-msgstr[1] "%{count} saptamani in urma"
-msgstr[2] "%{count} de saptamani in urma"
+msgstr[0] "acum o săptămână"
+msgstr[1] "acum %{count} săptămâni"
+msgstr[2] "acum %{count} de săptămâni"
 
 #: lib/l10n/translator.ex:235
 msgid "%{count} year ago"
 msgid_plural "%{count} years ago"
-msgstr[0] "%{count} an in urma"
-msgstr[1] "%{count} ani in urma"
-msgstr[2] "%{count} de ani in urma"
+msgstr[0] "acum un an"
+msgstr[1] "acum %{count} ani"
+msgstr[2] "acum %{count} de ani"
 
 #: lib/l10n/translator.ex:252
 msgid "in %{count} day"
 msgid_plural "in %{count} days"
-msgstr[0] "in %{count} zi"
-msgstr[1] "in %{count} zile"
-msgstr[2] "in %{count} de zile"
+msgstr[0] "în o zi"
+msgstr[1] "în %{count} zile"
+msgstr[2] "în %{count} de zile"
 
 #: lib/l10n/translator.ex:277
 msgid "in %{count} hour"
 msgid_plural "in %{count} hours"
-msgstr[0] "in %{count} ora"
-msgstr[1] "in %{count} ore"
-msgstr[2] "in %{count} de ore"
+msgstr[0] "în o oră"
+msgstr[1] "în %{count} ore"
+msgstr[2] "în %{count} de ore"
 
 #: lib/l10n/translator.ex:280
 msgid "in %{count} minute"
 msgid_plural "in %{count} minutes"
-msgstr[0] "in %{count} minut"
-msgstr[1] "in %{count} minute"
-msgstr[2] "in %{count} de minute"
+msgstr[0] "în un minut"
+msgstr[1] "în %{count} minute"
+msgstr[2] "în %{count} de minute"
 
 #: lib/l10n/translator.ex:240
 msgid "in %{count} month"
 msgid_plural "in %{count} months"
-msgstr[0] "in %{count} luna"
-msgstr[1] "in %{count} luni"
-msgstr[2] "in %{count} de luni"
+msgstr[0] "în o lună"
+msgstr[1] "în %{count} luni"
+msgstr[2] "în %{count} de luni"
 
 #: lib/l10n/translator.ex:283
 msgid "in %{count} second"
 msgid_plural "in %{count} seconds"
-msgstr[0] "in %{count} secunda"
-msgstr[1] "in %{count} secunde"
-msgstr[2] "in %{count} de secunde"
+msgstr[0] "în o secundă"
+msgstr[1] "în %{count} secunde"
+msgstr[2] "în %{count} de secunde"
 
 #: lib/l10n/translator.ex:246
 msgid "in %{count} week"
 msgid_plural "in %{count} weeks"
-msgstr[0] "in %{count} saptamana"
-msgstr[1] "in %{count} saptamani"
-msgstr[2] "in %{count} de saptamani"
+msgstr[0] "în o săptămână"
+msgstr[1] "în %{count} săptămâni"
+msgstr[2] "in %{count} de săptămâni"
 
 #: lib/l10n/translator.ex:234
 msgid "in %{count} year"
 msgid_plural "in %{count} years"
-msgstr[0] "in %{count} an"
-msgstr[1] "in %{count} ani"
-msgstr[2] "in %{count} de ani"
+msgstr[0] "în un an"
+msgstr[1] "în %{count} ani"
+msgstr[2] "în %{count} de ani"
 
 #: lib/l10n/translator.ex:267
 msgid "last friday"
-msgstr "vinerea trecuta"
+msgstr "vinerea trecută"
 
 #: lib/l10n/translator.ex:255
 msgid "last monday"
-msgstr "lunea trecuta"
+msgstr "lunea trecută"
 
 #: lib/l10n/translator.ex:270
 msgid "last saturday"
-msgstr "sambata trecuta"
+msgstr "sâmbăta trecută"
 
 #: lib/l10n/translator.ex:273
 msgid "last sunday"
-msgstr "duminica trecuta"
+msgstr "duminica trecută"
 
 #: lib/l10n/translator.ex:264
 msgid "last thursday"
-msgstr "joia trecuta"
+msgstr "joia trecută"
 
 #: lib/l10n/translator.ex:258
 msgid "last tuesday"
-msgstr "martea trecuta"
+msgstr "marțea trecută"
 
 #: lib/l10n/translator.ex:261
 msgid "last wednesday"
-msgstr "miercurea trecuta"
+msgstr "miercurea trecută"
 
 #: lib/l10n/translator.ex:269
 msgid "next friday"
@@ -204,7 +204,7 @@ msgstr "lunea viitoare"
 
 #: lib/l10n/translator.ex:272
 msgid "next saturday"
-msgstr "sambata viitoare"
+msgstr "sâmbăta viitoare"
 
 #: lib/l10n/translator.ex:275
 msgid "next sunday"
@@ -216,7 +216,7 @@ msgstr "joia viitoare"
 
 #: lib/l10n/translator.ex:260
 msgid "next tuesday"
-msgstr "martea viitoare"
+msgstr "marțea viitoare"
 
 #: lib/l10n/translator.ex:263
 msgid "next wednesday"
@@ -232,7 +232,7 @@ msgstr "lunea aceasta"
 
 #: lib/l10n/translator.ex:271
 msgid "this saturday"
-msgstr "sambata aceasta"
+msgstr "sâmbăta aceasta"
 
 #: lib/l10n/translator.ex:274
 msgid "this sunday"
@@ -244,7 +244,7 @@ msgstr "joia aceasta"
 
 #: lib/l10n/translator.ex:259
 msgid "this tuesday"
-msgstr "martea aceasta"
+msgstr "marțea aceasta"
 
 #: lib/l10n/translator.ex:262
 msgid "this wednesday"

--- a/priv/translations/ro/LC_MESSAGES/units.po
+++ b/priv/translations/ro/LC_MESSAGES/units.po
@@ -13,10 +13,10 @@ msgstr ""
 "Project-Id-Version: \n"
 "POT-Creation-Date: \n"
 "PO-Revision-Date: \n"
-"Last-Translator: \n"
+"Last-Translator: Mihai Târnovan <mihai@steadyhq.com>\n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=iso-8859-1\n"
+"Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: Poedit 1.8.11\n"
 
@@ -30,21 +30,21 @@ msgstr[2] "%{count} de zile"
 #: lib/l10n/translator.ex:177
 msgid "%{count} hour"
 msgid_plural "%{count} hours"
-msgstr[0] "%{count} ora"
+msgstr[0] "%{count} oră"
 msgstr[1] "%{count} ore"
 msgstr[2] "%{count} de ore"
 
 #: lib/l10n/translator.ex:173
 msgid "%{count} microsecond"
 msgid_plural "%{count} microseconds"
-msgstr[0] "%{count} microsecunda"
+msgstr[0] "%{count} microsecundă"
 msgstr[1] "%{count} microsecunde"
 msgstr[2] "%{count} de microsecunde"
 
 #: lib/l10n/translator.ex:174
 msgid "%{count} millisecond"
 msgid_plural "%{count} milliseconds"
-msgstr[0] "%{count} millisecunda"
+msgstr[0] "%{count} millisecundă"
 msgstr[1] "%{count} millisecunde"
 msgstr[2] "%{count} de millisecunde"
 
@@ -58,30 +58,30 @@ msgstr[2] "%{count} de minute"
 #: lib/l10n/translator.ex:180
 msgid "%{count} month"
 msgid_plural "%{count} months"
-msgstr[0] "%{count} luna"
+msgstr[0] "%{count} lună"
 msgstr[1] "%{count} luni"
 msgstr[2] "%{count} de luni"
 
 #: lib/l10n/translator.ex:172
 msgid "%{count} nanosecond"
 msgid_plural "%{count} nanoseconds"
-msgstr[0] "%{count} nanosecunda"
+msgstr[0] "%{count} nanosecundă"
 msgstr[1] "%{count} nanosecunde"
 msgstr[2] "%{count} de nanosecunde"
 
 #: lib/l10n/translator.ex:175
 msgid "%{count} second"
 msgid_plural "%{count} seconds"
-msgstr[0] "%{count} secunda"
+msgstr[0] "%{count} secundă"
 msgstr[1] "%{count} secunde"
 msgstr[2] "%{count} de secunde"
 
 #: lib/l10n/translator.ex:179
 msgid "%{count} week"
 msgid_plural "%{count} weeks"
-msgstr[0] "%{count} saptamana"
-msgstr[1] "%{count} saptamani"
-msgstr[2] "%{count} de saptamani"
+msgstr[0] "%{count} săptămână"
+msgstr[1] "%{count} săptămâni"
+msgstr[2] "%{count} de săptămâni"
 
 #: lib/l10n/translator.ex:181
 msgid "%{count} year"

--- a/priv/translations/ro/LC_MESSAGES/weekdays.po
+++ b/priv/translations/ro/LC_MESSAGES/weekdays.po
@@ -12,10 +12,10 @@ msgstr ""
 "Project-Id-Version: \n"
 "POT-Creation-Date: \n"
 "PO-Revision-Date: \n"
-"Last-Translator: \n"
+"Last-Translator: Mihai Târnovan <mihai@steadyhq.com>\n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=iso-8859-1\n"
+"Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: Poedit 1.8.11\n"
 
@@ -37,11 +37,11 @@ msgstr "Luni"
 
 #: lib/l10n/translator.ex:193
 msgid "Sat"
-msgstr "Sam"
+msgstr "Sâm"
 
 #: lib/l10n/translator.ex:201
 msgid "Saturday"
-msgstr "Sambata"
+msgstr "Sâmbătă"
 
 #: lib/l10n/translator.ex:194
 msgid "Sun"
@@ -49,7 +49,7 @@ msgstr "Dum"
 
 #: lib/l10n/translator.ex:202
 msgid "Sunday"
-msgstr "Duminica"
+msgstr "Duminică"
 
 #: lib/l10n/translator.ex:191
 msgid "Thu"
@@ -65,7 +65,7 @@ msgstr "Mar"
 
 #: lib/l10n/translator.ex:197
 msgid "Tuesday"
-msgstr "Marti"
+msgstr "Marți"
 
 #: lib/l10n/translator.ex:190
 msgid "Wed"


### PR DESCRIPTION
- use diacritics, change encoding to utf-8 where necessary
- improve wording of relative time
- some minor fixes
