### PR TITLE
Fix #576 - indentation on example

### DIFF
--- a/lib/interval/interval.ex
+++ b/lib/interval/interval.ex
@@ -309,20 +309,20 @@ defmodule Timex.Interval do
 
   ## Examples
 
-  iex> #{__MODULE__}.contains?(#{__MODULE__}.new(from: ~D[2018-01-01], until: ~D[2018-01-31]), #{
+      iex> #{__MODULE__}.contains?(#{__MODULE__}.new(from: ~D[2018-01-01], until: ~D[2018-01-31]), #{
     __MODULE__
   }.new(from: ~D[2018-01-01], until: ~D[2018-01-30]))
-  true
+      true
 
-  iex> #{__MODULE__}.contains?(#{__MODULE__}.new(from: ~D[2018-01-01], until: ~D[2018-01-30]), #{
+      iex> #{__MODULE__}.contains?(#{__MODULE__}.new(from: ~D[2018-01-01], until: ~D[2018-01-30]), #{
     __MODULE__
   }.new(from: ~D[2018-01-01], until: ~D[2018-01-31]))
-  false
+      false
 
-  iex> #{__MODULE__}.contains?(#{__MODULE__}.new(from: ~D[2018-01-01], until: ~D[2018-01-10]), #{
+      iex> #{__MODULE__}.contains?(#{__MODULE__}.new(from: ~D[2018-01-01], until: ~D[2018-01-10]), #{
     __MODULE__
   }.new(from: ~D[2018-01-05], until: ~D[2018-01-15]))
-  false
+      false
   """
   @spec contains?(__MODULE__.t(), __MODULE__.t()) :: boolean()
   def contains?(%__MODULE__{} = a, %__MODULE__{} = b) do


### PR DESCRIPTION
### Summary of changes

`Timex.Interval.contains?` examples are not generated correctly.
https://hexdocs.pm/timex/Timex.Interval.html#contains?/2-examples

Thanks for great library!

### Checklist

- [x] New functions have typespecs, changed functions were updated
- [x] Same for documentation, including moduledocs
- [x] Tests were added or updated to cover changes
- [x] Commits were squashed into a single coherent commit
- [x] Notes added to CHANGELOG file which describe changes at a high-level
