### PR TITLE
Relax gettext dependency constraint to allow >= 0.26.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Changed charlists from the deprecated `''` to `~c""`
 - Changed negative range to pass the step of default value for suppressing deprecation warnings
 - Update Gettext to 0.26
+- Relax Gettext dependency to allow >= 0.26.0 (supports both 0.26.x and 1.0.x)
 
 ### Fixed
 

--- a/mix.exs
+++ b/mix.exs
@@ -57,7 +57,7 @@ defmodule Timex.Mixfile do
     [
       {:tzdata, "~> 1.1"},
       {:combine, "~> 0.10"},
-      {:gettext, "~> 0.26"},
+      {:gettext, ">= 0.26.0"},
       {:ex_doc, "~> 0.13", only: [:docs]},
       {:benchfella, "~> 0.3", only: [:bench]},
       {:dialyxir, "~> 1.0", only: [:dev], runtime: false},


### PR DESCRIPTION
### Summary of changes

Relax gettext dependency constraint to allow >= 0.26.0
This allows users to choose between gettext 0.26.x and 1.0.x versions

[gettext 1.0.0 changelog](https://github.com/elixir-gettext/gettext/blob/main/CHANGELOG.md#v100)

### Checklist

- N/A New functions have typespecs, changed functions were updated
- N/A Same for documentation, including moduledocs
- N/A Tests were added or updated to cover changes
- [x] Commits were squashed into a single coherent commit
- [x] Notes added to CHANGELOG file which describe changes at a high-level

Fixes #782 