### PR TITLE
typespec for Timezone.convert/2 fixed

### DIFF
--- a/lib/timezone/timezone.ex
+++ b/lib/timezone/timezone.ex
@@ -406,7 +406,7 @@ defmodule Timex.Timezone do
   """
   @spec convert(date :: DateTime.t(), tz :: AmbiguousTimezoneInfo.t()) ::
           AmbiguousDateTime.t() | {:error, term}
-  @spec convert(date :: DateTime.t(), tz :: TimezoneInfo.t() | String.t()) ::
+  @spec convert(date :: DateTime.t(), tz :: TimezoneInfo.t() | Types.valid_timezone()) ::
           DateTime.t() | AmbiguousDateTime.t() | {:error, term}
 
   def convert(%DateTime{} = date, %AmbiguousTimezoneInfo{} = tz) do


### PR DESCRIPTION
### Summary of changes

This PR doesn't fix any opened issues like #495 but just resolves dialyzer warnings on `Timex.now(:utc)` call.
