### PR TITLE
Fix deprecation warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Add Croatian translation
 - Changed charlists from the deprecated `''` to `~c""`
 - Changed negative range to pass the step of default value for suppressing deprecation warnings
+- Update Gettext to 0.26
 
 ### Fixed
 
@@ -20,6 +21,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Corrected pluralization rules for bg/cs/he/id/ro/ru
 - Fixed documentation formatting of `Timex.TimezoneInfo.create/6`
 - Updated tzdata to fix issues with 2024b
+- Fix deprecation: Module.eval_quoted/4 is deprecated. Use Code.eval_quoted/3 instead
+- Fix deprecation: "min..max inside match is deprecated"
 
 ---
 

--- a/lib/format/datetime/formatter.ex
+++ b/lib/format/datetime/formatter.ex
@@ -890,6 +890,6 @@ defmodule Timex.Format.DateTime.Formatter do
   defp pad_char(:zeroes), do: <<?0>>
   defp pad_char(:spaces), do: <<32>>
 
-  defp width_spec(min..max), do: [min: min, max: max]
+  defp width_spec(min..max//1), do: [min: min, max: max]
   defp width_spec(min, max), do: [min: min, max: max]
 end

--- a/lib/l10n/gettext.ex
+++ b/lib/l10n/gettext.ex
@@ -1,3 +1,3 @@
 defmodule Timex.Gettext do
-  use Gettext, otp_app: :timex, priv: "priv/translations"
+  use Gettext.Backend, otp_app: :timex, priv: "priv/translations"
 end

--- a/lib/l10n/translator.ex
+++ b/lib/l10n/translator.ex
@@ -1,5 +1,5 @@
 defmodule Timex.Translator do
-  import Timex.Gettext
+  use Gettext, backend: Timex.Gettext
 
   defmacro with_locale(locale, do: block) do
     quote do

--- a/lib/timex.ex
+++ b/lib/timex.ex
@@ -1202,7 +1202,7 @@ defmodule Timex do
         def day_to_num(unquote(atom)), do: unquote(day_num)
       end
 
-    Module.eval_quoted(__MODULE__, day_quoted, [], __ENV__)
+    Code.eval_quoted(day_quoted, [], __ENV__)
   end)
 
   # Make an attempt at cleaning up the provided string
@@ -1300,7 +1300,7 @@ defmodule Timex do
         end
       end
 
-    Module.eval_quoted(__MODULE__, month_quoted, [], __ENV__)
+    Code.eval_quoted(month_quoted, [], __ENV__)
   end)
 
   # Make an attempt at cleaning up the provided string

--- a/lib/timezone/utils.ex
+++ b/lib/timezone/utils.ex
@@ -19,7 +19,7 @@ defmodule Timex.Timezone.Utils do
         def to_olson(unquote(key)), do: unquote(value)
       end
 
-    Module.eval_quoted(__MODULE__, quoted, [], __ENV__)
+    Code.eval_quoted(quoted, [], __ENV__)
   end)
 
   def to_olson(_tz), do: nil
@@ -39,7 +39,7 @@ defmodule Timex.Timezone.Utils do
         def olson_to_win(unquote(key)), do: unquote(value)
       end
 
-    Module.eval_quoted(__MODULE__, quoted, [], __ENV__)
+    Code.eval_quoted(quoted, [], __ENV__)
   end)
 
   def olson_to_win(_tz), do: nil

--- a/mix.exs
+++ b/mix.exs
@@ -57,12 +57,12 @@ defmodule Timex.Mixfile do
     [
       {:tzdata, "~> 1.1"},
       {:combine, "~> 0.10"},
-      {:gettext, "~> 0.20"},
+      {:gettext, "~> 0.26"},
       {:ex_doc, "~> 0.13", only: [:docs]},
       {:benchfella, "~> 0.3", only: [:bench]},
       {:dialyxir, "~> 1.0", only: [:dev], runtime: false},
       {:excoveralls, "~> 0.4", only: [:test]},
-      {:stream_data, "~> 0.4", only: [:test]}
+      {:stream_data, "~> 1.1", only: [:test]}
     ]
   end
 

--- a/mix.lock
+++ b/mix.lock
@@ -20,7 +20,7 @@
   "nimble_parsec": {:hex, :nimble_parsec, "1.4.2", "8efba0122db06df95bfaa78f791344a89352ba04baedd3849593bfce4d0dc1c6", [:mix], [], "hexpm", "4b21398942dda052b403bbe1da991ccd03a053668d147d53fb8c4e0efe09c973"},
   "parse_trans": {:hex, :parse_trans, "3.4.1", "6e6aa8167cb44cc8f39441d05193be6e6f4e7c2946cb2759f015f8c56b76e5ff", [:rebar3], [], "hexpm", "620a406ce75dada827b82e453c19cf06776be266f5a67cff34e1ef2cbb60e49a"},
   "ssl_verify_fun": {:hex, :ssl_verify_fun, "1.1.7", "354c321cf377240c7b8716899e182ce4890c5938111a1296add3ec74cf1715df", [:make, :mix, :rebar3], [], "hexpm", "fe4c190e8f37401d30167c8c405eda19469f34577987c76dde613e838bbc67f8"},
-  "stream_data": {:hex, :stream_data, "0.6.0", "e87a9a79d7ec23d10ff83eb025141ef4915eeb09d4491f79e52f2562b73e5f47", [:mix], [], "hexpm", "b92b5031b650ca480ced047578f1d57ea6dd563f5b57464ad274718c9c29501c"},
+  "stream_data": {:hex, :stream_data, "1.2.0", "58dd3f9e88afe27dc38bef26fce0c84a9e7a96772b2925c7b32cd2435697a52b", [:mix], [], "hexpm", "eb5c546ee3466920314643edf68943a5b14b32d1da9fe01698dc92b73f89a9ed"},
   "tzdata": {:hex, :tzdata, "1.1.3", "b1cef7bb6de1de90d4ddc25d33892b32830f907e7fc2fccd1e7e22778ab7dfbc", [:mix], [{:hackney, "~> 1.17", [hex: :hackney, repo: "hexpm", optional: false]}], "hexpm", "d4ca85575a064d29d4e94253ee95912edfb165938743dbf002acdf0dcecb0c28"},
   "unicode_util_compat": {:hex, :unicode_util_compat, "0.7.1", "a48703a25c170eedadca83b11e88985af08d35f37c6f664d6dcfb106a97782fc", [:rebar3], [], "hexpm", "b3a917854ce3ae233619744ad1e0102e05673136776fb2fa76234f3e03b23642"},
 }


### PR DESCRIPTION
### Summary of changes

This PR fixes deprecation warnings with latest versions of Elixir.

Fixes #771 

### Checklist

- [x] New functions have typespecs, changed functions were updated
- [x] Same for documentation, including moduledocs
- [x] Tests were added or updated to cover changes
- [x] Commits were squashed into a single coherent commit
- [x] Notes added to CHANGELOG file which describe changes at a high-level
