### PR TITLE
Fix #615 - add padding for hour12 in kitchen format

### DIFF
--- a/lib/parse/datetime/parsers.ex
+++ b/lib/parse/datetime/parsers.ex
@@ -630,7 +630,7 @@ defmodule Timex.Parse.DateTime.Parsers do
   """
   def kitchen(opts) do
     sequence([
-      hour12(),
+      hour12(padding: :zeroes),
       literal(char(":")),
       minute(padding: :zeroes),
       ampm(opts)

--- a/test/parse_default_test.exs
+++ b/test/parse_default_test.exs
@@ -363,6 +363,13 @@ defmodule DateFormatTest.ParseDefault do
       )
 
     assert {:ok, ^date} = parse("3:25PM", "{kitchen}")
+
+    date =
+      Timex.to_naive_datetime(
+        Timex.set(Timex.now(), hour: 11, minute: 28, second: 0, microsecond: {0, 0})
+      )
+
+    assert {:ok, ^date} = parse("11:28AM", "{kitchen}")
   end
 
   test "parse ISO8601 (Extended)" do


### PR DESCRIPTION
### Summary of changes

Fixes issue #615 where two-digit hours aren't parsed correctly for `"{kitchen}"`

### Checklist

- [x] Tests were added or updated to cover changes
- [x] Commits were squashed into a single coherent commit