### PR TITLE
🐎 Make Timex.Duration.parse ~2x faster

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added/Changed
 
+- Changed `Timex.Duration.Parse` to be 2x faster
+
 ### Fixed
 
 ---

--- a/bench/dateformat_bench.exs
+++ b/bench/dateformat_bench.exs
@@ -6,6 +6,7 @@ defmodule Timex.Timex.Bench do
 
     @datetime "2014-07-22T12:30:05Z"
     @datetime_zoned "2014-07-22T12:30:05+02:00"
+    @duration "P15Y3M2DT1H14M37.25S"
 
     setup_all do
       Application.ensure_all_started(:tzdata)
@@ -51,5 +52,9 @@ defmodule Timex.Timex.Bench do
     bench "Timex.local" do
       _ = Timex.local
       :ok
+    end
+
+    bench "Timex.Duration.parse" do
+      {:ok, _} = Timex.Duration.parse(@duration)
     end
 end


### PR DESCRIPTION
It's very important for us at Duffel speedup the duration
parsing. We're were investigating this function and we
noticed a big number of calls to `String.contains?` that is
a O(n) order algorithm in a loop.

So we did a quick experiment on putting a flag on the number
type while reading the chars. So it assumes that is a integer,
until find a dot, where it changes the type to float. Then, it
parses using Float or Integer depending on the flag. Avoiding
the String.contains calls.

The results were quite interesting:

```
Before
Timex.Duration.parse		500000	3322687 ~6.65µs/op

After
Timex.Duration.parse		500000	1710993 ~3.42µs/op
```

### Checklist

- [x] New functions have typespecs, changed functions were updated
- [x] Same for documentation, including moduledocs
- [x] Tests were added or updated to cover changes
- [x] Commits were squashed into a single coherent commit
- [x] Notes added to CHANGELOG file which describe changes at a high-level
