### PR TITLE
Fix i18n for day_periods

### DIFF
--- a/priv/translations/tr/LC_MESSAGES/day_periods.po
+++ b/priv/translations/tr/LC_MESSAGES/day_periods.po
@@ -22,16 +22,16 @@ msgstr ""
 
 #: lib/l10n/translator.ex:266
 msgid "AM"
-msgstr "ÖÖ"
+msgstr "Ã–Ã–"
 
 #: lib/l10n/translator.ex:268
 msgid "PM"
-msgstr "ÖS"
+msgstr "Ã–S"
 
 #: lib/l10n/translator.ex:267
 msgid "am"
-msgstr "öö"
+msgstr "Ã¶Ã¶"
 
 #: lib/l10n/translator.ex:269
 msgid "pm"
-msgstr "ös"
+msgstr "Ã¶s"


### PR DESCRIPTION
### Summary of changes

Fix the translation on the day_periods domain in the Turkish language.
I try a testcase like this and it's failed like
```
Timex.lformat!(~N[2021-12-28 05:15:30], "%d %b %I:%M%P", "tr", :strftime)
<<50, 56, 32, 65, 114, 97, 32, 48, 53, 58, 49, 53, 246, 246>>
```
Because the character %P on the Turkish is may wrong

### Checklist

- [ ] New functions have typespecs, changed functions were updated
- [ ] Same for documentation, including moduledocs
- [x] Tests were added or updated to cover changes
- [ ] Commits were squashed into a single coherent commit
- [ ] Notes added to CHANGELOG file which describe changes at a high-level
