### PR TITLE
Fix #616 - fix negative week_of_month/3

### DIFF
--- a/lib/timex.ex
+++ b/lib/timex.ex
@@ -1312,8 +1312,28 @@ defmodule Timex do
   """
   @spec week_of_month(Types.year(), Types.month(), Types.day()) :: Types.week_of_month()
   def week_of_month(year, month, day) when is_date(year, month, day) do
-    {_, week_index_of_given_date} = iso_week(year, month, day)
-    {_, week_index_of_first_day_of_given_month} = iso_week(year, month, 1)
+    next_year = year + 1
+    prev_year = year - 1
+
+    week_index_of_given_date =
+      case iso_week(year, month, day) do
+        {^prev_year, _} ->
+          0
+
+        {^next_year, _} ->
+          {_, week_index_of_given_date_shifted} = iso_week(year, month, day - 7)
+          week_index_of_given_date_shifted + 1
+
+        {_, week_index} ->
+          week_index
+      end
+
+    week_index_of_first_day_of_given_month =
+      case iso_week(year, month, 1) do
+        {^prev_year, _} -> 0
+        {_, week_index} -> week_index
+      end
+
     week_index_of_given_date - week_index_of_first_day_of_given_month + 1
   end
 

--- a/test/timex_test.exs
+++ b/test/timex_test.exs
@@ -158,6 +158,28 @@ defmodule TimexTests do
     assert {:error, :invalid_date} = Timex.days_in_month(nil)
   end
 
+  test "week_of_month" do
+    assert Timex.week_of_month(~D[2019-01-01]) == 1
+
+    assert Timex.week_of_month(~D[2021-01-01]) == 1
+    assert Timex.week_of_month(~D[2021-01-04]) == 2
+    assert Timex.week_of_month(~D[2021-01-11]) == 3
+
+    assert Timex.week_of_month(~D[2021-02-08]) == 2
+
+    assert Timex.week_of_month(~D[2019-12-01]) == 1
+    assert Timex.week_of_month(~D[2019-12-31]) == 6
+
+    assert Timex.week_of_month(~N[2021-01-01T00:00:00Z]) == 1
+
+    assert Timex.week_of_month(2019, 12, 31) == 6
+    assert Timex.week_of_month(2021, 1, 11) == 3
+
+    assert {:error, :invalid_date} = Timex.week_of_month(2020, 40, 40)
+    assert {:error, :invalid_date} = Timex.week_of_month(2020, nil, 10)
+    assert {:error, :invalid_date} = Timex.week_of_month(nil)
+  end
+
   test "month_to_num" do
     assert Timex.month_to_num("April") == 4
     assert Timex.month_to_num("april") == 4


### PR DESCRIPTION
### Summary of changes

Fixes issue #616 

Currently `week_of_month/3` relying on `iso_week/3`. But at certain cases `iso_week/3` return different year than the year input, it may return the previous or the next year.

Example case for returning week on the previous year.
```
iex(1)> Timex.iso_week(2021, 1, 1)
{2020, 53}
```
Thus, it leads to:
```
iex(3)> Timex.week_of_month(2021, 1, 10)
-51 # should be 1
```

This is the case for returning the next year.
```
iex(6)> Timex.iso_week(2019, 12, 31)     
{2020, 1}
```
Leads to:
```
iex(7)> Timex.week_of_month(2019, 12, 31)
-46 # should be 6
```
### Checklist

- [x] Tests were added or updated to cover changes
- [x] Commits were squashed into a single coherent commit
