### PR TITLE
Add missing translations

### DIFF
--- a/priv/translations/en/LC_MESSAGES/relative_time.po
+++ b/priv/translations/en/LC_MESSAGES/relative_time.po
@@ -238,4 +238,4 @@ msgstr "this wednesday"
 
 #: lib/l10n/translator.ex:369
 msgid "now"
-msgstr ""
+msgstr "now"

--- a/priv/translations/id/LC_MESSAGES/relative_time.po
+++ b/priv/translations/id/LC_MESSAGES/relative_time.po
@@ -238,4 +238,4 @@ msgstr "Rabu ini"
 
 #: lib/l10n/translator.ex:369
 msgid "now"
-msgstr ""
+msgstr "sekarang"

--- a/priv/translations/it/LC_MESSAGES/relative_time.po
+++ b/priv/translations/it/LC_MESSAGES/relative_time.po
@@ -238,4 +238,4 @@ msgstr "questo mercoledì"
 
 #: lib/l10n/translator.ex:369
 msgid "now"
-msgstr ""
+msgstr "adesso"

--- a/priv/translations/ja/LC_MESSAGES/relative_time.po
+++ b/priv/translations/ja/LC_MESSAGES/relative_time.po
@@ -224,4 +224,4 @@ msgstr "今週の水曜日"
 
 #: lib/l10n/translator.ex:369
 msgid "now"
-msgstr ""
+msgstr "今"

--- a/priv/translations/pt/LC_MESSAGES/relative_time.po
+++ b/priv/translations/pt/LC_MESSAGES/relative_time.po
@@ -238,4 +238,4 @@ msgstr "esta quarta-feira"
 
 #: lib/l10n/translator.ex:369
 msgid "now"
-msgstr ""
+msgstr "agora"

--- a/priv/translations/pt_BR/LC_MESSAGES/relative_time.po
+++ b/priv/translations/pt_BR/LC_MESSAGES/relative_time.po
@@ -238,4 +238,4 @@ msgstr "esta quarta-feira"
 
 #: lib/l10n/translator.ex:369
 msgid "now"
-msgstr ""
+msgstr "agora"

--- a/priv/translations/ro/LC_MESSAGES/months_abbr.po
+++ b/priv/translations/ro/LC_MESSAGES/months_abbr.po
@@ -22,19 +22,19 @@ msgstr ""
 
 #: lib/l10n/translator.ex:290
 msgid "Apr"
-msgstr ""
+msgstr "Apr"
 
 #: lib/l10n/translator.ex:294
 msgid "Aug"
-msgstr ""
+msgstr "Aug"
 
 #: lib/l10n/translator.ex:298
 msgid "Dec"
-msgstr ""
+msgstr "Dec"
 
 #: lib/l10n/translator.ex:288
 msgid "Feb"
-msgstr ""
+msgstr "Feb"
 
 #: lib/l10n/translator.ex:287
 msgid "Jan"
@@ -50,7 +50,7 @@ msgstr "Iun"
 
 #: lib/l10n/translator.ex:289
 msgid "Mar"
-msgstr ""
+msgstr "Mar"
 
 #: lib/l10n/translator.ex:291
 msgid "May"
@@ -62,8 +62,8 @@ msgstr "Noi"
 
 #: lib/l10n/translator.ex:296
 msgid "Oct"
-msgstr ""
+msgstr "Oct"
 
 #: lib/l10n/translator.ex:295
 msgid "Sep"
-msgstr ""
+msgstr "Sep"

--- a/priv/translations/tr/LC_MESSAGES/relative_time.po
+++ b/priv/translations/tr/LC_MESSAGES/relative_time.po
@@ -238,4 +238,4 @@ msgstr "bu çarşamba"
 
 #: lib/l10n/translator.ex:369
 msgid "now"
-msgstr ""
+msgstr "şimdi"


### PR DESCRIPTION
### Summary of changes

I am trying to use Timex with the `pt_BR` locale and noticed a missing translation for the term "now".
Looking at the source I identified the same missing translation in other languages, so translated them too (using machine translation).

### Checklist

- [x] New functions have typespecs, changed functions were updated
- [x] Same for documentation, including moduledocs
- [x] Tests were added or updated to cover changes
- [x] Commits were squashed into a single coherent commit
- [ ] Notes added to CHANGELOG file which describe changes at a high-level
