### PR TITLE
Fix uk locale for relative days

### DIFF
--- a/priv/translations/uk/LC_MESSAGES/relative_time.po
+++ b/priv/translations/uk/LC_MESSAGES/relative_time.po
@@ -72,7 +72,7 @@ msgstr "вчора"
 msgid "%{count} day ago"
 msgid_plural "%{count} days ago"
 msgstr[0] "%{count} день тому"
-msgstr[1] "%{count} дня тому"
+msgstr[1] "%{count} дні тому"
 msgstr[2] "%{count} днів тому"
 
 #: lib/l10n/translator.ex:361


### PR DESCRIPTION
### Summary of changes

Hi, folks. I fixed incorrect locale for Ukrainian language.

Was:
```
msgstr[1] "%{count} дня тому"
```

Become
```
msgstr[1] "%{count} дні тому"
```

That was just incorrect according to Ukrainian grammar
<img width="478" alt="Screenshot 2023-11-06 at 13 26 04" src="https://github.com/bitwalker/timex/assets/5221643/ee859de9-1377-4f83-bb07-6ed8e584c588">

You can check it here: https://ukr-mova.in.ua/perevirka-tekstu with current "три дня тому"
