### PR TITLE
Add microsecond support to Time.set/2 with :time option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,11 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
 
-- TBD
+### Potentially Breaking
+- `Timex.set/2` now sets microseconds when setting `:time` from a `%Time{}` struct
+
+### Added
+- `Timex.set/2` now also accepts setting the `:date` from a `%Date{}` and `:time` from a `%Time{}` struct for NaiveDateTime
 
 ## 3.6.1
 

--- a/lib/datetime/datetime.ex
+++ b/lib/datetime/datetime.ex
@@ -265,8 +265,21 @@ defimpl Timex.Protocol, for: DateTime do
               %{result | :hour => h, :minute => m, :second => s}
             end
 
+          {:time, {h, m, s, ms}} ->
+            if validate? do
+              %{
+                result
+                | :hour => Timex.normalize(:hour, h),
+                  :minute => Timex.normalize(:minute, m),
+                  :second => Timex.normalize(:second, s),
+                  :microsecond => Timex.normalize(:microsecond, ms)
+              }
+            else
+              %{result | :hour => h, :minute => m, :second => s, :microsecond => ms}
+            end
+
           {:time, %Time{} = t} ->
-            Timex.set(result, time: {t.hour, t.minute, t.second})
+            Timex.set(result, time: {t.hour, t.minute, t.second, t.microsecond})
 
           {:day, d} ->
             if validate? do
@@ -312,7 +325,7 @@ defimpl Timex.Protocol, for: DateTime do
   def shift(%DateTime{time_zone: tz, microsecond: {_us, precision}} = datetime, shifts)
       when is_list(shifts) do
     {logical_shifts, shifts} = Keyword.split(shifts, [:years, :months, :weeks, :days])
-    # applied_offset is applied when converting to gregorian microseconds, 
+    # applied_offset is applied when converting to gregorian microseconds,
     # we want to reverse that when converting back to the origin timezone
     applied_offset_ms = Timezone.total_offset(datetime.std_offset, datetime.utc_offset) * -1
     datetime = logical_shift(datetime, logical_shifts)

--- a/lib/datetime/naivedatetime.ex
+++ b/lib/datetime/naivedatetime.ex
@@ -248,6 +248,9 @@ defimpl Timex.Protocol, for: NaiveDateTime do
               %{result | :year => y, :month => m, :day => d}
             end
 
+          {:date, %Date{} = d} ->
+            Timex.set(result, date: {d.year, d.month, d.day})
+
           {:time, {h, m, s}} ->
             if validate? do
               %{
@@ -259,6 +262,22 @@ defimpl Timex.Protocol, for: NaiveDateTime do
             else
               %{result | :hour => h, :minute => m, :second => s}
             end
+
+          {:time, {h, m, s, ms}} ->
+            if validate? do
+              %{
+                result
+                | :hour => Timex.normalize(:hour, h),
+                  :minute => Timex.normalize(:minute, m),
+                  :second => Timex.normalize(:second, s),
+                  :microsecond => Timex.normalize(:microsecond, ms)
+              }
+            else
+              %{result | :hour => h, :minute => m, :second => s, :microsecond => ms}
+            end
+
+          {:time, %Time{} = t} ->
+            Timex.set(result, time: {t.hour, t.minute, t.second, t.microsecond})
 
           {:day, d} ->
             if validate? do

--- a/test/set_test.exs
+++ b/test/set_test.exs
@@ -43,8 +43,8 @@ defmodule SetTests do
     end
   end
 
-  test "sets from time struct" do
-    original_date = Timex.to_datetime({{2017, 7, 21}, {1, 2, 3}})
+  test "sets DateTime time values from time struct" do
+    original_date = Timex.to_datetime({{2017, 7, 21}, {1, 2, 3, 4}})
     new_date = Timex.set(original_date, time: ~T[09:52:33.000])
 
     assert original_date.year == new_date.year
@@ -54,10 +54,25 @@ defmodule SetTests do
     assert new_date.hour == 9
     assert new_date.minute == 52
     assert new_date.second == 33
+    assert new_date.microsecond == {0, 3}
   end
 
-  test "sets from time struct with more than one change requested" do
-    original_date = Timex.to_datetime({{2017, 7, 21}, {1, 2, 3}})
+  test "sets DateTime time values from time tuple" do
+    original_date = Timex.to_datetime({{2017, 7, 21}, {1, 2, 3, 4}})
+    new_date = Timex.set(original_date, time: {9, 52, 33})
+
+    assert original_date.year == new_date.year
+    assert original_date.month == new_date.month
+    assert original_date.day == new_date.day
+
+    assert new_date.hour == 9
+    assert new_date.minute == 52
+    assert new_date.second == 33
+    assert new_date.microsecond == {4, 6}
+  end
+
+  test "sets DateTime time values from time struct with more than one change requested" do
+    original_date = Timex.to_datetime({{2017, 7, 21}, {1, 2, 3, 4}})
     new_date = Timex.set(original_date, time: ~T[09:52:33.000], year: 1989)
 
     assert new_date.year == 1989
@@ -67,6 +82,35 @@ defmodule SetTests do
     assert new_date.hour == 9
     assert new_date.minute == 52
     assert new_date.second == 33
+    assert new_date.microsecond == {0, 3}
+  end
+
+  test "sets NaiveDateTime time values from time struct" do
+    original_date = Timex.to_naive_datetime({{2017, 7, 21}, {1, 2, 3, 4}})
+    new_date = Timex.set(original_date, time: ~T[09:52:33.000])
+
+    assert original_date.year == new_date.year
+    assert original_date.month == new_date.month
+    assert original_date.day == new_date.day
+
+    assert new_date.hour == 9
+    assert new_date.minute == 52
+    assert new_date.second == 33
+    assert new_date.microsecond == {0, 3}
+  end
+
+  test "sets NaiveDateTime time values from time tuple" do
+    original_date = Timex.to_naive_datetime({{2017, 7, 21}, {1, 2, 3, 4}})
+    new_date = Timex.set(original_date, time: {9, 52, 33})
+
+    assert original_date.year == new_date.year
+    assert original_date.month == new_date.month
+    assert original_date.day == new_date.day
+
+    assert new_date.hour == 9
+    assert new_date.minute == 52
+    assert new_date.second == 33
+    assert new_date.microsecond == {4, 6}
   end
 
   test "sets from date struct" do


### PR DESCRIPTION
### Summary of changes

This PR has been created to allow setting microseconds from Time struct. Current implementation has been counter-intuitive 
where specifying `time: ~T[12:00:00.123456]` option in `Time.set/2` didn't actually change the microseconds and additional option `microsecond: {123456, 6}` was necessary to achieve that goal.

I also noticed that setting date and time from structs didn't work for NaiveDateTime, so I have fixed that.

### Checklist

- [ ] New functions have typespecs, changed functions were updated
- [ ] Same for documentation, including moduledocs
- [X] Tests were added or updated to cover changes
- [X] Commits were squashed into a single coherent commit
- [X] Notes added to CHANGELOG file which describe changes at a high-level
