### PR TITLE
Fix docs - padding specifier should be inside braces

### DIFF
--- a/lib/format/datetime/formatters/default.ex
+++ b/lib/format/datetime/formatters/default.ex
@@ -7,10 +7,10 @@ defmodule Timex.Format.DateTime.Formatters.Default do
 
   ## Directive format
 
-  A directive is an optional _padding specifier_ followed by a _mnemonic_ enclosed
+  A directive is an optional _padding specifier_ followed by a _mnemonic_, all enclosed
   in braces (`{` and `}`):
 
-      <padding>{<mnemonic>}
+      {<padding><mnemonic>}
 
   Supported padding specifiers:
 


### PR DESCRIPTION
### Summary of changes

As far as I can tell, the docs are wrong here.

The padding specifier, if present, goes inside the brackets, before the mnemonic.

### Checklist

- [x] New functions have typespecs, changed functions were updated
- [x] Same for documentation, including moduledocs
- [x] Tests were added or updated to cover changes
- [x] Commits were squashed into a single coherent commit
- [x] Notes added to CHANGELOG file which describe changes at a high-level
