### PR TITLE
Set correct day when year or month is changed too

### DIFF
--- a/lib/datetime/erlang.ex
+++ b/lib/datetime/erlang.ex
@@ -1,5 +1,6 @@
 defimpl Timex.Protocol, for: Tuple do
   alias Timex.AmbiguousDateTime
+  alias Timex.DateTime.Helpers
   import Timex.Macros
 
   @epoch :calendar.datetime_to_gregorian_seconds({{1970, 1, 1}, {0, 0, 0}})
@@ -40,7 +41,7 @@ defimpl Timex.Protocol, for: Tuple do
   end
 
   def to_datetime({{y, m, d}, {h, mm, s, us}}, timezone) when is_datetime(y, m, d, h, mm, s) do
-    us = Timex.DateTime.Helpers.construct_microseconds(us)
+    us = Helpers.construct_microseconds(us)
     dt = Timex.NaiveDateTime.new!(y, m, d, h, mm, s, us)
 
     with %DateTime{} = datetime <- Timex.Timezone.convert(dt, timezone) do
@@ -57,7 +58,7 @@ defimpl Timex.Protocol, for: Tuple do
   def to_datetime(_, _), do: {:error, :invalid_date}
 
   def to_naive_datetime({{y, m, d}, {h, mm, s, us}}) when is_datetime(y, m, d, h, mm, s) do
-    us = Timex.DateTime.Helpers.construct_microseconds(us)
+    us = Helpers.construct_microseconds(us)
     Timex.NaiveDateTime.new!(y, m, d, h, mm, s, us)
   end
 
@@ -285,7 +286,9 @@ defimpl Timex.Protocol, for: Tuple do
   defp do_set(date, options, datetime_type) do
     validate? = Keyword.get(options, :validate, true)
 
-    Enum.reduce(options, date, fn
+    options
+    |> Helpers.sort_options()
+    |> Enum.reduce(date, fn
       _option, {:error, _} = err ->
         err
 

--- a/lib/datetime/helpers.ex
+++ b/lib/datetime/helpers.ex
@@ -145,4 +145,28 @@ defmodule Timex.DateTime.Helpers do
       new_p
     end
   end
+
+  def sort_options(options) when is_list(options) do
+    options =
+      case Keyword.pop(options, :day) do
+        {nil, options} -> options
+        {day, opts} -> Keyword.put(opts, :day, day)
+      end
+
+    options =
+      case Keyword.pop(options, :month) do
+        {nil, options} -> options
+        {month, opts} -> Keyword.put(opts, :month, month)
+      end
+
+    options =
+      case Keyword.pop(options, :year) do
+        {nil, options} -> options
+        {year, opts} -> Keyword.put(opts, :year, year)
+      end
+
+    options
+  end
+
+  def sort_options(options), do: options
 end

--- a/lib/datetime/naivedatetime.ex
+++ b/lib/datetime/naivedatetime.ex
@@ -3,6 +3,7 @@ defimpl Timex.Protocol, for: NaiveDateTime do
   This module implements Timex functionality for NaiveDateTime
   """
   alias Timex.AmbiguousDateTime
+  alias Timex.DateTime.Helpers
   import Timex.Macros
 
   @epoch_seconds :calendar.datetime_to_gregorian_seconds({{1970, 1, 1}, {0, 0, 0}})
@@ -56,7 +57,7 @@ defimpl Timex.Protocol, for: NaiveDateTime do
   end
 
   def end_of_day(%NaiveDateTime{microsecond: {_, precision}} = datetime) do
-    us = Timex.DateTime.Helpers.construct_microseconds(999_999, precision)
+    us = Helpers.construct_microseconds(999_999, precision)
     %{datetime | :hour => 23, :minute => 59, :second => 59, :microsecond => us}
   end
 
@@ -70,7 +71,7 @@ defimpl Timex.Protocol, for: NaiveDateTime do
   def end_of_week(%NaiveDateTime{microsecond: {_, precision}} = date, weekstart) do
     with ws when is_atom(ws) <- Timex.standardize_week_start(weekstart) do
       date = Timex.Date.end_of_week(date, ws)
-      us = Timex.DateTime.Helpers.construct_microseconds(999_999, precision)
+      us = Helpers.construct_microseconds(999_999, precision)
       Timex.NaiveDateTime.new!(date.year, date.month, date.day, 23, 59, 59, us)
     end
   end
@@ -80,7 +81,7 @@ defimpl Timex.Protocol, for: NaiveDateTime do
   end
 
   def end_of_year(%NaiveDateTime{year: year, microsecond: {_, precision}}) do
-    us = Timex.DateTime.Helpers.construct_microseconds(999_999, precision)
+    us = Helpers.construct_microseconds(999_999, precision)
     Timex.NaiveDateTime.new!(year, 12, 31, 23, 59, 59, us)
   end
 
@@ -99,7 +100,7 @@ defimpl Timex.Protocol, for: NaiveDateTime do
 
   def end_of_month(%NaiveDateTime{year: year, month: month, microsecond: {_, precision}} = date) do
     day = days_in_month(date)
-    us = Timex.DateTime.Helpers.construct_microseconds(999_999, precision)
+    us = Helpers.construct_microseconds(999_999, precision)
     Timex.NaiveDateTime.new!(year, month, day, 23, 59, 59, us)
   end
 
@@ -141,7 +142,9 @@ defimpl Timex.Protocol, for: NaiveDateTime do
   def set(%NaiveDateTime{} = date, options) do
     validate? = Keyword.get(options, :validate, true)
 
-    Enum.reduce(options, date, fn
+    options
+    |> Helpers.sort_options()
+    |> Enum.reduce(date, fn
       _option, {:error, _} = err ->
         err
 

--- a/test/set_test.exs
+++ b/test/set_test.exs
@@ -125,4 +125,21 @@ defmodule SetTests do
     assert new_date.minute == 0
     assert new_date.second == 0
   end
+
+  test "set day 31 and another month from date with month with only 30 days" do
+    original_date = Timex.to_datetime({{2021, 4, 1}, {12, 0, 0}})
+    new_date = Timex.set(original_date, day: 31, month: 5)
+
+    assert new_date.month == 5
+    assert new_date.day == 31
+  end
+
+  test "set day 29 for February from year without it" do
+    original_date = Timex.to_datetime({{2023, 2, 28}, {12, 0, 0}})
+    new_date = Timex.set(original_date, day: 29, month: 2, year: 2024)
+
+    assert new_date.month == 2
+    assert new_date.day == 29
+    assert new_date.year == 2024
+  end
 end


### PR DESCRIPTION
### Summary of changes
 
- when you call `Timex.set/2` function from date which has less days than new month it should apply month or year changes before day changes so validation will be correct. So options have to be in exact order: year, month, day
 - added alias for Helpers module

Example before this fix:

```Elixir
Timex.now() |> Timex.set(day: 31, month: 5)
~U[2021-05-30 17:49:07.917681Z]
Timex.now() |> Timex.set(month: 5, day: 31)
~U[2021-05-31 17:49:10.264841Z]
```
There you can see correct date is only when I change order of options. 

### Checklist

- [ ] New functions have typespecs, changed functions were updated
- [ ] Same for documentation, including moduledocs
- [x] Tests were added or updated to cover changes
- [x] Commits were squashed into a single coherent commit
- [ ] Notes added to CHANGELOG file which describe changes at a high-level
