### PR TITLE
Remove :applications instructions from getting started guide

### DIFF
--- a/docs/Getting Started.md
+++ b/docs/Getting Started.md
@@ -11,10 +11,6 @@ the vast majority of functionality you will care about.
 To use Timex with your projects, edit your `mix.exs` file and add it as a dependency, as well as add `:timex` to your applications list.
 
 ```elixir
-def application do
-  [applications: [:timex]]
-end
-
 defp deps do
   [{:timex, "~> 3.0"}]
 end


### PR DESCRIPTION
It was previously removed from the README but hasn't yet been removed from the Getting Started Guide.

### Summary of changes

Removes outdated instructions from the getting started guide to better match the README: https://github.com/bitwalker/timex/commit/77984a5a2f5c8f38033aa2f4794af0d79812ab90

### Checklist

- [x] New functions have typespecs, changed functions were updated
- [x] Same for documentation, including moduledocs
- [x] Tests were added or updated to cover changes
- [x] Commits were squashed into a single coherent commit
- [ ] Notes added to CHANGELOG file which describe changes at a high-level
  - N/A