### PR TITLE
fixes for caching in Cirrus CI

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -11,16 +11,23 @@ task:
     image: elixir:1.10
   env:
       MIX_ENV: 'test'
+      MIX_HOME: '/opt/mix'
       LC_ALL: 'en_US.UTF-8'
       LANG: 'en_US.utf8'
   mix_cache:
-    folder: deps
-    fingerprint_script: cat mix.lock
+    folder: '/opt/mix'
     populate_script: |
         mix local.hex --if-missing --force
         mix local.rebar --force
+  deps_cache:
+    folder: deps
+    fingerprint_script:
+      - echo $CIRRUS_OS
+      - cat mix.lock
+    populate_script: |
         mix deps.get
-  compile_script: mix compile
+  compile_script: |
+        mix compile
   test_script: mix test
 
 task:
@@ -31,12 +38,15 @@ task:
       MIX_ENV: 'test'
   script: |
     brew install erlang elixir
-  mix_cache:
+  deps_cache:
     folder: deps
     fingerprint_script: cat mix.lock
     populate_script: |
         mix local.hex --if-missing --force
         mix local.rebar --force
         mix deps.get
-  compile_script: mix compile
+  compile_script: |
+      mix local.hex --if-missing --force
+      mix local.rebar --force
+      mix compile
   test_script: mix test


### PR DESCRIPTION
### Summary of changes

`mix compile` needs Hex (and Rebar) to build dependencies:

```
Could not find Hex, which is needed to build dependency :tzdata
Shall I install Hex? (if running non-interactively, use "mix local.hex --force") [Yn] ** (Mix) Could not find an SCM for dependency :tzdata from Timex.Mixfile
```

We can add it to a cache ( as in the Linux task in this PR ), or we can install it every time ( as in the MacOS task in this PR ).

* https://hexdocs.pm/mix/master/Mix.Tasks.Local.Hex.html#content
* https://hexdocs.pm/mix/master/Mix.Tasks.Local.Rebar.html#content
* https://cirrus-ci.org/guide/writing-tasks/#cache-instruction

### Checklist

- [x] Commits were squashed into a single coherent commit
