### PR TITLE
fix: remove protocol definition default args deprecated in Elixir 1.20

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Updated tzdata to fix issues with 2024b
 - Fix deprecation: Module.eval_quoted/4 is deprecated. Use Code.eval_quoted/3 instead
 - Fix deprecation: "min..max inside match is deprecated"
+- Fix deprecation: default arguments in protocol definitions are deprecated in Elixir 1.20 (`Timex.Comparable.compare/3`, `Timex.Comparable.diff/3`, `Timex.Protocol.to_datetime/2`)
 
 ---
 

--- a/lib/comparable/comparable.ex
+++ b/lib/comparable/comparable.ex
@@ -81,7 +81,7 @@ defprotocol Timex.Comparable do
       0
   """
   @spec compare(comparable, comparable, granularity) :: compare_result
-  def compare(a, b, granularity \\ :microsecond)
+  def compare(a, b, granularity)
 
   @doc """
   Get the difference between two date or datetime types.
@@ -136,5 +136,5 @@ defprotocol Timex.Comparable do
       0
   """
   @spec diff(comparable, comparable, granularity) :: diff_result
-  def diff(a, b, granularity \\ :microsecond)
+  def diff(a, b, granularity)
 end

--- a/lib/protocol.ex
+++ b/lib/protocol.ex
@@ -42,10 +42,9 @@ defprotocol Timex.Protocol do
   Convert a date/time value to a DateTime.
   An optional timezone can be provided, UTC will be assumed if one is not provided.
   """
-  @spec to_datetime(Types.valid_datetime()) :: DateTime.t() | {:error, term}
   @spec to_datetime(Types.valid_datetime(), Types.valid_timezone()) ::
           DateTime.t() | Timex.AmbiguousDateTime.t() | {:error, term}
-  def to_datetime(datetime, timezone \\ :utc)
+  def to_datetime(datetime, timezone)
 
   @doc """
   Convert a date/time value to a NaiveDateTime

--- a/lib/timex.ex
+++ b/lib/timex.ex
@@ -1021,7 +1021,7 @@ defmodule Timex do
     compare(a, b, :microseconds)
   end
 
-  defdelegate compare(a, b), to: Timex.Comparable
+  def compare(a, b), do: Timex.Comparable.compare(a, b, :microsecond)
 
   @doc """
   Compare two `Timex.Comparable` values, returning one of the following values:
@@ -1090,7 +1090,7 @@ defmodule Timex do
   @spec diff(Time.t() | Comparable.comparable(), Time.t() | Comparable.comparable()) ::
           Duration.t() | integer | {:error, term}
   def diff(%Time{} = a, %Time{} = b), do: diff(a, b, :microseconds)
-  defdelegate diff(a, b), to: Timex.Comparable
+  def diff(a, b), do: Timex.Comparable.diff(a, b, :microsecond)
 
   @doc """
   Calculate time interval between two dates. The result will be a signed integer, negative


### PR DESCRIPTION
Default arguments in defprotocol definitions are deprecated in Elixir 1.20 and will become a hard error in a future release.

- Remove `\ :microsecond` defaults from Timex.Comparable.compare/3 and diff/3
- Remove `\ :utc` default from Timex.Protocol.to_datetime/2
- Drop now-invalid 1-arity `@spec` for `to_datetime`
- Change `defdelegate compare/2` and `diff/2` in Timex to explicit calls with hardcoded `:microsecond` default to preserve public API

The warnings:

```bash
warning: default arguments in protocol definitions is deprecated
│
84 │   def compare(a, b, granularity \\ :microsecond)
│   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
│
└─ lib/comparable/comparable.ex:84: Timex.Comparable (module)

 warning: default arguments in protocol definitions is deprecated
 │
139 │   def diff(a, b, granularity \\ :microsecond)
│   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
│
└─ lib/comparable/comparable.ex:139: Timex.Comparable (module)

warning: default arguments in protocol definitions is deprecated
│
48 │   def to_datetime(datetime, timezone \\ :utc)
│   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
│
└─ lib/protocol.ex:48: Timex.Protocol (module)

Note there's also a secondary warning that comes with each ofault silently creates a lower-arity function that protocolsaren't supposed to have:

warning: protocols can only define functions without implementation via def/1, found: compare/2, diff/2
│
 1 │ defprotocol Timex.Comparable do
│   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
│
└─ lib/comparable/comparable.ex:1: Timex.Comparable (module)
```

### Summary of changes

Elixir 1.20 deprecated default arguments inside defprotocol definitions — they produce both f/n and f/n-1 as protocol variants, which will become a hard compile error in a future version. Timex 3.7.13 has three such defaults: compare/3, diff/3 in Timex.Comparable, and to_datetime/2 in Timex.Protocol.

Projects running --warnings-as-errors (a common CI setup) can't compile against this on Elixir 1.20.

This removes the three defaults from the protocol definitions and makes the 2-arity public wrappers in Timex supply the hardcoded defaults explicitly, so callers see no behaviour change.

### Checklist

- [ ] New functions have typespecs, changed functions were updated
- [ ] Same for documentation, including moduledocs
- [ ] Tests were added or updated to cover changes - it's not testable
- [x] Commits were squashed into a single coherent commit
- [x] Notes added to CHANGELOG file which describe changes at a high-level
