### PR TITLE
Fix `@doc` formatting for `TimezoneInfo.create/6`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 - Updated `Timex.now/1` typespec to remove the `AmbiguousDateTime`
 - Corrected pluralization rules for bg/cs/he/id/ro/ru
+- Fixed documentation formatting of `Timex.TimezoneInfo.create/6`
 
 ---
 

--- a/lib/timezone/timezone_info.ex
+++ b/lib/timezone/timezone_info.ex
@@ -50,16 +50,16 @@ defmodule Timex.TimezoneInfo do
   during daylight savings time for this timezone. If DST does not apply for this zone, simply
   set it to 0.
 
-  The from/until reference points must meet the following criteria:
+  The `from`/`until` reference points must meet the following criteria:
 
-      - Be set to `:min` for from, or `:max` for until, which represent
-        "infinity" for the start/end of the zone period.
-      - OR, be a tuple of {day_of_week, datetime}, where:
-        - `day_of_week` is an atom like `:sunday`
-        - `datetime` is an Erlang datetime tuple, e.g. `{{2016,10,8},{2,0,0}}`
+  - Be set to `:min` for `from`, or `:max` for `until`, which represents
+    "infinity" for the start/end of the zone period
+  - OR, be a tuple of `{day_of_week, datetime}`, where:
+    - `day_of_week` is an atom like `:sunday`
+    - `datetime` is an Erlang datetime tuple, e.g. `{{2016,10,8},{2,0,0}}`
 
-  *IMPORTANT*: Offsets are in seconds, not minutes, if you do not ensure they
-               are in the correct unit, runtime errors or incorrect results are probable.
+  **IMPORTANT**: Offsets are in seconds, not minutes. If you do not ensure they
+  are in the correct unit, runtime errors or incorrect results are probable.
 
   ## Examples
 


### PR DESCRIPTION
### Summary of changes

The doc generated from `Timex.TimezoneInfo.create/6` had a few formatting issues that were fixed:

- Un-indented the `from`/`until` criteria list so it isn't rendered as a code block
- Un-indented the second line of the `**IMPORTANT**` block so it isn't rendered as a code block
- Split the `**IMPORTANT**` message into two sentences.

**Before**
> ![image](https://github.com/bitwalker/timex/assets/27983/5f984ba9-fb06-41d1-8630-d7f854c34363)

**After**
> ![image](https://github.com/bitwalker/timex/assets/27983/2b075b14-a22f-4481-90c9-2161216421f6)




### Checklist

- [ ] New functions have typespecs, changed functions were updated
- [x] Same for documentation, including moduledocs
- [ ] Tests were added or updated to cover changes
- [x] Commits were squashed into a single coherent commit
- [x] Notes added to CHANGELOG file which describe changes at a high-level
