### PR TITLE
Fix lformat wrong on AM/PM cases in locale tr

### DIFF
--- a/priv/translations/tr/LC_MESSAGES/day_periods.po
+++ b/priv/translations/tr/LC_MESSAGES/day_periods.po
@@ -22,16 +22,16 @@ msgstr ""
 
 #: lib/l10n/translator.ex:266
 msgid "AM"
-msgstr "ÖÖ"
+msgstr "Ã–Ã–"
 
 #: lib/l10n/translator.ex:268
 msgid "PM"
-msgstr "ÖS"
+msgstr "Ã–S"
 
 #: lib/l10n/translator.ex:267
 msgid "am"
-msgstr "öö"
+msgstr "Ã¶Ã¶"
 
 #: lib/l10n/translator.ex:269
 msgid "pm"
-msgstr "ös"
+msgstr "Ã¶s"

--- a/test/lformat_strftime_test.exs
+++ b/test/lformat_strftime_test.exs
@@ -1,0 +1,18 @@
+defmodule DateFormatTest.LFormatStrftime do
+  use ExUnit.Case, async: true
+  use Timex
+
+  @aug182013_am Timex.to_datetime({{2013, 8, 18}, {11, 00, 5}})
+  @aug182013_pm Timex.to_datetime({{2013, 8, 18}, {12, 30, 5}})
+
+  describe "locale tr" do
+    test "lformat %P" do
+      formatter = Timex.Format.DateTime.Formatters.Strftime
+
+      assert {:ok, "öö"} = formatter.lformat(@aug182013_am, "%P", "tr")
+      assert {:ok, "ÖÖ"} = formatter.lformat(@aug182013_am, "%p", "tr")
+      assert {:ok, "ös"} = formatter.lformat(@aug182013_pm, "%P", "tr")
+      assert {:ok, "ÖS"} = formatter.lformat(@aug182013_pm, "%p", "tr")
+    end
+  end
+end


### PR DESCRIPTION
### Summary of changes

Fix the translation on the day_periods domain in the Turkish language.
I try a test case like this and it's failed like
```
Timex.lformat!(~N[2021-12-28 05:15:30], "%d %b %I:%M%P", "tr", :strftime)
<<50, 56, 32, 65, 114, 97, 32, 48, 53, 58, 49, 53, 246, 246>>
```
Because the character %P/%p on the Turkish translation in the source code may be wrong encoding (display like a diamond with `?` mark when I pull from the repo)

### Checklist

- [ ] New functions have typespecs, changed functions were updated
- [ ] Same for documentation, including moduledocs
- [x] Tests were added or updated to cover changes
- [ ] Commits were squashed into a single coherent commit
- [ ] Notes added to CHANGELOG file which describe changes at a high-level
