### PR TITLE
Fix specs for parse to allow AmbiguousDateTime

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,13 +9,15 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 
+- Added specs to parse function to account for AmbiguousDateTime return type
+
 ---
 
 ## 3.7.6
 
 ### Changed
 
-- The documentation on weekday formatting via `%w` and `%u` strftime directives and `WDmon` and `WDsun` 
+- The documentation on weekday formatting via `%w` and `%u` strftime directives and `WDmon` and `WDsun`
 default directives did not match, and worse, the behaviour had regressed as well and did not match the
 docs for either. The behaviour now matches between the two formatters, as does the documentation, and
 aligns with the C strftime specification (i.e. Monday is 1..7, Sunday is 0..6)
@@ -117,7 +119,7 @@ removed the unnecessary parsing work that was going on here.
 
 ### Fixed
 
-- Handling of timezones across DST. More generally we now handle gaps/ambiguity 
+- Handling of timezones across DST. More generally we now handle gaps/ambiguity
 much more consistently
 - ZoneInfo parser was refactored, now properly supports version 2/3
 files, addresses some small bugs in previous code

--- a/lib/parse/datetime/parser.ex
+++ b/lib/parse/datetime/parser.ex
@@ -25,7 +25,8 @@ defmodule Timex.Parse.DateTime.Parser do
       "Etc/UTC"
 
   """
-  @spec parse(binary, binary) :: {:ok, DateTime.t() | NaiveDateTime.t()} | {:error, term}
+  @spec parse(binary, binary) ::
+          {:ok, DateTime.t() | NaiveDateTime.t() | AmbiguousDateTime.t()} | {:error, term}
   def parse(date_string, format_string)
       when is_binary(date_string) and is_binary(format_string),
       do: parse(date_string, format_string, Default)
@@ -51,7 +52,8 @@ defmodule Timex.Parse.DateTime.Parser do
       "Etc/UTC-2"
 
   """
-  @spec parse(binary, binary, atom) :: {:ok, DateTime.t() | NaiveDateTime.t()} | {:error, term}
+  @spec parse(binary, binary, atom) ::
+          {:ok, DateTime.t() | NaiveDateTime.t() | AmbiguousDateTime.t()} | {:error, term}
   def parse(date_string, format_string, tokenizer)
       when is_binary(date_string) and is_binary(format_string) do
     try do
@@ -67,7 +69,8 @@ defmodule Timex.Parse.DateTime.Parser do
   @doc """
   Same as `parse/2` and `parse/3`, but raises on error.
   """
-  @spec parse!(String.t(), String.t(), atom | nil) :: DateTime.t() | NaiveDateTime.t() | no_return
+  @spec parse!(String.t(), String.t(), atom | nil) ::
+          DateTime.t() | NaiveDateTime.t() | AmbiguousDateTime.t() | no_return
   def parse!(date_string, format_string, tokenizer \\ Default)
 
   def parse!(date_string, format_string, :strftime),

--- a/lib/timex.ex
+++ b/lib/timex.ex
@@ -508,9 +508,10 @@ defmodule Timex do
       true
 
   """
-  @spec parse(String.t(), String.t()) :: {:ok, DateTime.t() | NaiveDateTime.t()} | {:error, term}
+  @spec parse(String.t(), String.t()) ::
+          {:ok, DateTime.t() | NaiveDateTime.t() | AmbiguousDateTime.t()} | {:error, term}
   @spec parse(String.t(), String.t(), atom) ::
-          {:ok, DateTime.t() | NaiveDateTime.t()} | {:error, term}
+          {:ok, DateTime.t() | NaiveDateTime.t() | AmbiguousDateTime.t()} | {:error, term}
   defdelegate parse(datetime_string, format_string), to: Timex.Parse.DateTime.Parser
   defdelegate parse(datetime_string, format_string, tokenizer), to: Timex.Parse.DateTime.Parser
 
@@ -519,8 +520,10 @@ defmodule Timex do
 
   See parse/2 or parse/3 docs for usage examples.
   """
-  @spec parse!(String.t(), String.t()) :: DateTime.t() | NaiveDateTime.t() | no_return
-  @spec parse!(String.t(), String.t(), atom) :: DateTime.t() | NaiveDateTime.t() | no_return
+  @spec parse!(String.t(), String.t()) ::
+          DateTime.t() | NaiveDateTime.t() | AmbiguousDateTime.t() | no_return
+  @spec parse!(String.t(), String.t(), atom) ::
+          DateTime.t() | NaiveDateTime.t() | AmbiguousDateTime.t() | no_return
   defdelegate parse!(datetime_string, format_string), to: Timex.Parse.DateTime.Parser
   defdelegate parse!(datetime_string, format_string, tokenizer), to: Timex.Parse.DateTime.Parser
 
@@ -936,7 +939,11 @@ defmodule Timex do
       ...> #{__MODULE__}.equal?(date1, date2)
       true
   """
-  @spec equal?(Time.t() | Comparable.comparable(), Time.t() | Comparable.comparable(), Comparable.granularity()) ::
+  @spec equal?(
+          Time.t() | Comparable.comparable(),
+          Time.t() | Comparable.comparable(),
+          Comparable.granularity()
+        ) ::
           boolean | no_return
   def equal?(a, a, granularity \\ :seconds)
   def equal?(a, a, _granularity), do: true
@@ -957,7 +964,8 @@ defmodule Timex do
   @doc """
   See docs for `compare/3`
   """
-  @spec compare(Time.t() | Comparable.comparable(), Time.t() | Comparable.comparable()) :: Comparable.compare_result()
+  @spec compare(Time.t() | Comparable.comparable(), Time.t() | Comparable.comparable()) ::
+          Comparable.compare_result()
   def compare(%Time{} = a, %Time{} = b) do
     compare(a, b, :microseconds)
   end
@@ -1014,7 +1022,11 @@ defmodule Timex do
       0
 
   """
-  @spec compare(Time.t() | Comparable.comparable(), Time.t() | Comparable.comparable(), Comparable.granularity()) ::
+  @spec compare(
+          Time.t() | Comparable.comparable(),
+          Time.t() | Comparable.comparable(),
+          Comparable.granularity()
+        ) ::
           Comparable.compare_result()
   def compare(%Time{} = a, %Time{} = b, granularity),
     do: Timex.Comparable.Utils.to_compare_result(diff(a, b, granularity))
@@ -1060,7 +1072,11 @@ defmodule Timex do
 
   and the result will be an integer value of those units or a Duration.
   """
-  @spec diff(Time.t() | Comparable.comparable(), Time.t() | Comparable.comparable(), Comparable.granularity()) ::
+  @spec diff(
+          Time.t() | Comparable.comparable(),
+          Time.t() | Comparable.comparable(),
+          Comparable.granularity()
+        ) ::
           Duration.t() | integer | {:error, term}
   def diff(%Time{}, %Time{}, granularity)
       when granularity in [


### PR DESCRIPTION
### Summary of changes
When issue:
https://github.com/bitwalker/timex/issues/674

was addressed to allow the parse function to return AmbiguousDateTime,
the specs were not updated and this can cause dialyzer errors in code
that uses this function.

### Checklist

- [x] New functions have typespecs, changed functions were updated
- [x] Same for documentation, including moduledocs
- [x] Tests were added or updated to cover changes
- [x] Commits were squashed into a single coherent commit
- [x] Notes added to CHANGELOG file which describe changes at a high-level
