### PR TITLE
set MIX_HOME in CI

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -36,7 +36,9 @@ task:
     brew install erlang elixir
   mix_cache:
     folder: deps
-    fingerprint_script: cat mix.lock
+    fingerprint_script:
+      - echo $CIRRUS_OS
+      - cat mix.lock
     populate_script: |
         mix local.hex --if-missing --force
         mix local.rebar --force

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -11,6 +11,7 @@ task:
     image: elixir:1.10
   env:
       MIX_ENV: 'test'
+      MIX_HOME: '/opt/mix'
       LC_ALL: 'en_US.UTF-8'
       LANG: 'en_US.utf8'
   mix_cache:

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -16,7 +16,9 @@ task:
       LANG: 'en_US.utf8'
   mix_cache:
     folder: deps
-    fingerprint_script: cat mix.lock
+    fingerprint_script:
+      - echo $CIRRUS_OS
+      - cat mix.lock
     populate_script: |
         mix local.hex --if-missing --force
         mix local.rebar --force


### PR DESCRIPTION
### Summary of changes

Mix fails to get dependencies in Cirrus CI, using `elixir:1.10`:

```
(Mix) Could not find an SCM for dependency :tzdata from Timex.Mixfile
```

Adding `MIX_HOME` to the ENV makes it work:

* https://gitlab.com/gitlab-org/security-products/analyzers/sobelow/-/merge_requests/2
* https://pre.hn/elixir-on-heroku-with-docker
* https://cirrus-ci.com/task/6461184138280960

### Checklist

- [x] Commits were squashed into a single coherent commit
