### PR TITLE
Update Timex.now/1 typespec to remove the AmbiguousDateTime

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 
+- Updated `Timex.now/1` typespec to remove the `AmbiguousDateTime` 
+
 ---
 
 ## 3.7.8

--- a/lib/timex.ex
+++ b/lib/timex.ex
@@ -66,7 +66,7 @@ defmodule Timex do
   Returns a DateTime representing the current moment in time in the provided
   timezone.
   """
-  @spec now(Types.valid_timezone()) :: DateTime.t() | AmbiguousDateTime.t() | {:error, term}
+  @spec now(Types.valid_timezone()) :: DateTime.t() | {:error, term}
   def now(tz) do
     with tzname when is_binary(tzname) <- Timezone.name_of(tz),
          {:ok, dt} <- DateTime.now(tzname, Timex.Timezone.Database) do


### PR DESCRIPTION
### Summary of changes

I'll review the commits, so I mostly want to understand the "why" rather than the "what"

### Checklist

- [x] New functions have typespecs, changed functions were updated
- [x] Same for documentation, including moduledocs
- [x] Tests were added or updated to cover changes
- [x] Commits were squashed into a single coherent commit
- [x] Notes added to CHANGELOG file which describe changes at a high-level
