### PR TITLE
Add latvian translations

### DIFF
--- a/priv/translations/lv/LC_MESSAGES/day_periods.po
+++ b/priv/translations/lv/LC_MESSAGES/day_periods.po
@@ -1,0 +1,27 @@
+# # `msgid`s in this file come from POT (.pot) files.
+# #
+# # Do not add, change, or remove `msgid`s manually here as
+# # they're tied to the ones in the corresponding POT file
+# # (with the same domain).
+# #
+# # Use `mix gettext.extract --merge` or `mix gettext.merge`
+# # to merge POT files into PO files.
+msgid ""
+msgstr ""
+"Language: lv\n"
+
+#: lib/l10n/translator.ex:266
+msgid "AM"
+msgstr "AM"
+
+#: lib/l10n/translator.ex:268
+msgid "PM"
+msgstr "PM"
+
+#: lib/l10n/translator.ex:267
+msgid "am"
+msgstr "am"
+
+#: lib/l10n/translator.ex:269
+msgid "pm"
+msgstr "pm"

--- a/priv/translations/lv/LC_MESSAGES/months.po
+++ b/priv/translations/lv/LC_MESSAGES/months.po
@@ -1,0 +1,59 @@
+# # `msgid`s in this file come from POT (.pot) files.
+# #
+# # Do not add, change, or remove `msgid`s manually here as
+# # they're tied to the ones in the corresponding POT file
+# # (with the same domain).
+# #
+# # Use `mix gettext.extract --merge` or `mix gettext.merge`
+# # to merge POT files into PO files.
+msgid ""
+msgstr ""
+"Language: lv\n"
+
+#: lib/l10n/translator.ex:303
+msgid "April"
+msgstr "aprīlis"
+
+#: lib/l10n/translator.ex:307
+msgid "August"
+msgstr "augusts"
+
+#: lib/l10n/translator.ex:311
+msgid "December"
+msgstr "decembris"
+
+#: lib/l10n/translator.ex:301
+msgid "February"
+msgstr "februāris"
+
+#: lib/l10n/translator.ex:300
+msgid "January"
+msgstr "janvāris"
+
+#: lib/l10n/translator.ex:306
+msgid "July"
+msgstr "jūlijs"
+
+#: lib/l10n/translator.ex:305
+msgid "June"
+msgstr "jūnijs"
+
+#: lib/l10n/translator.ex:302
+msgid "March"
+msgstr "marts"
+
+#: lib/l10n/translator.ex:304
+msgid "May"
+msgstr "maijs"
+
+#: lib/l10n/translator.ex:310
+msgid "November"
+msgstr "novembris"
+
+#: lib/l10n/translator.ex:309
+msgid "October"
+msgstr "oktobris"
+
+#: lib/l10n/translator.ex:308
+msgid "September"
+msgstr "septembris"

--- a/priv/translations/lv/LC_MESSAGES/months_abbr.po
+++ b/priv/translations/lv/LC_MESSAGES/months_abbr.po
@@ -1,0 +1,59 @@
+## `msgid`s in this file come from POT (.pot) files.
+##
+## Do not add, change, or remove `msgid`s manually here as
+## they're tied to the ones in the corresponding POT file
+## (with the same domain).
+##
+## Use `mix gettext.extract --merge` or `mix gettext.merge`
+## to merge POT files into PO files.
+msgid ""
+msgstr ""
+"Language: lv\n"
+
+#: lib/l10n/translator.ex:290
+msgid "Apr"
+msgstr "apr"
+
+#: lib/l10n/translator.ex:294
+msgid "Aug"
+msgstr "aug"
+
+#: lib/l10n/translator.ex:298
+msgid "Dec"
+msgstr "dec"
+
+#: lib/l10n/translator.ex:288
+msgid "Feb"
+msgstr "febr"
+
+#: lib/l10n/translator.ex:287
+msgid "Jan"
+msgstr "janv"
+
+#: lib/l10n/translator.ex:293
+msgid "Jul"
+msgstr "jūl"
+
+#: lib/l10n/translator.ex:292
+msgid "Jun"
+msgstr "jūn"
+
+#: lib/l10n/translator.ex:289
+msgid "Mar"
+msgstr "marts"
+
+#: lib/l10n/translator.ex:291
+msgid "May"
+msgstr "maijs"
+
+#: lib/l10n/translator.ex:297
+msgid "Nov"
+msgstr "nov"
+
+#: lib/l10n/translator.ex:296
+msgid "Oct"
+msgstr "okt"
+
+#: lib/l10n/translator.ex:295
+msgid "Sep"
+msgstr "sept"

--- a/priv/translations/lv/LC_MESSAGES/numbers.po
+++ b/priv/translations/lv/LC_MESSAGES/numbers.po
@@ -1,0 +1,15 @@
+# # `msgid`s in this file come from POT (.pot) files.
+# #
+# # Do not add, change, or remove `msgid`s manually here as
+# # they're tied to the ones in the corresponding POT file
+# # (with the same domain).
+# #
+# # Use `mix gettext.extract --merge` or `mix gettext.merge`
+# # to merge POT files into PO files.
+msgid ""
+msgstr ""
+"Language: lv\n"
+
+#: lib/l10n/translator.ex:389
+msgid "#,##0.###"
+msgstr "###0,###"

--- a/priv/translations/lv/LC_MESSAGES/relative_time.po
+++ b/priv/translations/lv/LC_MESSAGES/relative_time.po
@@ -1,0 +1,245 @@
+# # `msgid`s in this file come from POT (.pot) files.
+# #
+# # Do not add, change, or remove `msgid`s manually here as
+# # they're tied to the ones in the corresponding POT file
+# # (with the same domain).
+# #
+# # Use `mix gettext.extract --merge` or `mix gettext.merge`
+# # to merge POT files into PO files.
+msgid ""
+msgstr ""
+"Language: lv\n"
+
+#: lib/l10n/translator.ex:320
+msgid "last month"
+msgstr "pagāšmēnes"
+
+#: lib/l10n/translator.ex:326
+msgid "last week"
+msgstr "pagāšnedēļ"
+
+#: lib/l10n/translator.ex:314
+msgid "last year"
+msgstr "pagāšgad"
+
+#: lib/l10n/translator.ex:322
+msgid "next month"
+msgstr "nākammēness"
+
+#: lib/l10n/translator.ex:328
+msgid "next week"
+msgstr "nākamnedēļ"
+
+#: lib/l10n/translator.ex:316
+msgid "next year"
+msgstr "nākamgad"
+
+#: lib/l10n/translator.ex:321
+msgid "this month"
+msgstr "šomēness"
+
+#: lib/l10n/translator.ex:327
+msgid "this week"
+msgstr "šonedēļ"
+
+#: lib/l10n/translator.ex:315
+msgid "this year"
+msgstr "šogad"
+
+#: lib/l10n/translator.ex:333
+msgid "today"
+msgstr "šodien"
+
+#: lib/l10n/translator.ex:334
+msgid "tomorrow"
+msgstr "rīt"
+
+#: lib/l10n/translator.ex:332
+msgid "yesterday"
+msgstr "vakar"
+
+#: lib/l10n/translator.ex:336
+msgid "%{count} day ago"
+msgid_plural "%{count} days ago"
+msgstr[0] "pirms %{count} dienas"
+msgstr[1] "pirms %{count} dienām"
+msgstr[2] "pirms %{count} dienām"
+
+#: lib/l10n/translator.ex:361
+msgid "%{count} hour ago"
+msgid_plural "%{count} hours ago"
+msgstr[0] "pirms %{count} stundas"
+msgstr[1] "pirms %{count} stundām"
+msgstr[2] "pirms %{count} stundām"
+
+#: lib/l10n/translator.ex:364
+msgid "%{count} minute ago"
+msgid_plural "%{count} minutes ago"
+msgstr[0] "pirms %{count} minūtes"
+msgstr[1] "pirms %{count} minūtēm"
+msgstr[2] "pirms %{count} minūtēm"
+
+#: lib/l10n/translator.ex:324
+msgid "%{count} month ago"
+msgid_plural "%{count} months ago"
+msgstr[0] "pirms %{count} mēneša"
+msgstr[1] "pirms %{count} mēnešiem"
+msgstr[2] "pirms %{count} mēnešiem"
+
+#: lib/l10n/translator.ex:367
+msgid "%{count} second ago"
+msgid_plural "%{count} seconds ago"
+msgstr[0] "pirms %{count} sekundes"
+msgstr[1] "pirms %{count} sekundēm"
+msgstr[2] "pirms %{count} sekundēm"
+
+#: lib/l10n/translator.ex:330
+msgid "%{count} week ago"
+msgid_plural "%{count} weeks ago"
+msgstr[0] "pirms %{count} nedēļas"
+msgstr[1] "pirms %{count} nedēļām"
+msgstr[2] "pirms %{count} nedēļām"
+
+#: lib/l10n/translator.ex:318
+msgid "%{count} year ago"
+msgid_plural "%{count} years ago"
+msgstr[0] "pirms %{count} gada"
+msgstr[1] "pirms %{count} gadiem"
+msgstr[2] "pirms %{count} gadiem"
+
+#: lib/l10n/translator.ex:335
+msgid "in %{count} day"
+msgid_plural "in %{count} days"
+msgstr[0] "pēc %{count} dienas"
+msgstr[1] "pēc %{count} dienām"
+msgstr[2] "pēc %{count} dienām"
+
+#: lib/l10n/translator.ex:360
+msgid "in %{count} hour"
+msgid_plural "in %{count} hours"
+msgstr[0] "pēc %{count} stundas"
+msgstr[1] "pēc %{count} stundām"
+msgstr[2] "pēc %{count} stundām"
+
+#: lib/l10n/translator.ex:363
+msgid "in %{count} minute"
+msgid_plural "in %{count} minutes"
+msgstr[0] "pēc %{count} minūtes"
+msgstr[1] "pēc %{count} minūtēm"
+msgstr[2] "pēc %{count} minūtēm"
+
+#: lib/l10n/translator.ex:323
+msgid "in %{count} month"
+msgid_plural "in %{count} months"
+msgstr[0] "pēc %{count} mēneša"
+msgstr[1] "pēc %{count} mēnešiem"
+msgstr[2] "pēc %{count} mēnešiem"
+
+#: lib/l10n/translator.ex:366
+msgid "in %{count} second"
+msgid_plural "in %{count} seconds"
+msgstr[0] "pēc %{count} sekundes"
+msgstr[1] "pēc %{count} sekundēm"
+msgstr[2] "pēc %{count} sekundēm"
+
+#: lib/l10n/translator.ex:329
+msgid "in %{count} week"
+msgid_plural "in %{count} weeks"
+msgstr[0] "pēc %{count} nedēļas"
+msgstr[1] "pēc %{count} nedēļām"
+msgstr[2] "pēc %{count} nedēļām"
+
+#: lib/l10n/translator.ex:317
+msgid "in %{count} year"
+msgid_plural "in %{count} years"
+msgstr[0] "pēc %{count} gada"
+msgstr[1] "pēc %{count} gadiem"
+msgstr[2] "pēc %{count} gadiem"
+
+#: lib/l10n/translator.ex:350
+msgid "last friday"
+msgstr "pagāšpiektdien"
+
+#: lib/l10n/translator.ex:338
+msgid "last monday"
+msgstr "pagāšpirmdien"
+
+#: lib/l10n/translator.ex:353
+msgid "last saturday"
+msgstr "pagāšsestdien"
+
+#: lib/l10n/translator.ex:356
+msgid "last sunday"
+msgstr "pagāšsvētdien"
+
+#: lib/l10n/translator.ex:347
+msgid "last thursday"
+msgstr "pagāšceturtdien"
+
+#: lib/l10n/translator.ex:341
+msgid "last tuesday"
+msgstr "pagāšotrdien"
+
+#: lib/l10n/translator.ex:344
+msgid "last wednesday"
+msgstr "pagāštrešdien"
+
+#: lib/l10n/translator.ex:352
+msgid "next friday"
+msgstr "nākampiektdien"
+
+#: lib/l10n/translator.ex:340
+msgid "next monday"
+msgstr "nākampirmdien"
+
+#: lib/l10n/translator.ex:355
+msgid "next saturday"
+msgstr "nākamsestdien"
+
+#: lib/l10n/translator.ex:358
+msgid "next sunday"
+msgstr "nākamsvētdien"
+
+#: lib/l10n/translator.ex:349
+msgid "next thursday"
+msgstr "nākamceturtdien"
+
+#: lib/l10n/translator.ex:343
+msgid "next tuesday"
+msgstr "nākamotrdien"
+
+#: lib/l10n/translator.ex:346
+msgid "next wednesday"
+msgstr "nākamtrešdien"
+
+#: lib/l10n/translator.ex:351
+msgid "this friday"
+msgstr "šopiektdien"
+
+#: lib/l10n/translator.ex:339
+msgid "this monday"
+msgstr "šopirmdien"
+
+#: lib/l10n/translator.ex:354
+msgid "this saturday"
+msgstr "šosestdien"
+
+#: lib/l10n/translator.ex:357
+msgid "this sunday"
+msgstr "šosvētdien"
+
+#: lib/l10n/translator.ex:348
+msgid "this thursday"
+msgstr "šoceturtdien"
+
+#: lib/l10n/translator.ex:342
+msgid "this tuesday"
+msgstr "šootrdien"
+
+#: lib/l10n/translator.ex:345
+msgid "this wednesday"
+msgstr "šotrešdien"
+
+#: lib/l10n/translator.ex:369
+msgid "now"
+msgstr "tagad"

--- a/priv/translations/lv/LC_MESSAGES/symbols.po
+++ b/priv/translations/lv/LC_MESSAGES/symbols.po
@@ -1,0 +1,39 @@
+# # `msgid`s in this file come from POT (.pot) files.
+# #
+# # Do not add, change, or remove `msgid`s manually here as
+# # they're tied to the ones in the corresponding POT file
+# # (with the same domain).
+# #
+# # Use `mix gettext.extract --merge` or `mix gettext.merge`
+# # to merge POT files into PO files.
+msgid ""
+msgstr ""
+"Language: lv\n"
+
+#: lib/l10n/translator.ex:379
+msgid "+"
+msgstr "+"
+
+#: lib/l10n/translator.ex:375
+msgid ","
+msgstr ","
+
+#: lib/l10n/translator.ex:381
+msgid "-"
+msgstr "-"
+
+#: lib/l10n/translator.ex:373
+msgid "."
+msgstr "."
+
+#: lib/l10n/translator.ex:385
+msgid ":"
+msgstr ":"
+
+#: lib/l10n/translator.ex:377
+msgid ";"
+msgstr ";"
+
+#: lib/l10n/translator.ex:383
+msgid "E"
+msgstr "E"

--- a/priv/translations/lv/LC_MESSAGES/units.po
+++ b/priv/translations/lv/LC_MESSAGES/units.po
@@ -1,0 +1,81 @@
+# # `msgid`s in this file come from POT (.pot) files.
+# #
+# # Do not add, change, or remove `msgid`s manually here as
+# # they're tied to the ones in the corresponding POT file
+# # (with the same domain).
+# #
+# # Use `mix gettext.extract --merge` or `mix gettext.merge`
+# # to merge POT files into PO files.
+msgid ""
+msgstr ""
+"Language: lv\n"
+
+#: lib/l10n/translator.ex:261
+msgid "%{count} day"
+msgid_plural "%{count} days"
+msgstr[0] "%{count} diena"
+msgstr[1] "%{count} dienas"
+msgstr[2] "%{count} dienas"
+
+#: lib/l10n/translator.ex:260
+msgid "%{count} hour"
+msgid_plural "%{count} hours"
+msgstr[0] "%{count} stunda"
+msgstr[1] "%{count} stundas"
+msgstr[2] "%{count} stundas"
+
+#: lib/l10n/translator.ex:256
+msgid "%{count} microsecond"
+msgid_plural "%{count} microseconds"
+msgstr[0] "%{count} mikrosekunde"
+msgstr[1] "%{count} mikrosekundes"
+msgstr[2] "%{count} mikrosekundes"
+
+#: lib/l10n/translator.ex:257
+msgid "%{count} millisecond"
+msgid_plural "%{count} milliseconds"
+msgstr[0] "%{count} milisekunde"
+msgstr[1] "%{count} milisekundes"
+msgstr[2] "%{count} milisekundes"
+
+#: lib/l10n/translator.ex:259
+msgid "%{count} minute"
+msgid_plural "%{count} minutes"
+msgstr[0] "%{count} minūte"
+msgstr[1] "%{count} minūtes"
+msgstr[2] "%{count} minūtes"
+
+#: lib/l10n/translator.ex:263
+msgid "%{count} month"
+msgid_plural "%{count} months"
+msgstr[0] "%{count} mēnesis"
+msgstr[1] "%{count} mēneši"
+msgstr[2] "%{count} mēneši"
+
+#: lib/l10n/translator.ex:255
+msgid "%{count} nanosecond"
+msgid_plural "%{count} nanoseconds"
+msgstr[0] "%{count} nanosekunde"
+msgstr[1] "%{count} nanosekundes"
+msgstr[2] "%{count} nanosekundes"
+
+#: lib/l10n/translator.ex:258
+msgid "%{count} second"
+msgid_plural "%{count} seconds"
+msgstr[0] "%{count} sekunde"
+msgstr[1] "%{count} sekundes"
+msgstr[2] "%{count} sekundes"
+
+#: lib/l10n/translator.ex:262
+msgid "%{count} week"
+msgid_plural "%{count} weeks"
+msgstr[0] "%{count} nedēļa"
+msgstr[1] "%{count} nedēļas"
+msgstr[2] "%{count} nedēļas"
+
+#: lib/l10n/translator.ex:264
+msgid "%{count} year"
+msgid_plural "%{count} years"
+msgstr[0] "%{count} gads"
+msgstr[1] "%{count} gadi"
+msgstr[2] "%{count} gadi"

--- a/priv/translations/lv/LC_MESSAGES/weekdays.po
+++ b/priv/translations/lv/LC_MESSAGES/weekdays.po
@@ -1,0 +1,67 @@
+# # `msgid`s in this file come from POT (.pot) files.
+# #
+# # Do not add, change, or remove `msgid`s manually here as
+# # they're tied to the ones in the corresponding POT file
+# # (with the same domain).
+# #
+# # Use `mix gettext.extract --merge` or `mix gettext.merge`
+# # to merge POT files into PO files.
+msgid ""
+msgstr ""
+"Language: lv\n"
+
+#: lib/l10n/translator.ex:275
+msgid "Fri"
+msgstr "Pk"
+
+#: lib/l10n/translator.ex:283
+msgid "Friday"
+msgstr "piektdiena"
+
+#: lib/l10n/translator.ex:271
+msgid "Mon"
+msgstr "P"
+
+#: lib/l10n/translator.ex:279
+msgid "Monday"
+msgstr "pirmdiena"
+
+#: lib/l10n/translator.ex:276
+msgid "Sat"
+msgstr "S"
+
+#: lib/l10n/translator.ex:284
+msgid "Saturday"
+msgstr "sestdiena"
+
+#: lib/l10n/translator.ex:277
+msgid "Sun"
+msgstr "Sv"
+
+#: lib/l10n/translator.ex:285
+msgid "Sunday"
+msgstr "svētdiena"
+
+#: lib/l10n/translator.ex:274
+msgid "Thu"
+msgstr "C"
+
+#: lib/l10n/translator.ex:282
+msgid "Thursday"
+msgstr "ceturtdiena"
+
+#: lib/l10n/translator.ex:272
+msgid "Tue"
+msgstr "O"
+
+#: lib/l10n/translator.ex:280
+msgid "Tuesday"
+msgstr "otrdiena"
+
+#: lib/l10n/translator.ex:273
+msgid "Wed"
+msgstr "T"
+
+#: lib/l10n/translator.ex:281
+msgid "Wednesday"
+msgstr "trešdiena"


### PR DESCRIPTION
saw that those were missing, and was keen on using them for stuff, so I figured I'd be nice and make them a thing.

Some things of note.
1) Latvians don't really use the 1000 separator, it's not really a thing over here
2) You might notice that the abbreviations are somewhat unusual (e.g. march and may aren't abbreviated) that's because apparently according to the official language center documents those months _aren't_ abbreviated
(see http://www.vvc.gov.lv/advantagecms/export/docs/noderigi/saisinajumi/saisinajumi-1.pdf) additionally days of the week are generally abbreviated to a single letter, and second one is added only to the second day of that week that begins with said letter (e.g. S - Sestdiena (Saturday)  and Sv - Svētdiena (Sunday)

### Summary of changes

I'll review the commits, so I mostly want to understand the "why" rather than the "what"

### Checklist

- [n/a ] New functions have typespecs, changed functions were updated
- [n/a ] Same for documentation, including moduledocs
- [n/a] Tests were added or updated to cover changes
- [✅] Commits were squashed into a single coherent commit
- [X] Notes added to CHANGELOG file which describe changes at a high-level
