### PR TITLE
Changed negative range to suppress warnings for Elixir 1.18

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Added `cycled` option for `Timex.between?/4` to support time-range checks that pass through midnight
 - Add Croatian translation
 - Changed charlists from the deprecated `''` to `~c""`
+- Changed negative range to pass the step of default value for suppressing deprecation warnings
 
 ### Fixed
 

--- a/lib/parse/datetime/helpers.ex
+++ b/lib/parse/datetime/helpers.ex
@@ -159,13 +159,13 @@ defmodule Timex.Parse.DateTime.Helpers do
 
     case {padding, min_width, max_width} do
       {:zeroes, _, nil} -> Text.integer()
-      {:zeroes, min, max} -> choice(Enum.map(max..min, &fixed_integer(&1)))
+      {:zeroes, min, max} -> choice(Enum.map(max..min//-1, &fixed_integer(&1)))
       {:spaces, -1, nil} -> skip(spaces()) |> Text.integer()
       {:spaces, min, nil} -> skip(spaces()) |> fixed_integer(min)
-      {:spaces, _, max} -> skip(spaces()) |> choice(Enum.map(max..1, &fixed_integer(&1)))
+      {:spaces, _, max} -> skip(spaces()) |> choice(Enum.map(max..1//-1, &fixed_integer(&1)))
       {_, -1, nil} -> Text.integer()
       {_, min, nil} -> fixed_integer(min)
-      {_, min, max} -> choice(Enum.map(max..min, &fixed_integer(&1)))
+      {_, min, max} -> choice(Enum.map(max..min//-1, &fixed_integer(&1)))
     end
   end
 end

--- a/test/duration_test.exs
+++ b/test/duration_test.exs
@@ -125,7 +125,7 @@ defmodule DurationTests do
 
   # Just make sure that Timex.Duration.measure is called at least once in the tests
   test "measure/1" do
-    reversed_list = Enum.to_list(100_000..1)
+    reversed_list = Enum.to_list(100_000..1//-1)
 
     assert {%Duration{} = d, ^reversed_list} =
              Duration.measure(fn -> Enum.reverse(1..100_000) end)

--- a/test/shift_test.exs
+++ b/test/shift_test.exs
@@ -19,7 +19,7 @@ defmodule ShiftTests do
   property "is always lower than input date for negative shift values" do
     check all(
             input_date <- PropertyHelpers.date_time_generator(:struct),
-            shift <- StreamData.integer(-1..-1000),
+            shift <- StreamData.integer(-1..-1000//-1),
             unit <- StreamData.member_of(@units)
           ) do
       date = Timex.shift(input_date, [{unit, shift}])


### PR DESCRIPTION
### Summary of changes

This PR includes updates to suppress warnings for Elixir 1.18.

Elixir 1.18 shows below warning because Range.new/2 with negative steps is now deprecated.
(ref. https://github.com/elixir-lang/elixir/commit/47079bc0b23ef1bf0a2eaf0ba7c409c253c57281)

This PR uses Range.new/3 explicitly passing the step of -1 for suppressing the warning.

```
warning: Range.new/2 has a default step of -1, please call Range.new/3 explicitly passing the step of -1 instead
  (timex 3.7.11) lib/parse/datetime/helpers.ex:162: Timex.Parse.DateTime.Helpers.integer/1
  (timex 3.7.11) lib/parse/datetime/parsers.ex:24: Timex.Parse.DateTime.Parsers.year4/1
  (timex 3.7.11) lib/parse/datetime/parsers.ex:306: Timex.Parse.DateTime.Parsers.iso_week/1
  (timex 3.7.11) lib/parse/datetime/tokenizers/directive.ex:110: Timex.Parse.DateTime.Tokenizers.Directive.get/5
  (combine 0.10.0) lib/combine/parsers/base.ex:154: Combine.Parsers.Base.pipe_impl/3
  (combine 0.10.0) lib/combine/parsers/base.ex:490: Combine.Parsers.Base.preserve_ignored_impl/2
  (combine 0.10.0) lib/combine/parsers/base.ex:163: Combine.Parsers.Base.do_pipe/3
  (combine 0.10.0) lib/combine/parsers/base.ex:152: Combine.Parsers.Base.pipe_impl/3
  (combine 0.10.0) lib/combine/parsers/base.ex:606: Combine.Parsers.Base.label_impl/3
  (combine 0.10.0) lib/combine/parsers/base.ex:130: Combine.Parsers.Base.try_choice/3
  (combine 0.10.0) lib/combine/parsers/base.ex:333: Combine.Parsers.Base.many1_impl/2
  (combine 0.10.0) lib/combine/parsers/base.ex:44: anonymous fn/2 in Combine.Parsers.Base.eof/1
  (combine 0.10.0) lib/combine.ex:52: Combine.parse/3
  (timex 3.7.11) lib/parse/datetime/tokenizers/default.ex:19: Timex.Parse.DateTime.Tokenizers.Default.tokenize/1
  (timex 3.7.11) lib/format/datetime/formatters/default.ex:185: Timex.Format.DateTime.Formatters.Default.lformat/3
  test/format_default_test.exs:311: DateFormatTest.FormatDefault."test format ISOweek"/1
  (ex_unit 1.18.0-rc.0) lib/ex_unit/runner.ex:511: ExUnit.Runner.exec_test/2
```

### Checklist

- [ ] New functions have typespecs, changed functions were updated
- [ ] Same for documentation, including moduledocs
- [ ] Tests were added or updated to cover changes
- [x] Commits were squashed into a single coherent commit
- [x] Notes added to CHANGELOG file which describe changes at a high-level
