### PR TITLE
Support one-digit hour when parsing timezone offset

### DIFF
--- a/lib/timezone/timezone.ex
+++ b/lib/timezone/timezone.ex
@@ -292,6 +292,12 @@ defmodule Timex.Timezone do
     {suffix, secs}
   end
 
+  defp parse_offset(<<h1::utf8, ?:, m1::utf8, m2::utf8>> = suffix) do
+    secs = String.to_integer(<<h1::utf8>>) * 60 * 60
+    secs = secs + String.to_integer(<<m1::utf8, m2::utf8>>) * 60
+    {suffix, secs}
+  end
+
   defp parse_offset(<<?0, h2::utf8>>) do
     secs = String.to_integer(<<h2::utf8>>) * 60 * 60
     {<<h2::utf8>>, secs}

--- a/test/timezone_test.exs
+++ b/test/timezone_test.exs
@@ -18,6 +18,10 @@ defmodule TimezoneTests do
     assert tz.full_name === "Europe/Stockholm"
     assert tz.abbreviation === "CET"
     assert tz.offset_utc === 3600
+    %TimezoneInfo{} = tz = Timezone.get("GMT-5:00", ~N[2015-01-01T01:00:00])
+    assert tz.full_name === "Etc/GMT-5:00"
+    assert tz.abbreviation === "+5:00"
+    assert tz.offset_utc === 18000
     %TimezoneInfo{} = tz = Timezone.get(:utc)
     assert tz.full_name === "Etc/UTC"
     assert tz.offset_utc === 0


### PR DESCRIPTION
Recently Google Calendar API started to respond with timezones in the form of `GMT-/+H:MM` — not preceding the one-digit hour mark with `0`. This is not recognised by timex resulting in **FunctionClauseError** in Timex.Timezone.parse_offset/1. While the `GMT-0H:MM` format is perfectly supported there should be no risk in adding this variation.