### PR TITLE
doc: fix layout

### DIFF
--- a/lib/timezone/timezone_info.ex
+++ b/lib/timezone/timezone_info.ex
@@ -7,6 +7,7 @@ defmodule Timex.TimezoneInfo do
     - `abbreviation` is the abbreviated name for the zone in the current period, i.e. "America/Chicago" on 3/30/15 is "CDT"
     - `offset_std` is the offset in seconds from standard time for this period
     - `offset_utc` is the offset in seconds from UTC for this period
+
   Spec:
     - `day_of_week`: :sunday, :monday, :tuesday, etc
     - `datetime`:    {{year, month, day}, {hour, minute, second}}


### PR DESCRIPTION
### Summary of changes

missing line return before `Spec` 
<img width="832" alt="Screenshot 2021-02-10 at 22 55 20" src="https://user-images.githubusercontent.com/1539793/107577950-6293a400-6bf3-11eb-8874-e3f79d477346.png">

### Checklist

- [x] New functions have typespecs, changed functions were updated
- [x] Same for documentation, including moduledocs
- [x] Tests were added or updated to cover changes
- [x] Commits were squashed into a single coherent commit
- [x] Notes added to CHANGELOG file which describe changes at a high-level
