### PR TITLE
Add Timex.today(timezone)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added
 - `Timex.set/2` now also accepts setting the `:date` from a `%Date{}` and `:time` from a `%Time{}` struct for NaiveDateTime
+- `Timex.today/1` which returns today's date in the provided timezone
 
 ## 3.6.1
 

--- a/lib/timex.ex
+++ b/lib/timex.ex
@@ -44,6 +44,12 @@ defmodule Timex do
   end
 
   @doc """
+  Returns a Date representing the current day in the provided timezone.
+  """
+  @spec today(Types.valid_timezone()) :: Date.t()
+  def today(timezone), do: now(timezone) |> DateTime.to_date()
+
+  @doc """
   Returns a DateTime representing the current moment in time in UTC
   """
   @spec now() :: DateTime.t()


### PR DESCRIPTION
### Summary of changes

Adds a variant of `Timex.today()` which takes a timezone as an argument.

The reason being that the current day is different depending on timezones, e.g.

```ex
iex()> Timex.now("Pacific/Honolulu")                        
#DateTime<2021-02-09 00:30:46.070275-10:00 HST Pacific/Honolulu>
iex()> Timex.now("Pacific/Kiritimati")
#DateTime<2021-02-10 00:30:51.387246+14:00 +14 Pacific/Kiritimati>
```

I don't know of a good way to test since it depends on the current time.

### Checklist

- [x] New functions have typespecs, changed functions were updated
- [x] Same for documentation, including moduledocs
- [ ] Tests were added or updated to cover changes
- [x] Commits were squashed into a single coherent commit
- [x] Notes added to CHANGELOG file which describe changes at a high-level
