### PR TITLE
Fix dialyzer errors when using from_* functions

### DIFF
--- a/lib/time/duration.ex
+++ b/lib/time/duration.ex
@@ -346,7 +346,7 @@ defmodule Timex.Duration do
   @doc """
   Converts an integer value representing microseconds to a Duration
   """
-  @spec from_microseconds(integer) :: __MODULE__.t()
+  @spec from_microseconds(integer | float) :: __MODULE__.t()
   def from_microseconds(us) when is_integer(us) do
     mega = div(us, 1_000_000_000_000)
     sec = div(rem(us, 1_000_000_000_000), 1_000_000)

--- a/test/duration_test.exs
+++ b/test/duration_test.exs
@@ -97,7 +97,7 @@ defmodule DurationTests do
     assert Duration.to_seconds(13, :hours) == 13 * 3600
   end
 
-  test "from_*" do
+  test "from_* with integers" do
     assert Duration.to_erl(Duration.from_microseconds(1)) == {0, 0, 1}
     assert Duration.to_erl(Duration.from_milliseconds(1)) == {0, 0, 1000}
     assert Duration.to_erl(Duration.from_seconds(1)) == {0, 1, 0}
@@ -105,6 +105,16 @@ defmodule DurationTests do
     assert Duration.to_erl(Duration.from_hours(1)) == {0, 3600, 0}
     assert Duration.to_erl(Duration.from_days(1)) == {0, 86400, 0}
     assert Duration.to_erl(Duration.from_weeks(1)) == {0, 604_800, 0}
+  end
+
+  test "from_* with floats" do
+    assert Duration.to_erl(Duration.from_microseconds(1.5)) == {0, 0, 1}
+    assert Duration.to_erl(Duration.from_milliseconds(1.5)) == {0, 0, 1500}
+    assert Duration.to_erl(Duration.from_seconds(1.5)) == {0, 1, 500_000}
+    assert Duration.to_erl(Duration.from_minutes(1.5)) == {0, 90, 0}
+    assert Duration.to_erl(Duration.from_hours(1.5)) == {0, 5400, 0}
+    assert Duration.to_erl(Duration.from_days(1.5)) == {0, 129_600, 0}
+    assert Duration.to_erl(Duration.from_weeks(1.5)) == {0, 907_200, 0}
   end
 
   test "elapsed" do


### PR DESCRIPTION
i was getting a dialyzer error when calling 

`Timex.Duration.from_hours()` with a float

i believe that the code supports floats, but the typespec on one function is incorrect

this pr adds the `| float` to the `from_microseconds` function and adds some tests for calculating from_* with floats