### PR TITLE
Fix compiler warnings for Elixir 1.15

### DIFF
--- a/lib/parse/zoneinfo/parser.ex
+++ b/lib/parse/zoneinfo/parser.ex
@@ -4,7 +4,7 @@ defmodule Timex.Parse.ZoneInfo.Parser do
   such as those found in /usr/local/zoneinfo.
   """
 
-  # See https://tools.ietf.org/id/draft-murchison-tzdist-tzif-00.html for details 
+  # See https://tools.ietf.org/id/draft-murchison-tzdist-tzif-00.html for details
   defmodule Zone do
     @moduledoc """
     Represents the data retrieved from a binary tzfile.
@@ -681,10 +681,10 @@ defmodule Timex.Parse.ZoneInfo.Parser do
   defp parse_int(1, bin), do: parse_i32(bin)
   defp parse_int(_, bin), do: parse_i64(bin)
 
-  defp parse_i32(<<val::integer_32bit_be, rest::binary>>), do: {val, rest}
-  defp parse_i64(<<val::integer_64bit_be, rest::binary>>), do: {val, rest}
-  defp parse_char(<<val::signed_char_be, rest::binary>>), do: {val, rest}
-  defp parse_uchar(<<val::unsigned_char_be, rest::binary>>), do: {val, rest}
+  defp parse_i32(<<val::integer_32bit_be(), rest::binary>>), do: {val, rest}
+  defp parse_i64(<<val::integer_64bit_be(), rest::binary>>), do: {val, rest}
+  defp parse_char(<<val::signed_char_be(), rest::binary>>), do: {val, rest}
+  defp parse_uchar(<<val::unsigned_char_be(), rest::binary>>), do: {val, rest}
 
   defp parse_null_terminated_str(bin), do: parse_null_terminated_str(bin, <<>>)
 


### PR DESCRIPTION
### Summary of changes

Elixir 1.15 will warn on missing parentheses for bitstring modifiers (https://github.com/elixir-lang/elixir/pull/11862).
This PR adds the missing parentheses.

### Checklist

- [ ] ~~New functions have typespecs, changed functions were updated~~
- [ ] ~~Same for documentation, including moduledocs~~
- [ ] ~~Tests were added or updated to cover changes~~
- [ ] ~~Commits were squashed into a single coherent commit~~
- [ ] ~~Notes added to CHANGELOG file which describe changes at a high-level~~
