### PR TITLE
Update `tzdata` to 1.1.1 to solve warning: `:random.uniform/1`

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -55,7 +55,7 @@ defmodule Timex.Mixfile do
 
   def deps do
     [
-      {:tzdata, "~> 1.0"},
+      {:tzdata, "~> 1.1.1"},
       {:combine, "~> 0.10"},
       {:gettext, "~> 0.10"},
       {:ex_doc, "~> 0.13", only: [:docs]},


### PR DESCRIPTION
Hi, I checked `tzdata` version 1.1.1, they solved the `:random.uniform/1` warning, hence I updated it in mix file and tested it and have no problem with it if you agree please merge this PR.

```
elixir 1.12
elixir 1.13
```