### PR TITLE
Remove compilation warning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ### Added/Changed
 
 - Changed `Timex.Duration.Parse` to be 2x faster
+- Fixed compilation warning from gettext
 
 ### Fixed
 

--- a/mix.exs
+++ b/mix.exs
@@ -12,7 +12,7 @@ defmodule Timex.Mixfile do
       package: package(),
       deps: deps(),
       docs: docs(),
-      compilers: [:gettext] ++ Mix.compilers(),
+      compilers: Mix.compilers(),
       test_coverage: [tool: ExCoveralls],
       elixirc_paths: elixirc_paths(Mix.env()),
       preferred_cli_env: [

--- a/mix.exs
+++ b/mix.exs
@@ -7,7 +7,7 @@ defmodule Timex.Mixfile do
     [
       app: :timex,
       version: @version,
-      elixir: "~> 1.8",
+      elixir: "~> 1.11",
       description: description(),
       package: package(),
       deps: deps(),
@@ -57,7 +57,7 @@ defmodule Timex.Mixfile do
     [
       {:tzdata, "~> 1.1"},
       {:combine, "~> 0.10"},
-      {:gettext, "~> 0.10"},
+      {:gettext, "~> 0.20"},
       {:ex_doc, "~> 0.13", only: [:docs]},
       {:benchfella, "~> 0.3", only: [:bench]},
       {:dialyxir, "~> 1.0", only: [:dev], runtime: false},


### PR DESCRIPTION
### Summary of changes

Remove the compilation warning.

-----

warning: the :gettext compiler is no longer required in your mix.exs.

Please find the following line in your mix.exs and remove the :gettext entry:

    compilers: [..., :gettext, ...] ++ Mix.compilers(),

-----

### Checklist

- [x] Commits were squashed into a single coherent commit
- [x] Notes added to CHANGELOG file which describe changes at a high-level