### PR TITLE
fix typo in Timex.Comparable doc

### DIFF
--- a/lib/comparable/comparable.ex
+++ b/lib/comparable/comparable.ex
@@ -59,7 +59,7 @@ defprotocol Timex.Comparable do
   - :microseconds
   - :duration
 
-  and the dates will be compared with the cooresponding accuracy.
+  and the dates will be compared with the corresponding accuracy.
   The default granularity is `:microsecond`.
 
     - 0:  when equal

--- a/lib/timex.ex
+++ b/lib/timex.ex
@@ -978,7 +978,7 @@ defmodule Timex do
   - :microseconds
   - :duration
 
-  and the dates will be compared with the cooresponding accuracy.
+  and the dates will be compared with the corresponding accuracy.
   The default granularity is `:microsecond`.
 
   ## Examples


### PR DESCRIPTION
fixed typo in Timex.Comparable doc 
cooresponding -> corresponding

![image](https://user-images.githubusercontent.com/19915462/84825447-bb3d7d80-b021-11ea-8d64-c324b3686fa5.png)
