### PR TITLE
Fixing possible range for week_of_month type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 
+- Corrected type definition for Types.week_of_month to include possiblity of 6th week (see #703)
+
 ---
 
 ## 3.7.6

--- a/lib/timex/types.ex
+++ b/lib/timex/types.ex
@@ -5,7 +5,7 @@ defmodule Timex.Types do
   @type day :: Calendar.day()
   @type num_of_days :: 28..31
   @type daynum :: 1..366
-  @type week_of_month :: 1..5
+  @type week_of_month :: 1..6
   @type weekday :: 1..7
   @type weeknum :: 1..53
   # Time types


### PR DESCRIPTION
### Summary of changes

Pretty straightforward change to make the type specification match the actual possible outputs from the existing function. See #703 for full details, but in summary the `week_of_month` function can return values up to 6, but the type currently specifies that it should return a value between 1 and 5.

```
iex> Timex.week_of_month(2022,1,31)
6
```

January 2022 Calendar:

```
week  Su Mo Tu We Th Fr Sa

1                       01
2     02 03 04 05 06 07 08
3     09 10 11 12 13 14 15
4     16 17 18 19 20 21 22
5     23 24 25 26 27 28 29
6     30 31
```

I searched through the application, and this function (`Timex.week_of_month`) was the only place where this type is being used.

### Checklist

- [NA] New functions have typespecs, changed functions were updated
- [NA] Same for documentation, including moduledocs
- [NA] Tests were added or updated to cover changes
- [x] Commits were squashed into a single coherent commit
- [x] Notes added to CHANGELOG file which describe changes at a high-level
