### PR TITLE
fix: converting with empty time zone

### DIFF
--- a/lib/timezone/timezone.ex
+++ b/lib/timezone/timezone.ex
@@ -224,6 +224,8 @@ defmodule Timex.Timezone do
       when sign in [?+, ?-],
       do: "Etc/UTC" <> <<sign::utf8, hh::binary, ?:, mm::binary>>
 
+  def name_of(<<tz::binary-size(0)>>), do: {:error, :time_zone_not_found}
+
   def name_of(tz) when is_binary(tz) do
     if Tzdata.zone_exists?(tz) do
       tz

--- a/lib/timezone/timezone.ex
+++ b/lib/timezone/timezone.ex
@@ -224,7 +224,7 @@ defmodule Timex.Timezone do
       when sign in [?+, ?-],
       do: "Etc/UTC" <> <<sign::utf8, hh::binary, ?:, mm::binary>>
 
-  def name_of(<<tz::binary-size(0)>>), do: {:error, :time_zone_not_found}
+  def name_of(""), do: {:error, :time_zone_not_found}
 
   def name_of(tz) when is_binary(tz) do
     if Tzdata.zone_exists?(tz) do

--- a/test/timezone_test.exs
+++ b/test/timezone_test.exs
@@ -133,6 +133,12 @@ defmodule TimezoneTests do
     assert ~N[2017-03-15 06:00:00] = Timezone.convert(noon, custom_tx) |> DateTime.to_naive()
   end
 
+  test "converting with empty time zone returns error" do
+    assert {:ok, noon} = DateTime.from_naive(~N[2017-03-15 12:00:00], "Etc/UTC")
+
+    assert {:error, :time_zone_not_found} = Timezone.convert(noon, "")
+  end
+
   test "issue #142 - invalid results produced when converting across DST in Europe/Zurich" do
     # Hour of 2am is repeated twice for this change
     datetime1 = {{2015, 10, 25}, {3, 12, 34}}


### PR DESCRIPTION
fixed `Timex.Timezone.name_of` for empty value