### PR TITLE
Fix typo in Ecto.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Updated `Timex.now/1` typespec to remove the `AmbiguousDateTime`
 - Corrected pluralization rules for bg/cs/he/id/ro/ru
 - Fixed documentation formatting of `Timex.TimezoneInfo.create/6`
+- Fixed typo in `Ecto.md`
 
 ---
 

--- a/docs/Using with Ecto.md
+++ b/docs/Using with Ecto.md
@@ -4,7 +4,7 @@ How to use Timex DateTimes with Ecto.
 
 ### Getting Started
 
-Timex has can be integrated with Ecto via the `timex_ecto` plugin which is available on hex.pm:
+Timex can be integrated with Ecto via the `timex_ecto` plugin which is available on hex.pm:
 
 ```elixir
 defp deps do


### PR DESCRIPTION
### Summary of changes

There is a simple typo in `Ecto.md` where it reads as "Timex _has can_ be integrated with Ecto via...". 
The proposed change fixes the writing.

### Checklist

- [x] Notes added to CHANGELOG file which describe changes at a high-level
