### PR TITLE
Fix a typo in Timex.shift/2 doc

### DIFF
--- a/lib/timex.ex
+++ b/lib/timex.ex
@@ -1647,7 +1647,7 @@ defmodule Timex do
   if the shift moves to an ambiguous time period for the zone of that DateTime.
 
   Shifting by months will always return a date in the expected month. Because months
-  have different number of days, shifting to a month with fewer days may may not be
+  have different number of days, shifting to a month with fewer days may not be
   the same day of the month as the original date.
 
   If an error occurs, an error tuple will be returned.


### PR DESCRIPTION
### Summary of changes

Fix a typo in Timex.shift/2 doc.
I guess the one of 'may' is extra.

### Checklist

- [N/A] New functions have typespecs, changed functions were updated
- [N/A] Same for documentation, including moduledocs
- [N/A] Tests were added or updated to cover changes
- [N/A] Commits were squashed into a single coherent commit
- [N/A] Notes added to CHANGELOG file which describe changes at a high-level

<img width="792" alt="スクリーンショット 2020-05-11 22 05 08" src="https://user-images.githubusercontent.com/4215723/81573669-c1678b00-93df-11ea-9c3b-475496c547e5.png">
