### PR TITLE
Prevents :time_zone_not_found when no space  at the end on timezone value.

### DIFF
--- a/lib/timezone/local.ex
+++ b/lib/timezone/local.ex
@@ -229,7 +229,7 @@ defmodule Timex.Timezone.Local do
   defp read_timezone_data(_, @_ETC_TIMEZONE) do
     case File.read(@_ETC_TIMEZONE) do
       {:ok, name} ->
-        {:ok, String.trim(name, " \n")}
+        {:ok, String.replace(name, ~r/[\s\n]/, "")}
 
       {:error, _} ->
         nil

--- a/lib/timezone/local.ex
+++ b/lib/timezone/local.ex
@@ -229,7 +229,7 @@ defmodule Timex.Timezone.Local do
   defp read_timezone_data(_, @_ETC_TIMEZONE) do
     case File.read(@_ETC_TIMEZONE) do
       {:ok, name} ->
-        {:ok, String.replace(name, ~r/[\s\n]/, "")}
+        {:ok, String.trim(name)}
 
       {:error, _} ->
         nil


### PR DESCRIPTION
### Summary of changes

I'll review the commits, so I mostly want to understand the "why" rather than the "what"

After update to 3.7.5 I started to receive `:time_zone_not_found`, I detect the problem was related to the value obtained from the reading of the `/etc/timezone` file.

```elixir
iex(web@da370b35f69c)1> Timex.local()
{:error, :time_zone_not_found}
```

```bash
# I have the value `America/MexicoCity` **no spaces at the end** on /etc/timezone file
echo "America/Mexico_City" > /etc/timezone
```

After read the code I saw there is a space during the call of `String.trim(name, " \n")`; 
My next step was update the value from the timezone file I just add the missing space and it worked. 

```bash
echo "America/Mexico_City " > /etc/timezone
```

Then I decided update to `String.replace(name, ~r/[\s\n]/, "")` to keep both cases with space(s) and with no space(s).

I'm unsure if checklist is required to this particular change because it only applies to private function. Let me know if they are required.

### Checklist

- [ ] New functions have typespecs, changed functions were updated
- [ ] Same for documentation, including moduledocs
- [ ] Tests were added or updated to cover changes
- [ ] Commits were squashed into a single coherent commit
- [ ] Notes added to CHANGELOG file which describe changes at a high-level
