### PR TITLE
Expose TimezoneInfo.format_offset/1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ### Added/Changed
 
 - Add Estonian translation
+- Added `TimezoneInfo.format_offset/1`
 
 ### Fixed
 

--- a/lib/timezone/inspect.ex
+++ b/lib/timezone/inspect.ex
@@ -4,40 +4,8 @@ defimpl Inspect, for: Timex.TimezoneInfo do
   end
 
   def inspect(tzinfo, _) do
-    total_offset = Timex.Timezone.total_offset(tzinfo)
-    offset = format_offset(total_offset)
+    offset = Timex.TimezoneInfo.format_offset(tzinfo)
     "#<TimezoneInfo(#{tzinfo.full_name} - #{tzinfo.abbreviation} (#{offset}))>"
-  end
-
-  defp format_offset(total_offset) do
-    offset_hours = div(total_offset, 60 * 60)
-    offset_mins = div(rem(total_offset, 60 * 60), 60)
-    offset_secs = rem(rem(total_offset, 60 * 60), 60)
-    hour = "#{pad_numeric(offset_hours)}"
-    min = "#{pad_numeric(offset_mins)}"
-    secs = "#{pad_numeric(offset_secs)}"
-
-    cond do
-      offset_hours + offset_mins >= 0 -> "+#{hour}:#{min}:#{secs}"
-      true -> "#{hour}:#{min}:#{secs}"
-    end
-  end
-
-  defp pad_numeric(number) when is_integer(number), do: pad_numeric("#{number}")
-
-  defp pad_numeric(<<?-, number_str::binary>>) do
-    res = pad_numeric(number_str)
-    <<?-, res::binary>>
-  end
-
-  defp pad_numeric(number_str) do
-    min_width = 2
-    len = String.length(number_str)
-
-    cond do
-      len < min_width -> String.duplicate("0", min_width - len) <> number_str
-      true -> number_str
-    end
   end
 end
 

--- a/test/timezone_test.exs
+++ b/test/timezone_test.exs
@@ -5,6 +5,7 @@ defmodule TimezoneTests do
   doctest Timex.Timezone
   doctest Timex.Timezone.Local
   doctest Timex.Timezone.Utils
+  doctest Timex.TimezoneInfo
 
   test "get" do
     %TimezoneInfo{} = tz = Timezone.get("America/Chicago", ~N[2015-01-01T01:00:00])


### PR DESCRIPTION
### Summary of changes

Expose `TimezoneInfo.format_offset/1`

Previously, this was used only for inspection, but it can be useful for
user-facing elements such as time zone dropdowns.

### Checklist

- [x] New functions have typespecs, changed functions were updated
- [x] Same for documentation, including moduledocs
- [x] Tests were added or updated to cover changes
- [x] Commits were squashed into a single coherent commit
- [x] Notes added to CHANGELOG file which describe changes at a high-level
