### PR TITLE
Add for: Timex.Interval to Enumerable implementation

### DIFF
--- a/lib/interval/interval.ex
+++ b/lib/interval/interval.ex
@@ -484,7 +484,7 @@ defmodule Timex.Interval do
   def max(%__MODULE__{until: until, right_open: false}), do: until
   def max(%__MODULE__{until: until}), do: Timex.shift(until, microseconds: -1)
 
-  defimpl Enumerable do
+  defimpl Enumerable, for: Timex.Interval do
     alias Timex.Interval
 
     def reduce(%Interval{until: until, right_open: open?, step: step} = i, acc, fun) do


### PR DESCRIPTION
I can't find any documentation about `defimpl Enumerable` now requiring the `for:` option to be explicitly declared but adding `for: Timex.Interval` has instantly cured the problem we were having on Elixir 1.9.4 where it was saying that Timex.Enumerble was NOT Enumerable.

I've looked in a bunch of other libs like postgrex and Elixir itself and most modules defining `defimpl` are explicit in this way so seems to be correct but also harmless.

### Summary of changes

I'll review the commits, so I mostly want to understand the "why" rather than the "what"

### Checklist

- [ ] New functions have typespecs, changed functions were updated
- [ ] Same for documentation, including moduledocs
- [ ] Tests were added or updated to cover changes
- [x] Commits were squashed into a single coherent commit
- [ ] Notes added to CHANGELOG file which describe changes at a high-level
