### PR TITLE
simplify months attribute value generation

### DIFF
--- a/lib/timex/constants.ex
+++ b/lib/timex/constants.ex
@@ -39,7 +39,7 @@ defmodule Timex.Constants do
         "November",
         "December"
       ]
-      @months Enum.map(Enum.with_index(@month_names), fn {name, i} -> {name, i + 1} end)
+      @months Enum.with_index(@month_names, 1)
       @month_abbrs Enum.map(@month_names, fn name -> String.slice(name, 0, 3) end)
       @valid_months 1..12
 


### PR DESCRIPTION
No need to map after indexing. Setting offset or function in second argument of [Enum.with_index/2](https://hexdocs.pm/elixir/Enum.html#with_index/2) is shorter and faster.