### PR TITLE
Format zero Durations as "0 seconds" instead of "0 microseconds"

### DIFF
--- a/lib/format/duration/formatters/humanized.ex
+++ b/lib/format/duration/formatters/humanized.ex
@@ -98,7 +98,7 @@ defmodule Timex.Format.Duration.Formatters.Humanized do
   end
 
   defp deconstruct({0, 0}, []),
-    do: deconstruct({0, 0}, microsecond: 0)
+    do: deconstruct({0, 0}, second: 0)
 
   defp deconstruct({0, 0}, components),
     do: Enum.reverse(components)


### PR DESCRIPTION
### Summary of changes

While building a visual interface including a duration for a certain procedure, I noticed that calling the following:

```elixir
0
|> Timex.Duration.from_seconds()
|> Timex.Format.Duration.Formatter.lformat(0, "en", :humanized)
```

...returns the string "0 microseconds". While technically 100% correct, from a "humanized" point of view, this feels a bit odd, as nobody would ever describe a zero-second duration as "zero microseconds".

This pull request is actually a change request, but as the code code change was minimal, opening a PR seemed like a more logical choice than opening an issue.

I'd like to receive feedback on (a) whether this is seen as a valuable functional change, and if so, (b) if you would like me to do the remaining work (fixing tests where needed, adding a CHANGELOG line) or that if is preferred to leave this to a core contributor.

Thanks for a great library!

### Checklist

- [X] New functions have typespecs, changed functions were updated
- [X] Same for documentation, including moduledocs
- [ ] Tests were added or updated to cover changes
- [X] Commits were squashed into a single coherent commit
- [ ] Notes added to CHANGELOG file which describe changes at a high-level
