### PR TITLE
Fix zero behavior for default duration formatter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Potentially Breaking
 - `Timex.set/2` now sets microseconds when setting `:time` from a `%Time{}` struct
+- `Timex.Duration.to_string/1` now returns `PT0S` instead of `P` for zero-length durations with the default formatter
 
 ### Added
 - `Timex.set/2` now also accepts setting the `:date` from a `%Date{}` and `:time` from a `%Time{}` struct for NaiveDateTime

--- a/lib/format/duration/formatters/default.ex
+++ b/lib/format/duration/formatters/default.ex
@@ -55,6 +55,10 @@ defmodule Timex.Format.Duration.Formatters.Default do
       ...> Duration.from_erl({1435, 180354, 590264}) |> #{__MODULE__}.format
       "P45Y6M5DT21H12M34.590264S"
 
+      iex> use Timex
+      ...> Duration.from_erl({0, 0, 0}) |> #{__MODULE__}.format
+      "PT0S"
+
   """
   @spec format(Duration.t()) :: String.t() | {:error, term}
   def format(%Duration{} = duration), do: lformat(duration, Translator.default_locale())
@@ -69,6 +73,7 @@ defmodule Timex.Format.Duration.Formatters.Default do
   def lformat(_, _locale), do: {:error, :invalid_duration}
 
   defp do_format(components), do: do_format(components, <<?P>>)
+  defp do_format([], "P"), do: "PT0S"
   defp do_format([], str), do: str
 
   defp do_format([{unit, _} = component | rest], str) do


### PR DESCRIPTION
### Summary of changes

This PR changes the behavior of the default duration formatter for a zero-length duration. Previously it would report `P`, and now it reports `PT0S`. The use of seconds, as opposed to another unit, was arbitrary.

**Why**: [Second-hand reading](https://stackoverflow.com/a/29824127/4250566) of the ISO 8601 spec* says...

>If the number of years, months, days, hours, minutes or seconds in any of these expressions equals zero, the number and the corresponding designator may be absent; however, at least one number and its designator shall be present.

As a result, `P` is considered invalid whereas `PT0S` is an equivalent, valid expression.

*I haven't paid to read the paper myself.

### Checklist

- [x] New functions have typespecs, changed functions were updated
- [x] Same for documentation, including moduledocs
- [x] Tests were added or updated to cover changes
- [x] Commits were squashed into a single coherent commit
- [x] Notes added to CHANGELOG file which describe changes at a high-level
